### PR TITLE
Fix a memory crash (can't create more wxBitmap) when tiles are re-generated if the tileset contains a lot of tiles

### DIFF
--- a/Extensions/TileMapObject/RuntimeTileMapObject.cpp
+++ b/Extensions/TileMapObject/RuntimeTileMapObject.cpp
@@ -43,7 +43,7 @@ RuntimeTileMapObject::RuntimeTileMapObject(RuntimeScene & scene, const gd::Objec
 
     //Load the tileset and generate the vertex array
     tileSet.Get().LoadResources(*(scene.game));
-    tileSet.Get().Generate();
+    tileSet.Get().Generate(); //We don't need wxBitmaps
     vertexArray = TileMapExtension::GenerateVertexArray(tileSet.Get(), tileMap.Get());
     hitboxes = TileMapExtension::GenerateHitboxes(tileSet.Get(), tileMap.Get());
 }

--- a/Extensions/TileMapObject/TileEditor.cpp
+++ b/Extensions/TileMapObject/TileEditor.cpp
@@ -80,10 +80,9 @@ void TileEditor::UpdateScrollbars()
         return;
 
     //Compute the virtual size and the default scroll position to have a centered tile.
-    wxBitmap tileBitmap = m_tileset->GetTileBitmap(m_currentTile);
 
-    int virtualWidth = std::max(m_tilePreviewPanel->GetClientSize().GetWidth(), tileBitmap.GetWidth());
-    int virtualHeight = std::max(m_tilePreviewPanel->GetClientSize().GetHeight(), tileBitmap.GetHeight());
+    int virtualWidth = std::max(m_tilePreviewPanel->GetClientSize().GetWidth(), (int)m_tileset->tileSize.x);
+    int virtualHeight = std::max(m_tilePreviewPanel->GetClientSize().GetHeight(), (int)m_tileset->tileSize.y);
 
     m_tilePreviewPanel->SetVirtualSize(virtualWidth, virtualHeight);
 
@@ -105,6 +104,11 @@ void TileEditor::OnPreviewPaint(wxPaintEvent& event)
     wxAutoBufferedPaintDC dc(m_tilePreviewPanel);
     m_tilePreviewPanel->DoPrepareDC(dc);
 
+    //Load the tileset
+    wxBitmap btmp(m_tileset->GetWxBitmap());
+    wxMemoryDC tilesetDC;
+    tilesetDC.SelectObject(btmp);
+
     wxPoint minPos = m_tilePreviewPanel->GetViewStart();
     int width, height;
     m_tilePreviewPanel->GetClientSize(&width, &height);
@@ -118,10 +122,17 @@ void TileEditor::OnPreviewPaint(wxPaintEvent& event)
         return;
 
     //Draw the tile and compute the drawing offset
-    wxBitmap tileBitmap = m_tileset->GetTileBitmap(m_currentTile);
-    m_xOffset = width/2 - tileBitmap.GetWidth()/2;
-    m_yOffset = height/2 - tileBitmap.GetHeight()/2;
-    dc.DrawBitmap(tileBitmap, m_xOffset, m_yOffset, true);
+    m_xOffset = width/2 - m_tileset->tileSize.x/2;
+    m_yOffset = height/2 - m_tileset->tileSize.y/2;
+    dc.Blit(m_xOffset,
+            m_yOffset,
+            m_tileset->tileSize.x,
+            m_tileset->tileSize.y,
+            &tilesetDC,
+            m_tileset->GetTileTextureCoords(m_currentTile).topLeft.x,
+            m_tileset->GetTileTextureCoords(m_currentTile).topLeft.y,
+            wxCOPY,
+            true);
 
     //Draw the hitbox
     std::vector<Polygon2d> polygonList(1, m_tileset->GetTileHitbox(m_currentTile).hitbox);

--- a/Extensions/TileMapObject/TileMapPanel.cpp
+++ b/Extensions/TileMapObject/TileMapPanel.cpp
@@ -152,7 +152,6 @@ void TileMapPanel::OnPaint(wxPaintEvent& event)
                         m_tileset->GetTileTextureCoords(m_tilemap->GetTile(layer, col, row)).topLeft.y,
                         wxCOPY,
                         true);
-                //dc.DrawBitmap(m_tileset->GetTileBitmap(m_tilemap->GetTile(layer, col, row)), GetPositionOfTile(col, row).x, GetPositionOfTile(col, row).y, true);
             }
         }
     }

