### PR TITLE
Added 'all files' filter to opendialog in preferences - external image editor

### DIFF
--- a/IDE/Preferences.cpp
+++ b/IDE/Preferences.cpp
@@ -1539,7 +1539,7 @@ void Preferences::OnbrowseJavaBtClick(wxCommandEvent& event)
 
 void Preferences::OnBrowseEditionImageClick(wxCommandEvent& event)
 {
-    wxFileDialog dialog( this, _( "Choose a image editing software" ), "", "", "Programme (*.exe)|*.exe" );
+    wxFileDialog dialog( this, _( "Choose a image editing software" ), "", "", "Programme (*.exe)|*.exe|All Files (*.*)|*.*" );
     dialog.ShowModal();
 
     if ( !dialog.GetPath().empty() )


### PR DESCRIPTION
Currently there is only one ".exe" filter present in the linux build which prevents you from finding any linux executables.
This commit adds an 'All Files' filter to the open file dialog for external image editors in options - preferences.