### PR TITLE
Macro to disable the update dialog

### DIFF
--- a/Binaries/Packaging/debian-source-package/extra-files/debian/rules
+++ b/Binaries/Packaging/debian-source-package/extra-files/debian/rules
@@ -8,7 +8,7 @@
 	dh $@
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DCMAKE_INSTALL_PREFIX=/opt/gdevelop/useless -DCMAKE_BUILD_TYPE=Release
+	dh_auto_configure -- -DCMAKE_INSTALL_PREFIX=/opt/gdevelop/useless -DCMAKE_BUILD_TYPE=Release -DNO_UPDATE_CHECKER=TRUE
 
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=-ldebian/gdevelop/opt/gdevelop/

--- a/Binaries/Packaging/opensuse-build-service/PKGBUILD
+++ b/Binaries/Packaging/opensuse-build-service/PKGBUILD
@@ -21,7 +21,7 @@ build() {
   rm -rf .build
   mkdir .build
   cd .build
-  cmake ../..
+  cmake -DNO_UPDATE_CHECKER=TRUE ../..
 
   #Build the whole project
   make -j4

--- a/Binaries/Packaging/opensuse-build-service/gdevelop.spec
+++ b/Binaries/Packaging/opensuse-build-service/gdevelop.spec
@@ -47,9 +47,9 @@ cd .build
 
 #Fedora's wx-config name contains the version (wx-config-3.0 instead of wx-config and wxrc-3.0 instead of wxrc-3.0)
 %if 0%{?fedora}
-cmake ../.. -DwxWidgets_CONFIG_EXECUTABLE=/usr/bin/wx-config-3.0 -DwxWidgets_wxrc_EXECUTABLE=/usr/bin/wxrc-3.0
+cmake -DNO_UPDATE_CHECKER=TRUE -DwxWidgets_CONFIG_EXECUTABLE=/usr/bin/wx-config-3.0 -DwxWidgets_wxrc_EXECUTABLE=/usr/bin/wxrc-3.0 ../..
 %else
-cmake ../..
+cmake -DNO_UPDATE_CHECKER=TRUE ../..
 %endif
 
 #Build the whole project

--- a/IDE/CMakeLists.txt
+++ b/IDE/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_policy(SET CMP0015 NEW)
 
 project(GDIDE)
 
+gd_set_option(NO_UPDATE_CHECKER FALSE BOOL "TRUE to remove the integrated update dialog and checker (when building packages as GDevelop is automatically updated by its repository.")
+
 #Dependencies on external libraries:
 ###
 include_directories(${sfml_include_dir})
@@ -49,6 +51,10 @@ ELSE()
 	add_definitions( -DGD_CORE_API= )
 	add_definitions(${GTK_CFLAGS_OTHER})
 ENDIF(WIN32)
+
+IF(NO_UPDATE_CHECKER)
+	add_definitions( -DGD_NO_UPDATE_CHECKER)
+ENDIF(NO_UPDATE_CHECKER)
 
 
 #The targets

--- a/IDE/GDevelopIDEApp.cpp
+++ b/IDE/GDevelopIDEApp.cpp
@@ -369,13 +369,14 @@ bool GDevelopIDEApp::OnInit()
 
     //Checking for updates
     {
-#ifndef GD_NO_UPDATE_CHECKER
+
         wxString result;
         config->Read( "Startup/CheckUpdate", &result );
         if ( result != "false" )
         {
             UpdateChecker * checker = UpdateChecker::Get();
             checker->DownloadInformation();
+#ifndef GD_NO_UPDATE_CHECKER
             if ( checker->newVersionAvailable )
             {
                 MAJ dialog(mainEditor, true);
@@ -385,8 +386,8 @@ bool GDevelopIDEApp::OnInit()
                     return true;
                 }
             }
-        }
 #endif
+        }
         mainEditor->RefreshNews();
     }
 

--- a/IDE/GDevelopIDEApp.cpp
+++ b/IDE/GDevelopIDEApp.cpp
@@ -369,6 +369,7 @@ bool GDevelopIDEApp::OnInit()
 
     //Checking for updates
     {
+#ifndef GD_NO_UPDATE_CHECKER
         wxString result;
         config->Read( "Startup/CheckUpdate", &result );
         if ( result != "false" )
@@ -385,6 +386,7 @@ bool GDevelopIDEApp::OnInit()
                 }
             }
         }
