### PR TITLE
Remove borders in the eventsPanel from the EventEditor

### DIFF
--- a/IDE/EventsEditor.cpp
+++ b/IDE/EventsEditor.cpp
@@ -153,7 +153,7 @@ void EventsEditor::Init(wxWindow* parent)
 	FlexGridSizer1 = new wxFlexGridSizer(0, 2, 0, 0);
 	FlexGridSizer1->AddGrowableCol(0);
 	FlexGridSizer1->AddGrowableRow(0);
-	eventsPanel = new wxControl(this, ID_PANEL1, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, wxDefaultValidator, _T("ID_PANEL1"));
+	eventsPanel = new wxControl(this, ID_PANEL1, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL|wxBORDER_NONE, wxDefaultValidator, _T("ID_PANEL1"));
 	eventsPanel->SetBackgroundColour(wxColour(255,255,255));
 	liveEditingPanel = new wxPanel(eventsPanel, ID_PANEL2, wxPoint(100,100), wxDefaultSize, wxSIMPLE_BORDER, _T("ID_PANEL2"));
 	FlexGridSizer2 = new wxFlexGridSizer(0, 3, 0, 0);


### PR DESCRIPTION
On wxGTK, borders appear around the event editor. This commit removes them.