### PR TITLE
Fix GDevelop deb not depending on build-essential

### DIFF
--- a/Binaries/Packaging/debian-source-package/extra-files/debian/control
+++ b/Binaries/Packaging/debian-source-package/extra-files/debian/control
@@ -10,7 +10,7 @@ Homepage: http://www.compilgames.net
 
 Package: gdevelop
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, build-essential
 Description: GDevelop, open source HTML5 and native game creator software
  GDevelop is an open source game development software
  allowing to create HTML5 and native games


### PR DESCRIPTION
${shlibs:Depends}, ${misc:Depends} create an automatic list of dependency. But how can Launchpad know that GDevelop needs build-essential ?