+#endif
         mainEditor->RefreshNews();
     }
 

--- a/IDE/MAJ.cpp
+++ b/IDE/MAJ.cpp
@@ -3,6 +3,9 @@
  * Copyright 2008-2015 Florian Rival (Florian.Rival@gmail.com). All rights reserved.
  * This project is released under the GNU General Public License.
  */
+
+#ifndef GD_NO_UPDATE_CHECKER
+
 #include "MAJ.h"
 
 //(*InternalHeaders(MAJ)
@@ -262,3 +265,5 @@ void MAJ::OnHelpBtClick(wxCommandEvent& event)
 {
     gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/update"));
 }
+
+#endif

--- a/IDE/MAJ.h
+++ b/IDE/MAJ.h
@@ -6,6 +6,8 @@
 #ifndef MAJ_H
 #define MAJ_H
 
+#ifndef GD_NO_UPDATE_CHECKER
+
 //(*Headers(MAJ)
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -85,3 +87,4 @@ class MAJ: public wxDialog
 
 #endif
 
+#endif

--- a/IDE/MainFrame.cpp
+++ b/IDE/MainFrame.cpp
@@ -226,9 +226,11 @@ MainFrame::MainFrame( wxWindow* parent ) :
     MenuItem19 = new wxMenuItem((&helpMenu), ID_MENUITEM23, _("Tutorial"), wxEmptyString, wxITEM_NORMAL);
     helpMenu.Append(MenuItem19);
     helpMenu.AppendSeparator();
+#ifndef GD_NO_UPDATE_CHECKER
     MenuItem21 = new wxMenuItem((&helpMenu), ID_MENUITEM25, _("Check for updates"), wxEmptyString, wxITEM_NORMAL);
     helpMenu.Append(MenuItem21);
     helpMenu.AppendSeparator();
+#endif
     MenuItem20 = new wxMenuItem((&helpMenu), ID_MENUITEM24, _("Official web site"), wxEmptyString, wxITEM_NORMAL);
     MenuItem20->SetBitmap(gd::SkinHelper::GetIcon("site", 16));
     helpMenu.Append(MenuItem20);
@@ -262,7 +264,9 @@ MainFrame::MainFrame( wxWindow* parent ) :
     Connect(ID_MENUITEM14,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnQuit);
     Connect(ID_MENUITEM20,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnMenuAideSelected);
     Connect(ID_MENUITEM23,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnMenuTutoSelected);
+#ifndef GD_NO_UPDATE_CHECKER
     Connect(ID_MENUITEM25,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnMenuItem36Selected);
+#endif
     Connect(ID_MENUITEM24,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnMenuSiteSelected);
     Connect(ID_MENUITEM21,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnAbout);
     Connect(wxID_ANY,wxEVT_CLOSE_WINDOW,(wxObjectEventFunction)&MainFrame::OnClose);
@@ -279,7 +283,9 @@ MainFrame::MainFrame( wxWindow* parent ) :
     Connect( idRibbonHelp, wxEVT_COMMAND_RIBBONBUTTON_CLICKED, ( wxObjectEventFunction )&MainFrame::OnMenuAideSelected );
     Connect( idRibbonTuto, wxEVT_COMMAND_RIBBONBUTTON_CLICKED, ( wxObjectEventFunction )&MainFrame::OnMenuTutoSelected );
     Connect( idRibbonForum, wxEVT_COMMAND_RIBBONBUTTON_CLICKED, ( wxObjectEventFunction )&MainFrame::OnMenuForumSelected );
+#ifndef GD_NO_UPDATE_CHECKER
     Connect( idRibbonUpdate, wxEVT_COMMAND_RIBBONBUTTON_CLICKED, ( wxObjectEventFunction )&MainFrame::OnMenuItem36Selected );
+#endif
     Connect( idRibbonWebSite, wxEVT_COMMAND_RIBBONBUTTON_CLICKED, ( wxObjectEventFunction )&MainFrame::OnMenuSiteSelected );
     Connect( idRibbonCredits, wxEVT_COMMAND_RIBBONBUTTON_CLICKED, ( wxObjectEventFunction )&MainFrame::OnAbout );
     Connect( ID_RIBBON, wxEVT_COMMAND_RIBBONBAR_PAGE_CHANGING, ( wxObjectEventFunction )&MainFrame::OnRibbonPageChanging );

