### PR TITLE
Fix the high cpu usage when switching to the event editor on Linux

### DIFF
--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
@@ -118,7 +118,8 @@ LayoutEditorCanvas::LayoutEditorCanvas(wxWindow* parent, gd::Project & project_,
     smallButtonSize(gd::GUIContentScaleFactor::Get() > 1 ? 12 : 5),
     firstRefresh(true),
     isSelecting(false),
-    editing(true)
+    editing(true),
+    enableIdleEvents(true)
 {
 	//(*Initialize(LayoutEditorCanvas)
 	Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxWANTS_CHARS, _T("wxID_ANY"));
@@ -313,11 +314,14 @@ LayoutEditorCanvas::~LayoutEditorCanvas()
 
 void LayoutEditorCanvas::OnIdle(wxIdleEvent & event)
 {
-    // Send a paint message when the control is idle, to ensure maximum framerate
-    Refresh();
-    #if defined(__WXGTK__)
-    event.RequestMore(); //On GTK, we need to specify that we want continuous idle events.
-    #endif
+    if(enableIdleEvents)
+    {
+        // Send a paint message when the control is idle, to ensure maximum framerate
+        Refresh();
+        #if defined(__WXGTK__)
+        event.RequestMore(); //On GTK, we need to specify that we want continuous idle events.
+        #endif
+    }
 }
 
 void LayoutEditorCanvas::OnPaint(wxPaintEvent&)

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.h
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.h
@@ -247,6 +247,12 @@ public:
      */
     void GoToEditingState();
 
+    /**
+     * \brief Enable or disable idle events. Disabling them avoid the scene to be constantly rendered.
+     * \note Used by the scene editor when the user switch to the event editor.
+     */
+    void EnableIdleEvents(bool enable = true) {enableIdleEvents = enable;};
+
     virtual sf::Vector2f GetInitialInstanceSize(gd::InitialInstance & instance) const;
     virtual sf::Vector2f GetInitialInstanceOrigin(gd::InitialInstance & instance) const;
 
@@ -499,6 +505,8 @@ protected:
     //State
     bool editing; ///< True if the layout is being edited, false if a preview is running.
     std::shared_ptr<gd::LayoutEditorPreviewer> currentPreviewer; ///< The previewer being used to preview the layout.
+
+    bool enableIdleEvents;
 
     wxMenu contextMenu;
     wxMenu noObjectContextMenu;

--- a/IDE/EditorScene.cpp
+++ b/IDE/EditorScene.cpp
@@ -185,12 +185,14 @@ void EditorScene::ForceRefreshRibbonAndConnect()
     if ( notebook->GetPageText(notebook->GetSelection()) == _("Scene") )
     {
         layoutEditorCanvas->RecreateRibbonToolbar();
+        layoutEditorCanvas->EnableIdleEvents();
         mainFrameWrapper.GetRibbon()->SetActivePage(2);
         layoutEditorCanvas->ConnectEvents();
     }
     else if ( notebook->GetPageText(notebook->GetSelection()) == _("Events") )
     {
         mainFrameWrapper.GetRibbon()->SetActivePage(3);
+        layoutEditorCanvas->EnableIdleEvents(false);
         eventsEditor->ConnectEvents();
     }
 }


### PR DESCRIPTION
It doesn't use HasFocus() as a condition to enable the idle events because this condition is not fulfilled if we use the debugger during the preview.