### PR TITLE
Fix IsMoving condition from PlatformAutomatism

### DIFF
--- a/Extensions/PlatformAutomatism/PlatformerObjectAutomatism.cpp
+++ b/Extensions/PlatformAutomatism/PlatformerObjectAutomatism.cpp
@@ -378,7 +378,7 @@ void PlatformerObjectAutomatism::DoStepPreEvents(RuntimeScene & scene)
     jumpKey = false;
 
     //5) Track the movement
-    hasReallyMoved = abs(object->GetX()-oldX) >= 1;
+    hasReallyMoved = abs(object->GetX()-oldX) >= 60 * timeDelta;
 }
 
 bool PlatformerObjectAutomatism::SeparateFromPlatforms(const std::set<PlatformAutomatism*> & candidates, bool excludeJumpThrus)


### PR DESCRIPTION
Adapt the hasReallyMoved threshold to the current framerate.
(Need to be tested, edited from Github)