--- a/IDE/MainFrame.h
+++ b/IDE/MainFrame.h
@@ -196,7 +196,9 @@ public:
     void OnMenuItem23Selected(wxCommandEvent& event);
     void OnMenuForumSelected(wxCommandEvent& event);
     void OnMenuSiteSelected(wxCommandEvent& event);
+#ifndef GD_NO_UPDATE_CHECKER
     void OnMenuItem36Selected(wxCommandEvent& event);
+#endif
     void OnMenuTutoSelected(wxCommandEvent& event);
     void OnDecomposeGIFSelected(wxCommandEvent& event);
     void OnDecomposeRPGSelected(wxCommandEvent& event);

--- a/IDE/MainFrame_Help.cpp
+++ b/IDE/MainFrame_Help.cpp
@@ -10,7 +10,10 @@
 #include <wx/mimetype.h> // mimetype support
 #include "GDCore/Tools/HelpFileAccess.h"
 #include "Credits.h"
+
+#ifndef GD_NO_UPDATE_CHECKER
 #include "MAJ.h"
+#endif
 
 /**
  * Display help
@@ -94,6 +97,7 @@ void MainFrame::OnMenuSiteSelected(wxCommandEvent& event)
     }
 }
 
+#ifndef GD_NO_UPDATE_CHECKER
 /**
  * Open update dialog
  */
@@ -106,3 +110,4 @@ void MainFrame::OnMenuItem36Selected(wxCommandEvent& event)
         wxExit();
     }
 }
+#endif

--- a/IDE/Preferences.cpp
+++ b/IDE/Preferences.cpp
@@ -627,6 +627,12 @@ changesNeedRestart(false)
     Connect(ID_BUTTON3,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&Preferences::OnAideBtClick);
     //*)
 
+    //Hide the "Check update" item if GDevelop is compiled without the update checker
+#ifdef GD_NO_UPDATE_CHECKER
+    MAJCheck->Hide();
+#endif
+
+    //Create the image list
     wxImageList * imageList = new wxImageList( 24, 24 );
     imageList->Add(( wxBitmap( "res/pref24.png", wxBITMAP_TYPE_ANY ) ) );
     imageList->Add(( wxBitmap( "res/locale.png", wxBITMAP_TYPE_ANY ) ) );

--- a/IDE/Preferences.cpp
+++ b/IDE/Preferences.cpp
@@ -226,7 +226,7 @@ changesNeedRestart(false)
     FlexGridSizer14->AddGrowableCol(0);
     StaticBoxSizer1 = new wxStaticBoxSizer(wxVERTICAL, Panel2, _("Startup"));
     FlexGridSizer39 = new wxFlexGridSizer(0, 1, 0, 0);
-    MAJCheck = new wxCheckBox(Panel2, ID_CHECKBOX4, _("Check for updates"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX4"));
+    MAJCheck = new wxCheckBox(Panel2, ID_CHECKBOX4, _("Check for updates and the news"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX4"));
     MAJCheck->SetValue(false);
     FlexGridSizer39->Add(MAJCheck, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
     sendInfoCheck = new wxCheckBox(Panel2, ID_CHECKBOX10, _("Send anonymous statistics about GDevelop ( version, language used )"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX10"));
@@ -627,9 +627,9 @@ changesNeedRestart(false)
     Connect(ID_BUTTON3,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&Preferences::OnAideBtClick);
     //*)
 
-    //Hide the "Check update" item if GDevelop is compiled without the update checker
+    //If the update dialog is disabled, rename the checkbox to "Check for news"
 #ifdef GD_NO_UPDATE_CHECKER
-    MAJCheck->Hide();
+    MAJCheck->SetLabel(_("Check for the news"));
 #endif
 
     //Create the image list


### PR DESCRIPTION
Remove the possibility to open the update dialog (MAJ) when the cmake option NO_UPDATE_CHECKER (which define GD_NO_UPDATE_CHECKER in the source code) is defined.
It's "useful" (I know, not a lot) for the gdevelop linux packages as the update process is already managed by the package manager.