### PR TITLE
Render window border over the grid

### DIFF
--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
@@ -276,8 +276,8 @@ void LayoutEditorCanvas::RenderEdittime()
     //Go back to "window" view before drawing GUI elements
     setView(sf::View(sf::Vector2f(getSize().x/2,getSize().y/2), sf::Vector2f(getSize().x,getSize().y)));
 
-    RenderInitialWindowBorder();
     if ( options.grid ) RenderGrid();
+    RenderInitialWindowBorder();
 
     if ( renderer.drawResizeButtons )
     {


### PR DESCRIPTION
Just to propose change the render order, the grid can easily hide the window border.