### PR TITLE
Fix images insertion order when adding multiple picture to an animation

### DIFF
--- a/Core/GDCore/BuiltinExtensions/SpriteExtension/Dialogs/SpriteObjectEditor.cpp
+++ b/Core/GDCore/BuiltinExtensions/SpriteExtension/Dialogs/SpriteObjectEditor.cpp
@@ -1751,7 +1751,7 @@ void SpriteObjectEditor::OnAddImageFromFileSelected(wxCommandEvent& event)
         {
             wxArrayString files;
             FileDialog.GetPaths(files);
-            files.Sort(true); //Ensure that the order of insertion is alphabetical.
+            files.Sort(); //Ensure that the order of insertion is alphabetical.
 
             std::vector < std::string > filenames;
             for ( unsigned int i = 0; i < files.GetCount();++i )


### PR DESCRIPTION
Fix images insertion order when adding multiple picture to an animation of a sprite object.
(the boolean parameter of the wxArrayString::Sort method applies a reverse sort).