--- a/Extensions/TileMapObject/TileMapPanel.cpp
+++ b/Extensions/TileMapObject/TileMapPanel.cpp
@@ -107,6 +107,10 @@ void TileMapPanel::OnTileSetSelectionChanged(TileSelectionEvent &event)
 
 void TileMapPanel::OnPaint(wxPaintEvent& event)
 {
+    wxBitmap btmp(m_tileset->GetWxBitmap());
+    wxMemoryDC tilesetDC;
+    tilesetDC.SelectObject(btmp);
+
     wxAutoBufferedPaintDC dc(this);
     DoPrepareDC(dc);
 
@@ -139,7 +143,16 @@ void TileMapPanel::OnPaint(wxPaintEvent& event)
                 if(m_tilemap->GetTile(layer, col, row) == -1)
                     continue;
 
-                dc.DrawBitmap(m_tileset->GetTileBitmap(m_tilemap->GetTile(layer, col, row)), GetPositionOfTile(col, row).x, GetPositionOfTile(col, row).y, true);
+                dc.Blit(GetPositionOfTile(col, row).x, 
+                        GetPositionOfTile(col, row).y,
+                        m_tileset->tileSize.x,
+                        m_tileset->tileSize.y,
+                        &tilesetDC,
+                        m_tileset->GetTileTextureCoords(m_tilemap->GetTile(layer, col, row)).topLeft.x,
+                        m_tileset->GetTileTextureCoords(m_tilemap->GetTile(layer, col, row)).topLeft.y,
+                        wxCOPY,
+                        true);
+                //dc.DrawBitmap(m_tileset->GetTileBitmap(m_tilemap->GetTile(layer, col, row)), GetPositionOfTile(col, row).x, GetPositionOfTile(col, row).y, true);
             }
         }
     }

--- a/Extensions/TileMapObject/TileSet.cpp
+++ b/Extensions/TileMapObject/TileSet.cpp
@@ -13,6 +13,7 @@ This project is released under the MIT License.
 #include <wx/file.h>
 #include <wx/filefn.h>
 #include <wx/filename.h>
+#include <wx/image.h>
 #endif
 #include <GDCore/CommonTools.h>
 
@@ -152,9 +153,6 @@ void TileSet::Generate()
 
     //Generate the TextureCoords and the sub-bitmaps (only in IDE)
     m_coords.clear();
-#ifdef GD_IDE_ONLY
-    m_bitmaps.clear();
-#endif
     for(int row = 0; row < rows; row++)
     {
         for(int col = 0; col < columns; col++)
@@ -170,16 +168,6 @@ void TileSet::Generate()
             tileCoords.bottomLeft = sf::Vector2f(col * (tileSize.x + tileSpacing.x),
                                                  row * (tileSize.y + tileSpacing.y) + tileSize.y);
             m_coords.push_back(tileCoords);
-
-#ifdef GD_IDE_ONLY
-            //sub-wxBitmap
-            wxBitmap subbitmap;
-            subbitmap = m_tilesetBitmap.GetSubBitmap(wxRect(col * (tileSize.x + tileSpacing.x),
-                                                            row * (tileSize.y + tileSpacing.y),
-                                                            tileSize.x,
-                                                            tileSize.y));
-            m_bitmaps.push_back(subbitmap);
-#endif
         }
     }
 
@@ -224,11 +212,6 @@ int TileSet::GetTileIDFromCell(int col, int row)
 const wxBitmap& TileSet::GetWxBitmap() const
 {
     return m_tilesetBitmap;
-}
-
-const wxBitmap& TileSet::GetTileBitmap(int id) const
-{
-    return (id < m_bitmaps.size() ? m_bitmaps.at(id) : m_invalidBitmap);
 }
 
 #endif

--- a/Extensions/TileMapObject/TileSet.h
+++ b/Extensions/TileMapObject/TileSet.h
@@ -135,11 +135,6 @@ public:
      * Returns the tileset bitmap
      */
     const wxBitmap& GetWxBitmap() const;
-
-    /**
-     * Get a tile bitmap from its ID (only available in the IDE)
-     */
-    const wxBitmap& GetTileBitmap(int id) const;
 #endif
 
     /**
@@ -241,7 +236,6 @@ private:
 
     #ifdef GD_IDE_ONLY
     wxBitmap m_tilesetBitmap; ///< The tileset texture
-    std::vector<wxBitmap> m_bitmaps;
     static wxBitmap m_invalidBitmap;
     #endif
 


### PR DESCRIPTION
To display the tiles inside the tilemap editor, the extension was creating a wxBitmap for each tiles when the TileSet::Generate() method was called. It appears that it can cause crash when there are a lot of tiles (wxBitmap functions failling without any visible problem).

To solve this issue, there is now only one wxBitmap containing the whole tileset. In the editors, the wxDC::Blit method is used (with a wxMemoryDC containing the tileset wxBitmap) to display tiles instead of individual wxBitmaps.

(Need testing)