### PR TITLE
Store instructions as shared pointers instead of as values

### DIFF
--- a/Core/GDCore/Events/Builtin/ForEachEvent.cpp
+++ b/Core/GDCore/Events/Builtin/ForEachEvent.cpp
@@ -30,17 +30,17 @@ objectsToPickSelected(false)
 {
 }
 
-vector < vector<gd::Instruction>* > ForEachEvent::GetAllConditionsVectors()
+vector < gd::InstructionsList* > ForEachEvent::GetAllConditionsVectors()
 {
-    vector < vector<gd::Instruction>* > allConditions;
+    vector < gd::InstructionsList* > allConditions;
     allConditions.push_back(&conditions);
 
     return allConditions;
 }
 
-vector < vector<gd::Instruction>* > ForEachEvent::GetAllActionsVectors()
+vector < gd::InstructionsList* > ForEachEvent::GetAllActionsVectors()
 {
-    vector < vector<gd::Instruction>* > allActions;
+    vector < gd::InstructionsList* > allActions;
     allActions.push_back(&actions);
 
     return allActions;
@@ -53,17 +53,17 @@ vector < gd::Expression* > ForEachEvent::GetAllExpressions()
 
     return allExpressions;
 }
-vector < const vector<gd::Instruction>* > ForEachEvent::GetAllConditionsVectors() const
+vector < const gd::InstructionsList* > ForEachEvent::GetAllConditionsVectors() const
 {
-    vector < const vector<gd::Instruction>* > allConditions;
+    vector < const gd::InstructionsList* > allConditions;
     allConditions.push_back(&conditions);
 
     return allConditions;
 }
 
-vector < const vector<gd::Instruction>* > ForEachEvent::GetAllActionsVectors() const
+vector < const gd::InstructionsList* > ForEachEvent::GetAllActionsVectors() const
 {
-    vector < const vector<gd::Instruction>* > allActions;
+    vector < const gd::InstructionsList* > allActions;
     allActions.push_back(&actions);
 
     return allActions;

--- a/Core/GDCore/Events/Builtin/ForEachEvent.h
+++ b/Core/GDCore/Events/Builtin/ForEachEvent.h
@@ -39,20 +39,20 @@ public:
     virtual const gd::EventsList & GetSubEvents() const {return events;};
     virtual gd::EventsList & GetSubEvents() {return events;};
 
-    const std::vector < gd::Instruction > & GetConditions() const { return conditions; };
-    std::vector < gd::Instruction > & GetConditions() { return conditions; };
+    const gd::InstructionsList & GetConditions() const { return conditions; };
+    gd::InstructionsList & GetConditions() { return conditions; };
 
-    const std::vector < gd::Instruction > & GetActions() const { return actions; };
-    std::vector < gd::Instruction > & GetActions() { return actions; };
+    const gd::InstructionsList & GetActions() const { return actions; };
+    gd::InstructionsList & GetActions() { return actions; };
 
     std::string GetObjectToPick() const { return objectsToPick.GetPlainString(); };
     void SetObjectToPick(std::string objectsToPick_) { objectsToPick = gd::Expression(objectsToPick_); };
 
-    virtual std::vector < const std::vector<gd::Instruction>* > GetAllConditionsVectors() const;
-    virtual std::vector < const std::vector<gd::Instruction>* > GetAllActionsVectors() const;
+    virtual std::vector < const gd::InstructionsList* > GetAllConditionsVectors() const;
+    virtual std::vector < const gd::InstructionsList* > GetAllActionsVectors() const;
     virtual std::vector < const gd::Expression* > GetAllExpressions() const;
-    virtual std::vector < std::vector<gd::Instruction>* > GetAllConditionsVectors();
-    virtual std::vector < std::vector<gd::Instruction>* > GetAllActionsVectors();
+    virtual std::vector < gd::InstructionsList* > GetAllConditionsVectors();
+    virtual std::vector < gd::InstructionsList* > GetAllActionsVectors();
     virtual std::vector < gd::Expression* > GetAllExpressions();
 
     virtual void SerializeTo(SerializerElement & element) const;
@@ -75,8 +75,8 @@ public:
 
 private:
     gd::Expression objectsToPick;
-    std::vector < gd::Instruction > conditions;
-    std::vector < gd::Instruction > actions;
+    gd::InstructionsList conditions;
+    gd::InstructionsList actions;
     gd::EventsList events;
 
     bool objectsToPickSelected;

--- a/Core/GDCore/Events/Builtin/RepeatEvent.cpp
+++ b/Core/GDCore/Events/Builtin/RepeatEvent.cpp
@@ -28,17 +28,17 @@ repeatNumberExpressionSelected(false)
 }
 
 
-vector < vector<gd::Instruction>* > RepeatEvent::GetAllConditionsVectors()
+vector < gd::InstructionsList* > RepeatEvent::GetAllConditionsVectors()
 {
-    vector < vector<gd::Instruction>* > allConditions;
+    vector < gd::InstructionsList* > allConditions;
     allConditions.push_back(&conditions);
 
     return allConditions;
 }
 
-vector < vector<gd::Instruction>* > RepeatEvent::GetAllActionsVectors()
+vector < gd::InstructionsList* > RepeatEvent::GetAllActionsVectors()
 {
-    vector < vector<gd::Instruction>* > allActions;
+    vector < gd::InstructionsList* > allActions;
     allActions.push_back(&actions);
 
     return allActions;
@@ -52,17 +52,17 @@ vector < gd::Expression* > RepeatEvent::GetAllExpressions()
     return allExpressions;
 }
 
-vector < const vector<gd::Instruction>* > RepeatEvent::GetAllConditionsVectors() const
+vector < const gd::InstructionsList* > RepeatEvent::GetAllConditionsVectors() const
 {
-    vector < const vector<gd::Instruction>* > allConditions;
+    vector < const gd::InstructionsList* > allConditions;
     allConditions.push_back(&conditions);
 
     return allConditions;
 }
 
-vector < const vector<gd::Instruction>* > RepeatEvent::GetAllActionsVectors() const
+vector < const gd::InstructionsList* > RepeatEvent::GetAllActionsVectors() const
 {
-    vector < const vector<gd::Instruction>* > allActions;
+    vector < const gd::InstructionsList* > allActions;
     allActions.push_back(&actions);
 
     return allActions;

--- a/Core/GDCore/Events/Builtin/RepeatEvent.h
+++ b/Core/GDCore/Events/Builtin/RepeatEvent.h
@@ -34,20 +34,20 @@ public:
     virtual const gd::EventsList & GetSubEvents() const {return events;};
     virtual gd::EventsList & GetSubEvents() {return events;};
 
-    const std::vector < gd::Instruction > & GetConditions() const { return conditions; };
-    std::vector < gd::Instruction > & GetConditions() { return conditions; };
+    const gd::InstructionsList & GetConditions() const { return conditions; };
+    gd::InstructionsList & GetConditions() { return conditions; };
 
-    const std::vector < gd::Instruction > & GetActions() const { return actions; };
-    std::vector < gd::Instruction > & GetActions() { return actions; };
+    const gd::InstructionsList & GetActions() const { return actions; };
+    gd::InstructionsList & GetActions() { return actions; };
 
     const std::string & GetRepeatExpression() const { return repeatNumberExpression.GetPlainString(); };
     void SetRepeatExpression(std::string repeatNumberExpression_) { repeatNumberExpression = gd::Expression(repeatNumberExpression_); };
 
-    virtual std::vector < std::vector<gd::Instruction>* > GetAllConditionsVectors();
-    virtual std::vector < std::vector<gd::Instruction>* > GetAllActionsVectors();
+    virtual std::vector < gd::InstructionsList* > GetAllConditionsVectors();
+    virtual std::vector < gd::InstructionsList* > GetAllActionsVectors();
     virtual std::vector < gd::Expression* > GetAllExpressions();
-    virtual std::vector < const std::vector<gd::Instruction>* > GetAllConditionsVectors() const;
-    virtual std::vector < const std::vector<gd::Instruction>* > GetAllActionsVectors() const;
+    virtual std::vector < const gd::InstructionsList* > GetAllConditionsVectors() const;
+    virtual std::vector < const gd::InstructionsList* > GetAllActionsVectors() const;
     virtual std::vector < const gd::Expression* > GetAllExpressions() const;
 
     virtual void SerializeTo(SerializerElement & element) const;
@@ -70,8 +70,8 @@ public:
 
 private:
     gd::Expression repeatNumberExpression;
-    std::vector < gd::Instruction > conditions;
-    std::vector < gd::Instruction > actions;
+    gd::InstructionsList conditions;
+    gd::InstructionsList actions;
     EventsList events;
 
     bool repeatNumberExpressionSelected;

--- a/Core/GDCore/Events/Builtin/StandardEvent.cpp
+++ b/Core/GDCore/Events/Builtin/StandardEvent.cpp
@@ -29,32 +29,32 @@ StandardEvent::~StandardEvent()
 {
 };
 
-vector < const vector<gd::Instruction>* > StandardEvent::GetAllConditionsVectors() const
+vector < const gd::InstructionsList* > StandardEvent::GetAllConditionsVectors() const
 {
-    vector < const vector<gd::Instruction>* > allConditions;
+    vector < const gd::InstructionsList* > allConditions;
     allConditions.push_back(&conditions);
 
     return allConditions;
 }
 
-vector < const vector<gd::Instruction>* > StandardEvent::GetAllActionsVectors() const
+vector < const gd::InstructionsList* > StandardEvent::GetAllActionsVectors() const
 {
-    vector < const vector<gd::Instruction>* > allActions;
+    vector < const gd::InstructionsList* > allActions;
     allActions.push_back(&actions);
 
     return allActions;
 }
-vector < vector<gd::Instruction>* > StandardEvent::GetAllConditionsVectors()
+vector < gd::InstructionsList* > StandardEvent::GetAllConditionsVectors()
 {
-    vector < vector<gd::Instruction>* > allConditions;
+    vector < gd::InstructionsList* > allConditions;
     allConditions.push_back(&conditions);
 
     return allConditions;
 }
 
-vector < vector<gd::Instruction>* > StandardEvent::GetAllActionsVectors()
+vector < gd::InstructionsList* > StandardEvent::GetAllActionsVectors()
 {
-    vector < vector<gd::Instruction>* > allActions;
+    vector < gd::InstructionsList* > allActions;
     allActions.push_back(&actions);
 
     return allActions;

--- a/Core/GDCore/Events/Builtin/StandardEvent.h
+++ b/Core/GDCore/Events/Builtin/StandardEvent.h
@@ -9,6 +9,7 @@
 #define GDCORE_STANDARDEVENT_H
 #include "GDCore/Events/Event.h"
 #include "GDCore/Events/Instruction.h"
+#include "GDCore/Events/InstructionsList.h"
 #include "GDCore/Events/EventsList.h"
 namespace gd { class Instruction; }
 namespace gd { class Project; }
@@ -37,16 +38,16 @@ public:
     virtual const gd::EventsList & GetSubEvents() const {return events;};
     virtual gd::EventsList & GetSubEvents() {return events;};
 
-    const std::vector < gd::Instruction > & GetConditions() const { return conditions; };
-    std::vector < gd::Instruction > & GetConditions() { return conditions; };
+    const gd::InstructionsList & GetConditions() const { return conditions; };
+    gd::InstructionsList & GetConditions() { return conditions; };
 
-    const std::vector < gd::Instruction > & GetActions() const { return actions; };
-    std::vector < gd::Instruction > & GetActions() { return actions; };
+    const gd::InstructionsList & GetActions() const { return actions; };
+    gd::InstructionsList & GetActions() { return actions; };
 
-    virtual std::vector < const std::vector<gd::Instruction>* > GetAllConditionsVectors() const;
-    virtual std::vector < const std::vector<gd::Instruction>* > GetAllActionsVectors() const;
-    virtual std::vector < std::vector<gd::Instruction>* > GetAllConditionsVectors();
-    virtual std::vector < std::vector<gd::Instruction>* > GetAllActionsVectors();
+    virtual std::vector < const gd::InstructionsList* > GetAllConditionsVectors() const;
+    virtual std::vector < const gd::InstructionsList* > GetAllActionsVectors() const;
+    virtual std::vector < gd::InstructionsList* > GetAllConditionsVectors();
+    virtual std::vector < gd::InstructionsList* > GetAllActionsVectors();
 
     virtual void SerializeTo(SerializerElement & element) const;
     virtual void UnserializeFrom(gd::Project & project, const SerializerElement & element);
@@ -62,8 +63,8 @@ public:
     virtual unsigned int GetRenderedHeight(unsigned int width, const gd::Platform & platform) const;
 
 private:
-    std::vector < gd::Instruction > conditions;
-    std::vector < gd::Instruction > actions;
+    gd::InstructionsList conditions;
+    gd::InstructionsList actions;
     EventsList events;
 };
 

--- a/Core/GDCore/Events/Builtin/WhileEvent.cpp
+++ b/Core/GDCore/Events/Builtin/WhileEvent.cpp
@@ -25,35 +25,35 @@ using namespace std;
 namespace gd
 {
 
-vector < vector<gd::Instruction>* > WhileEvent::GetAllConditionsVectors()
+vector < gd::InstructionsList* > WhileEvent::GetAllConditionsVectors()
 {
-    vector < vector<gd::Instruction>* > allConditions;
+    vector < gd::InstructionsList* > allConditions;
     allConditions.push_back(&whileConditions);
     allConditions.push_back(&conditions);
 
     return allConditions;
 }
 
-vector < vector<gd::Instruction>* > WhileEvent::GetAllActionsVectors()
+vector < gd::InstructionsList* > WhileEvent::GetAllActionsVectors()
 {
-    vector < vector<gd::Instruction>* > allActions;
+    vector < gd::InstructionsList* > allActions;
     allActions.push_back(&actions);
 
     return allActions;
 }
 
-vector < const vector<gd::Instruction>* > WhileEvent::GetAllConditionsVectors() const
+vector < const gd::InstructionsList* > WhileEvent::GetAllConditionsVectors() const
 {
-    vector < const vector<gd::Instruction>* > allConditions;
+    vector < const gd::InstructionsList* > allConditions;
     allConditions.push_back(&whileConditions);
     allConditions.push_back(&conditions);
 
     return allConditions;
 }
 
-vector < const vector<gd::Instruction>* > WhileEvent::GetAllActionsVectors() const
+vector < const gd::InstructionsList* > WhileEvent::GetAllActionsVectors() const
 {
-    vector < const vector<gd::Instruction>* > allActions;
+    vector < const gd::InstructionsList* > allActions;
     allActions.push_back(&actions);
 
     return allActions;

--- a/Core/GDCore/Events/Builtin/WhileEvent.h
+++ b/Core/GDCore/Events/Builtin/WhileEvent.h
@@ -37,22 +37,22 @@ public:
     virtual const gd::EventsList & GetSubEvents() const {return events;};
     virtual gd::EventsList & GetSubEvents() {return events;};
 
-    const std::vector < gd::Instruction > & GetConditions() const { return conditions; };
-    std::vector < gd::Instruction > & GetConditions() { return conditions; };
+    const gd::InstructionsList & GetConditions() const { return conditions; };
+    gd::InstructionsList & GetConditions() { return conditions; };
 
-    const std::vector < gd::Instruction > & GetActions() const { return actions; };
-    std::vector < gd::Instruction > & GetActions() { return actions; };
+    const gd::InstructionsList & GetActions() const { return actions; };
+    gd::InstructionsList & GetActions() { return actions; };
 
-    const std::vector < gd::Instruction > & GetWhileConditions() const { return whileConditions; };
-    std::vector < gd::Instruction > & GetWhileConditions() { return whileConditions; };
-    void SetWhileConditions(std::vector < gd::Instruction > & whileConditions_) { whileConditions = whileConditions_; };
+    const gd::InstructionsList & GetWhileConditions() const { return whileConditions; };
+    gd::InstructionsList & GetWhileConditions() { return whileConditions; };
+    void SetWhileConditions(gd::InstructionsList & whileConditions_) { whileConditions = whileConditions_; };
 
     bool HasInfiniteLoopWarning() const { return infiniteLoopWarning; }
 
-    virtual std::vector < std::vector<gd::Instruction>* > GetAllConditionsVectors();
-    virtual std::vector < std::vector<gd::Instruction>* > GetAllActionsVectors();
-    virtual std::vector < const std::vector<gd::Instruction>* > GetAllConditionsVectors() const;
-    virtual std::vector < const std::vector<gd::Instruction>* > GetAllActionsVectors() const;
+    virtual std::vector < gd::InstructionsList* > GetAllConditionsVectors();
+    virtual std::vector < gd::InstructionsList* > GetAllActionsVectors();
+    virtual std::vector < const gd::InstructionsList* > GetAllConditionsVectors() const;
+    virtual std::vector < const gd::InstructionsList* > GetAllActionsVectors() const;
 
     virtual void SerializeTo(SerializerElement & element) const;
     virtual void UnserializeFrom(gd::Project & project, const SerializerElement & element);
@@ -73,9 +73,9 @@ public:
     virtual EditEventReturnType EditEvent(wxWindow* parent_, gd::Project & game_, gd::Layout & scene_, gd::MainFrameWrapper & mainFrameWrapper_);
 
 private:
-    std::vector < gd::Instruction > whileConditions;
-    std::vector < gd::Instruction > conditions;
-    std::vector < gd::Instruction > actions;
+    gd::InstructionsList whileConditions;
+    gd::InstructionsList conditions;
+    gd::InstructionsList actions;
     EventsList events;
     bool infiniteLoopWarning; ///< If true, code will be generated to warn the developer against an infinite loop.
     bool justCreatedByTheUser; ///< Used so as not to show message box to de/activate infinite loop warning when the user create the event

--- a/Core/GDCore/Events/Event.h
+++ b/Core/GDCore/Events/Event.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <memory>
 #include "GDCore/Events/Instruction.h"
+#include "GDCore/Events/InstructionsList.h"
 namespace gd { class EventsList; }
 namespace gd { class MainFrameWrapper; }
 namespace gd { class Project; }
@@ -93,15 +94,15 @@ public:
      * Event must be able to return all conditions std::vector they have.
      * Used to preprocess the conditions.
      */
-    virtual std::vector < std::vector<Instruction>* > GetAllConditionsVectors() { std::vector < std::vector<Instruction>* > noConditions; return noConditions; };
-    virtual std::vector < const std::vector<Instruction>* > GetAllConditionsVectors() const { std::vector < const std::vector<Instruction>* > noConditions; return noConditions; };
+    virtual std::vector < gd::InstructionsList* > GetAllConditionsVectors() { std::vector < gd::InstructionsList* > noConditions; return noConditions; };
+    virtual std::vector < const gd::InstructionsList* > GetAllConditionsVectors() const { std::vector < const gd::InstructionsList* > noConditions; return noConditions; };
 
     /**
      * Event must be able to return all actions std::vector they have.
      * Used to preprocess the actions.
      */
-    virtual std::vector < std::vector<Instruction>* > GetAllActionsVectors() { std::vector < std::vector<Instruction>* > noActions; return noActions; };
-    virtual std::vector < const std::vector<Instruction>* > GetAllActionsVectors() const { std::vector < const std::vector<Instruction>* > noActions; return noActions; };
+    virtual std::vector < gd::InstructionsList* > GetAllActionsVectors() { std::vector < gd::InstructionsList* > noActions; return noActions; };
+    virtual std::vector < const gd::InstructionsList* > GetAllActionsVectors() const { std::vector < const gd::InstructionsList* > noActions; return noActions; };
 
     /**
      * Event must be able to return all expressions they have.

--- a/Core/GDCore/Events/EventsCodeGenerator.cpp
+++ b/Core/GDCore/Events/EventsCodeGenerator.cpp
@@ -298,7 +298,7 @@ std::string EventsCodeGenerator::GenerateConditionCode(gd::Instruction & conditi
  * Generate code for a list of conditions.
  * Bools containing conditions results are named conditionXIsTrue.
  */
-string EventsCodeGenerator::GenerateConditionsListCode(vector < gd::Instruction > & conditions, EventsCodeGenerationContext & context)
+string EventsCodeGenerator::GenerateConditionsListCode(gd::InstructionsList & conditions, EventsCodeGenerationContext & context)
 {
     string outputCode;
 
@@ -437,7 +437,7 @@ std::string EventsCodeGenerator::GenerateActionCode(gd::Instruction & action, Ev
 /**
  * Generate actions code.
  */
-string EventsCodeGenerator::GenerateActionsListCode(vector < gd::Instruction > & actions, EventsCodeGenerationContext & context)
+string EventsCodeGenerator::GenerateActionsListCode(gd::InstructionsList & actions, EventsCodeGenerationContext & context)
 {
     string outputCode;
     for (unsigned int aId =0;aId < actions.size();++aId)

--- a/Core/GDCore/Events/EventsCodeGenerator.h
+++ b/Core/GDCore/Events/EventsCodeGenerator.h
@@ -2,6 +2,7 @@
 #define GDCORE_EVENTSCODEGENERATOR_H
 
 #include "GDCore/Events/Event.h"
+#include "GDCore/Events/Instruction.h"
 #include <string>
 #include <vector>
 #include <set>
@@ -71,7 +72,7 @@ public:
      * \param context Context used for generation
      * \return Code. Boolean containing conditions result are name conditionXIsTrue, with X = the number of the condition, starting from 0.
      */
-    virtual std::string GenerateConditionsListCode(std::vector < gd::Instruction > & conditions, EventsCodeGenerationContext & context);
+    virtual std::string GenerateConditionsListCode(gd::InstructionsList & conditions, EventsCodeGenerationContext & context);
 
     /**
      * \brief Generate code for executing an action list
@@ -84,7 +85,7 @@ public:
      * \param context Context used for generation
      * \return Code
      */
-    virtual std::string GenerateActionsListCode(std::vector < gd::Instruction > & actions, EventsCodeGenerationContext & context);
+    virtual std::string GenerateActionsListCode(gd::InstructionsList & actions, EventsCodeGenerationContext & context);
 
     /**
      * \brief Generate the code for a parameter of an action/condition/expression.

--- a/Core/GDCore/Events/Instruction.cpp
+++ b/Core/GDCore/Events/Instruction.cpp
@@ -4,6 +4,7 @@
  * This project is released under the MIT License.
  */
 #include "GDCore/Events/Instruction.h"
+#include "GDCore/Events/InstructionsList.h"
 #include "GDCore/Events/Expression.h"
 #include <string>
 #include <iostream>

--- a/Core/GDCore/Events/Instruction.h
+++ b/Core/GDCore/Events/Instruction.h
@@ -8,9 +8,15 @@
 #include <string>
 #include <vector>
 #include "GDCore/Events/Expression.h"
+#include "GDCore/Tools/SPtrList.h"
 
 namespace gd
 {
+
+class Instruction;
+
+template<typename T> class SPtrList;
+typedef SPtrList<Instruction> InstructionsList;
 
 /**
  * \brief An instruction is a member of an event: It can be a condition or an action.
@@ -114,12 +120,12 @@ public:
     /**
      * \brief Return a reference to the vector containing sub instructions
      */
-    inline const std::vector < Instruction > & GetSubInstructions() const { return subInstructions; };
+    inline const gd::InstructionsList & GetSubInstructions() const { return subInstructions; };
 
     /**
      * \brief Return a reference to the vector containing sub instructions
      */
-    inline std::vector < Instruction > & GetSubInstructions() { return subInstructions; };
+    inline gd::InstructionsList & GetSubInstructions() { return subInstructions; };
 
     /** \name Rendering
      * Members related to the instruction rendering in an event editor.
@@ -136,8 +142,8 @@ private:
 
     std::string                             type; ///< Instruction type
     bool                                    inverted; ///< True if the instruction if inverted. Only applicable for instruction used as conditions by events
-    mutable std::vector < gd::Expression >    parameters; ///< Vector containing the parameters
-    std::vector < Instruction >             subInstructions; ///< Sub instructions, if applicable.
+    mutable std::vector < gd::Expression >  parameters; ///< Vector containing the parameters
+    gd::InstructionsList                    subInstructions; ///< Sub instructions, if applicable.
 
     static gd::Expression badExpression;
 };

--- a/Core/GDCore/Events/InstructionsList.h
+++ b/Core/GDCore/Events/InstructionsList.h
@@ -1,0 +1,23 @@
+/*
+ * GDevelop Core
+ * Copyright 2015 Victor Levasseur (victorlevasseur52@gmail.com)
+ * This project is released under the MIT License.
+ */
+
+#ifndef GDCORE_INSTRUCTIONSLIST_H
+#define GDCORE_INSTRUCTIONSLIST_H
+
+#include <memory>
+#include <vector>
+
+#include "GDCore/Events/Instruction.h"
+#include "GDCore/Tools/SPtrList.h"
+
+namespace gd
+{
+
+typedef SPtrList<gd::Instruction> InstructionsList;
+
+}
+
+#endif

--- a/Core/GDCore/Events/Serialization.cpp
+++ b/Core/GDCore/Events/Serialization.cpp
@@ -22,7 +22,7 @@ using namespace std;
 namespace gd
 {
 
-void EventsListSerialization::UpdateInstructionsFromGD31x(gd::Project & project, std::vector < gd::Instruction > & list, bool instructionsAreActions)
+void EventsListSerialization::UpdateInstructionsFromGD31x(gd::Project & project, gd::InstructionsList & list, bool instructionsAreActions)
 {
     for (unsigned int i = 0;i<list.size();++i)
     {
@@ -57,7 +57,7 @@ void EventsListSerialization::UpdateInstructionsFromGD31x(gd::Project & project,
     }
 }
 
-void EventsListSerialization::UpdateInstructionsFromGD2x(gd::Project & project, std::vector < gd::Instruction > & list, bool instructionsAreActions)
+void EventsListSerialization::UpdateInstructionsFromGD2x(gd::Project & project, gd::InstructionsList & list, bool instructionsAreActions)
 {
     for (unsigned int i = 0;i<list.size();++i)
     {
@@ -210,7 +210,7 @@ void EventsListSerialization::SerializeEventsTo(const EventsList & list, Seriali
 
 using namespace std;
 
-void gd::EventsListSerialization::OpenConditions(gd::Project & project, vector < gd::Instruction > & conditions, const SerializerElement & elem)
+void gd::EventsListSerialization::OpenConditions(gd::Project & project, gd::InstructionsList & conditions, const SerializerElement & elem)
 {
     elem.ConsiderAsArrayOf("condition", "Condition");
     for(unsigned int i = 0; i<elem.GetChildrenCount(); ++i)
@@ -246,7 +246,7 @@ void gd::EventsListSerialization::OpenConditions(gd::Project & project, vector <
         if ( conditionElem.HasChild("subConditions", "SubConditions") )
             OpenConditions(project, instruction.GetSubInstructions(), conditionElem.GetChild("subConditions", 0, "SubConditions" ));
 
-        conditions.push_back( instruction );
+        conditions.Insert( instruction );
     }
 
     if ( project.GetLastSaveGDMajorVersion() < 3 ||
@@ -257,7 +257,7 @@ void gd::EventsListSerialization::OpenConditions(gd::Project & project, vector <
         UpdateInstructionsFromGD2x(project, conditions, false);
 }
 
-void gd::EventsListSerialization::OpenActions(gd::Project & project, vector < gd::Instruction > & actions, const SerializerElement & elem)
+void gd::EventsListSerialization::OpenActions(gd::Project & project, gd::InstructionsList & actions, const SerializerElement & elem)
 {
     elem.ConsiderAsArrayOf("action", "Action");
     for(unsigned int i = 0; i<elem.GetChildrenCount(); ++i)
@@ -292,7 +292,7 @@ void gd::EventsListSerialization::OpenActions(gd::Project & project, vector < gd
         if ( actionElem.HasChild("subActions", "SubActions") )
             OpenActions(project, instruction.GetSubInstructions(), actionElem.GetChild("subActions", 0, "SubActions" ));
 
-        actions.push_back( instruction );
+        actions.Insert( instruction );
     }
 
     if ( project.GetLastSaveGDMajorVersion() < 3 ||
@@ -303,7 +303,7 @@ void gd::EventsListSerialization::OpenActions(gd::Project & project, vector < gd
         UpdateInstructionsFromGD2x(project, actions, true);
 }
 
-void gd::EventsListSerialization::SaveActions(const vector < gd::Instruction > & list, SerializerElement & actions)
+void gd::EventsListSerialization::SaveActions(const gd::InstructionsList & list, SerializerElement & actions)
 {
     actions.ConsiderAsArrayOf("action");
     for ( unsigned int k = 0;k < list.size();k++ )
@@ -325,7 +325,7 @@ void gd::EventsListSerialization::SaveActions(const vector < gd::Instruction > &
     }
 }
 
-void gd::EventsListSerialization::SaveConditions(const vector < gd::Instruction > & list, SerializerElement & conditions)
+void gd::EventsListSerialization::SaveConditions(const gd::InstructionsList & list, SerializerElement & conditions)
 {
     conditions.ConsiderAsArrayOf("condition");
     for ( unsigned int k = 0;k < list.size();k++ )

--- a/Core/GDCore/Events/Serialization.h
+++ b/Core/GDCore/Events/Serialization.h
@@ -39,36 +39,36 @@ public:
     /**
      * \brief Load a list of conditions from a TiXmlElement
      */
-    static void OpenConditions(gd::Project & project, std::vector < gd::Instruction > & list, const SerializerElement & elem);
+    static void OpenConditions(gd::Project & project, gd::InstructionsList & list, const SerializerElement & elem);
 
     /**
      * \brief Load a list of actions from a TiXmlElement
      */
-    static void OpenActions(gd::Project & project, std::vector < gd::Instruction > & list, const SerializerElement & elem);
+    static void OpenActions(gd::Project & project, gd::InstructionsList & list, const SerializerElement & elem);
 
     /**
      * \brief Save a list of conditions to a TiXmlElement
      */
-    static void SaveConditions(const std::vector < gd::Instruction > & list, SerializerElement & elem);
+    static void SaveConditions(const gd::InstructionsList & list, SerializerElement & elem);
 
     /**
      * \brief Save a list of actions to a TiXmlElement
      */
-    static void SaveActions(const std::vector < gd::Instruction > & list, SerializerElement & elem);
+    static void SaveActions(const gd::InstructionsList & list, SerializerElement & elem);
 
     /**
      * \brief Internal method called when opening events created with GD2.x
      *
      * Some instructions names have been changed as well as parameters since GD 3.
      */
-    static void UpdateInstructionsFromGD2x(gd::Project & project, std::vector < gd::Instruction > & list, bool instructionsAreActions);
+    static void UpdateInstructionsFromGD2x(gd::Project & project, gd::InstructionsList & list, bool instructionsAreActions);
 
     /**
      * \brief Internal method called when opening events created with GD 3.1.x
      *
      * Variables related and some storage instructions have been changed.
      */
-    static void UpdateInstructionsFromGD31x(gd::Project & project, std::vector < gd::Instruction > & list, bool instructionsAreActions);
+    static void UpdateInstructionsFromGD31x(gd::Project & project, gd::InstructionsList & list, bool instructionsAreActions);
 };
 
 }

--- a/Core/GDCore/IDE/ArbitraryEventsWorker.cpp
+++ b/Core/GDCore/IDE/ArbitraryEventsWorker.cpp
@@ -40,23 +40,23 @@ void ArbitraryEventsWorker::VisitEvent(gd::BaseEvent & event)
 {
     DoVisitEvent(event);
 
-    vector < vector<gd::Instruction>* > conditionsVectors =  event.GetAllConditionsVectors();
+    vector < gd::InstructionsList* > conditionsVectors =  event.GetAllConditionsVectors();
     for (unsigned int j = 0;j < conditionsVectors.size();++j)
     	VisitInstructionList(*conditionsVectors[j], true);
 
-    vector < vector<gd::Instruction>* > actionsVectors =  event.GetAllActionsVectors();
+    vector < gd::InstructionsList* > actionsVectors =  event.GetAllActionsVectors();
     for (unsigned int j = 0;j < actionsVectors.size();++j)
     	VisitInstructionList(*actionsVectors[j], false);
 }
 
-void ArbitraryEventsWorker::VisitInstructionList(std::vector<gd::Instruction> & instructions, bool areConditions)
+void ArbitraryEventsWorker::VisitInstructionList(gd::InstructionsList & instructions, bool areConditions)
 {
     DoVisitInstructionList(instructions, areConditions);
 
     for (unsigned int i = 0;i < instructions.size();)
     {
         if ( VisitInstruction(instructions[i], areConditions) )
-            instructions.erase(instructions.begin()+i);
+            instructions.Remove(i);
         else
         {
         	if ( !instructions[i].GetSubInstructions().empty() )

--- a/Core/GDCore/IDE/ArbitraryEventsWorker.h
+++ b/Core/GDCore/IDE/ArbitraryEventsWorker.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include "GDCore/Events/InstructionsList.h"
 namespace gd {class Instruction;}
 namespace gd {class BaseEvent;}
 namespace gd {class Project;}
@@ -37,7 +38,7 @@ public:
 private:
     void VisitEventList(gd::EventsList & events);
     void VisitEvent(gd::BaseEvent & event);
-    void VisitInstructionList(std::vector<gd::Instruction> & instructions, bool areConditions);
+    void VisitInstructionList(gd::InstructionsList & instructions, bool areConditions);
     bool VisitInstruction(gd::Instruction & instruction, bool isCondition);
 
     /**
@@ -53,7 +54,7 @@ private:
     /**
      * Called to do some work on an instruction list
      */
-    virtual void DoVisitInstructionList(std::vector<gd::Instruction> & instructions, bool areConditions) {};
+    virtual void DoVisitInstructionList(gd::InstructionsList & instructions, bool areConditions) {};
 
     /**
      * Called to do some work on an instruction.

--- a/Core/GDCore/IDE/ArbitraryResourceWorker.cpp
+++ b/Core/GDCore/IDE/ArbitraryResourceWorker.cpp
@@ -51,12 +51,12 @@ void LaunchResourceWorkerOnEvents(const gd::Project & project, gd::EventsList & 
 
     for ( unsigned int j = 0;j < events.size() ;j++ )
     {
-        vector < vector<Instruction>* > allActionsVectors = events[j].GetAllActionsVectors();
+        vector < gd::InstructionsList* > allActionsVectors = events[j].GetAllActionsVectors();
         for (unsigned int i = 0;i<allActionsVectors.size();++i)
         {
             for ( unsigned int k = 0;k < allActionsVectors[i]->size() ;k++ )
             {
-                std::string type = allActionsVectors[i]->at( k ).GetType();
+                std::string type = allActionsVectors[i]->Get( k ).GetType();
                 for (unsigned int e = 0;e<allGameExtensions.size();++e)
                 {
                     bool extensionHasAction = false;
@@ -83,7 +83,7 @@ void LaunchResourceWorkerOnEvents(const gd::Project & project, gd::EventsList & 
 
                     if ( extensionHasAction )
                     {
-                        allGameExtensions[e]->ExposeActionsResources(allActionsVectors[i]->at( k ), worker);
+                        allGameExtensions[e]->ExposeActionsResources(allActionsVectors[i]->Get( k ), worker);
                         break;
                     }
                 }
@@ -91,12 +91,12 @@ void LaunchResourceWorkerOnEvents(const gd::Project & project, gd::EventsList & 
             }
         }
 
-        vector < vector<Instruction>* > allConditionsVector = events[j].GetAllConditionsVectors();
+        vector < gd::InstructionsList* > allConditionsVector = events[j].GetAllConditionsVectors();
         for (unsigned int i = 0;i<allConditionsVector.size();++i)
         {
             for ( unsigned int k = 0;k < allConditionsVector[i]->size() ;k++ )
             {
-                std::string type = allConditionsVector[i]->at( k ).GetType();
+                std::string type = allConditionsVector[i]->Get( k ).GetType();
                 for (unsigned int e = 0;e<allGameExtensions.size();++e)
                 {
                     bool extensionHasCondition = false;
@@ -121,7 +121,7 @@ void LaunchResourceWorkerOnEvents(const gd::Project & project, gd::EventsList & 
                             extensionHasCondition = true;
                     }
 
-                    if ( extensionHasCondition ) allGameExtensions[e]->ExposeConditionsResources(allConditionsVector[i]->at( k ), worker);
+                    if ( extensionHasCondition ) allGameExtensions[e]->ExposeConditionsResources(allConditionsVector[i]->Get( k ), worker);
                 }
 
             }

--- a/Core/GDCore/IDE/Clipboard.cpp
+++ b/Core/GDCore/IDE/Clipboard.cpp
@@ -121,14 +121,14 @@ gd::ExternalLayout Clipboard::GetExternalLayout()
     return *externalLayoutCopied;
 }
 
-void Clipboard::SetConditions( const std::vector<gd::Instruction> & conditions )
+void Clipboard::SetConditions( const gd::InstructionsList & conditions )
 {
     hasInstructions = true;
     instructionsAreConditions = true;
     instructionsCopied = conditions;
 }
 
-void Clipboard::SetActions( const std::vector<gd::Instruction> & actions )
+void Clipboard::SetActions( const gd::InstructionsList & actions )
 {
     hasInstructions = true;
     instructionsAreConditions = false;

--- a/Core/GDCore/IDE/Clipboard.h
+++ b/Core/GDCore/IDE/Clipboard.h
@@ -62,12 +62,12 @@ public:
     gd::ExternalLayout GetExternalLayout();
     bool HasExternalLayout() { return hasExternalLayout; };
 
-    void SetConditions( const std::vector<gd::Instruction> & conditions );
-    void SetActions( const std::vector<gd::Instruction> & actions );
+    void SetConditions( const gd::InstructionsList & conditions );
+    void SetActions( const gd::InstructionsList & actions );
 
     bool HasCondition() { return hasInstructions && instructionsAreConditions; };
     bool HasAction() { return hasInstructions && !instructionsAreConditions; };
-    std::vector<gd::Instruction> GetInstructions() const { return instructionsCopied; };
+    gd::InstructionsList GetInstructions() const { return instructionsCopied; };
 
     void SetObjectGroup( const gd::ObjectGroup & group );
     gd::ObjectGroup GetObjectGroup();
@@ -88,7 +88,7 @@ private:
     gd::EventsList eventsCopied;
     bool hasEvents;
 
-    std::vector<gd::Instruction> instructionsCopied;
+    gd::InstructionsList instructionsCopied;
     bool hasInstructions;
     bool instructionsAreConditions;
 

--- a/Core/GDCore/IDE/EventsEditorItemsAreas.cpp
+++ b/Core/GDCore/IDE/EventsEditorItemsAreas.cpp
@@ -266,7 +266,7 @@ bool gd::InstructionItem::operator==(const gd::InstructionItem & other) const
     return (instruction == other.instruction && isCondition == other.isCondition && instructionList == other.instructionList && positionInList == other.positionInList && event == other.event);
 }
 
-InstructionItem::InstructionItem(gd::Instruction * instruction_, bool isCondition_, std::vector<gd::Instruction>* instructionList_, unsigned int positionInList_, gd::BaseEvent * event_ ) :
+InstructionItem::InstructionItem(gd::Instruction * instruction_, bool isCondition_, gd::InstructionsList* instructionList_, unsigned int positionInList_, gd::BaseEvent * event_ ) :
     instruction(instruction_),
     isCondition(isCondition_),
     instructionList(instructionList_),
@@ -290,7 +290,7 @@ bool InstructionListItem::operator==(const InstructionListItem & other) const
     return (isConditionList == other.isConditionList && instructionList == other.instructionList && event == other.event);
 }
 
-InstructionListItem::InstructionListItem(bool isCondition_, std::vector<gd::Instruction>* instructionList_, gd::BaseEvent * event_ ) :
+InstructionListItem::InstructionListItem(bool isCondition_, gd::InstructionsList* instructionList_, gd::BaseEvent * event_ ) :
     isConditionList(isCondition_),
     instructionList(instructionList_),
     event(event_)

--- a/Core/GDCore/IDE/EventsEditorItemsAreas.h
+++ b/Core/GDCore/IDE/EventsEditorItemsAreas.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <vector>
 #include <utility>
+#include "GDCore/Events/InstructionsList.h"
 namespace gd { class EventsList; }
 namespace gd { class BaseEvent; }
 namespace gd { class Instruction; }
@@ -51,7 +52,7 @@ public:
     /**
      * Use this constructor to declare the instruction, the list it belongs to and its position in this list.
      */
-    InstructionItem(gd::Instruction * instruction_, bool isCondition, std::vector<gd::Instruction>* instructionList_, unsigned int positionInList_, gd::BaseEvent * event );
+    InstructionItem(gd::Instruction * instruction_, bool isCondition, gd::InstructionsList* instructionList_, unsigned int positionInList_, gd::BaseEvent * event );
     InstructionItem();
     ~InstructionItem() {};
 
@@ -59,7 +60,7 @@ public:
 
     gd::Instruction * instruction;
     bool isCondition;
-    std::vector<gd::Instruction>* instructionList;
+    gd::InstructionsList* instructionList;
     unsigned int positionInList;
     gd::BaseEvent * event;
 };
@@ -74,14 +75,14 @@ public:
     /**
      * Use this constructor to declare the instruction, the list it belongs to and its position in this list.
      */
-    InstructionListItem(bool isConditionList, std::vector<gd::Instruction>* instructionList_, gd::BaseEvent * event );
+    InstructionListItem(bool isConditionList, gd::InstructionsList* instructionList_, gd::BaseEvent * event );
     InstructionListItem();
     ~InstructionListItem() {};
 
     bool operator==(const InstructionListItem & other) const;
 
     bool isConditionList;
-    std::vector<gd::Instruction>* instructionList;
+    gd::InstructionsList* instructionList;
     gd::BaseEvent * event;
 };
 
@@ -269,7 +270,7 @@ namespace std
         std::size_t operator()(gd::InstructionItem const& item) const
         {
             return (std::hash<gd::Instruction*>()(item.instruction)) ^ 
-                   (std::hash<std::vector<gd::Instruction>*>()(item.instructionList) << 1) ^ 
+                   (std::hash<gd::InstructionsList*>()(item.instructionList) << 1) ^ 
                    (std::hash<unsigned int>()(item.positionInList) << 2) ^
                    (std::hash<gd::BaseEvent*>()(item.event) << 3) ^ 
                    (std::hash<bool>()(item.isCondition) << 4);
@@ -281,7 +282,7 @@ namespace std
     {
         std::size_t operator()(gd::InstructionListItem const& item) const
         {
-            return (std::hash<std::vector<gd::Instruction>*>()(item.instructionList)) ^ 
+            return (std::hash<gd::InstructionsList*>()(item.instructionList)) ^ 
                    (std::hash<gd::BaseEvent*>()(item.event) << 1) ^ 
                    (std::hash<bool>()(item.isConditionList) << 2);
         }

--- a/Core/GDCore/IDE/EventsEditorSelection.h
+++ b/Core/GDCore/IDE/EventsEditorSelection.h
@@ -171,7 +171,7 @@ public:
 
     void BeginDragInstruction();
     bool IsDraggingInstruction();
-    std::vector<gd::Instruction> * EndDragInstruction(bool deleteDraggedInstruction = true, bool dropAfterHighlightedElement = false);
+    gd::InstructionsList * EndDragInstruction(bool deleteDraggedInstruction = true, bool dropAfterHighlightedElement = false);
 
 private:
 
@@ -195,7 +195,7 @@ private:
     /**
      * Return true if an instruction is found in the list ( sub instructions are also taken in account )
      */
-    bool FindInInstructionsAndSubInstructions(std::vector<gd::Instruction> & list, const gd::Instruction * instrToSearch);
+    bool FindInInstructionsAndSubInstructions(gd::InstructionsList & list, const gd::Instruction * instrToSearch);
 
     gd::EventsEditorRefreshCallbacks & eventsEditorCallback;
 };

--- a/Core/GDCore/IDE/EventsRefactorer.cpp
+++ b/Core/GDCore/IDE/EventsRefactorer.cpp
@@ -199,7 +199,7 @@ private:
     std::string name;
 };
 
-bool EventsRefactorer::RenameObjectInActions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, vector < gd::Instruction > & actions, std::string oldName, std::string newName)
+bool EventsRefactorer::RenameObjectInActions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, gd::InstructionsList & actions, std::string oldName, std::string newName)
 {
     bool somethingModified = false;
 
@@ -250,7 +250,7 @@ bool EventsRefactorer::RenameObjectInActions(const gd::Platform & platform, gd::
     return somethingModified;
 }
 
-bool EventsRefactorer::RenameObjectInConditions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, vector < gd::Instruction > & conditions, std::string oldName, std::string newName)
+bool EventsRefactorer::RenameObjectInConditions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, gd::InstructionsList & conditions, std::string oldName, std::string newName)
 {
     bool somethingModified = false;
 
@@ -305,7 +305,7 @@ void EventsRefactorer::RenameObjectInEvents(const gd::Platform & platform, gd::P
 {
     for (unsigned int i = 0;i<events.size();++i)
     {
-        vector < vector<gd::Instruction>* > conditionsVectors =  events[i].GetAllConditionsVectors();
+        vector < gd::InstructionsList* > conditionsVectors =  events[i].GetAllConditionsVectors();
         for (unsigned int j = 0;j < conditionsVectors.size();++j)
         {
             bool somethingModified = RenameObjectInConditions(platform, project, layout, *conditionsVectors[j], oldName, newName);
@@ -314,7 +314,7 @@ void EventsRefactorer::RenameObjectInEvents(const gd::Platform & platform, gd::P
             #endif
         }
 
-        vector < vector<gd::Instruction>* > actionsVectors =  events[i].GetAllActionsVectors();
+        vector < gd::InstructionsList* > actionsVectors =  events[i].GetAllActionsVectors();
         for (unsigned int j = 0;j < actionsVectors.size();++j)
         {
             bool somethingModified = RenameObjectInActions(platform, project, layout, *actionsVectors[j], oldName, newName);
@@ -327,7 +327,7 @@ void EventsRefactorer::RenameObjectInEvents(const gd::Platform & platform, gd::P
     }
 }
 
-bool EventsRefactorer::RemoveObjectInActions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, vector < gd::Instruction > & actions, std::string name)
+bool EventsRefactorer::RemoveObjectInActions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, gd::InstructionsList & actions, std::string name)
 {
     bool somethingModified = false;
 
@@ -374,7 +374,7 @@ bool EventsRefactorer::RemoveObjectInActions(const gd::Platform & platform, gd::
         if ( deleteMe )
         {
             somethingModified = true;
-            actions.erase(actions.begin()+aId);
+            actions.Remove(aId);
             aId--;
         }
         else if ( !actions[aId].GetSubInstructions().empty() ) somethingModified = RemoveObjectInActions(platform, project, layout, actions[aId].GetSubInstructions(), name) || somethingModified;
@@ -383,7 +383,7 @@ bool EventsRefactorer::RemoveObjectInActions(const gd::Platform & platform, gd::
     return somethingModified;
 }
 
-bool EventsRefactorer::RemoveObjectInConditions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, vector < gd::Instruction > & conditions, std::string name)
+bool EventsRefactorer::RemoveObjectInConditions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, gd::InstructionsList & conditions, std::string name)
 {
     bool somethingModified = false;
 
@@ -428,7 +428,7 @@ bool EventsRefactorer::RemoveObjectInConditions(const gd::Platform & platform, g
         if ( deleteMe )
         {
             somethingModified = true;
-            conditions.erase(conditions.begin()+cId);
+            conditions.Remove(cId);
             cId--;
         }
         else if ( !conditions[cId].GetSubInstructions().empty() ) somethingModified = RemoveObjectInConditions(platform, project, layout, conditions[cId].GetSubInstructions(), name) || somethingModified;
@@ -441,7 +441,7 @@ void EventsRefactorer::RemoveObjectInEvents(const gd::Platform & platform, gd::P
 {
     for (unsigned int i = 0;i<events.size();++i)
     {
-        vector < vector<gd::Instruction>* > conditionsVectors =  events[i].GetAllConditionsVectors();
+        vector < gd::InstructionsList* > conditionsVectors =  events[i].GetAllConditionsVectors();
         for (unsigned int j = 0;j < conditionsVectors.size();++j)
         {
             bool conditionsModified = RemoveObjectInConditions(platform, project, layout, *conditionsVectors[j], name);
@@ -450,7 +450,7 @@ void EventsRefactorer::RemoveObjectInEvents(const gd::Platform & platform, gd::P
             #endif
         }
 
-        vector < vector<gd::Instruction>* > actionsVectors =  events[i].GetAllActionsVectors();
+        vector < gd::InstructionsList* > actionsVectors =  events[i].GetAllActionsVectors();
         for (unsigned int j = 0;j < actionsVectors.size();++j)
         {
             bool actionsModified = RemoveObjectInActions(platform, project, layout, *actionsVectors[j], name);
@@ -474,7 +474,7 @@ void EventsRefactorer::ReplaceStringInEvents(gd::Project & project, gd::Layout &
     {
         if ( inConditions )
         {
-            vector < vector<gd::Instruction>* > conditionsVectors =  events[i].GetAllConditionsVectors();
+            vector < gd::InstructionsList* > conditionsVectors =  events[i].GetAllConditionsVectors();
             for (unsigned int j = 0;j < conditionsVectors.size();++j)
             {
                 bool conditionsModified = ReplaceStringInConditions(project, layout, *conditionsVectors[j], toReplace, newString, matchCase);
@@ -486,7 +486,7 @@ void EventsRefactorer::ReplaceStringInEvents(gd::Project & project, gd::Layout &
 
         if ( inActions )
         {
-            vector < vector<gd::Instruction>* > actionsVectors =  events[i].GetAllActionsVectors();
+            vector < gd::InstructionsList* > actionsVectors =  events[i].GetAllActionsVectors();
             for (unsigned int j = 0;j < actionsVectors.size();++j)
             {
                 bool actionsModified = ReplaceStringInActions(project, layout, *actionsVectors[j], toReplace, newString, matchCase);
@@ -528,7 +528,7 @@ std::string ReplaceAllOccurencesCaseUnsensitive(string context, string from, con
     return context;
 }
 
-bool EventsRefactorer::ReplaceStringInActions(gd::Project & project, gd::Layout & layout, vector < gd::Instruction > & actions, std::string toReplace, std::string newString, bool matchCase)
+bool EventsRefactorer::ReplaceStringInActions(gd::Project & project, gd::Layout & layout, gd::InstructionsList & actions, std::string toReplace, std::string newString, bool matchCase)
 {
     bool somethingModified = false;
 
@@ -555,7 +555,7 @@ bool EventsRefactorer::ReplaceStringInActions(gd::Project & project, gd::Layout 
     return somethingModified;
 }
 
-bool EventsRefactorer::ReplaceStringInConditions(gd::Project & project, gd::Layout & layout, vector < gd::Instruction > & conditions, std::string toReplace, std::string newString, bool matchCase)
+bool EventsRefactorer::ReplaceStringInConditions(gd::Project & project, gd::Layout & layout, gd::InstructionsList & conditions, std::string toReplace, std::string newString, bool matchCase)
 {
     bool somethingModified = false;
 
@@ -596,7 +596,7 @@ vector < EventsSearchResult > EventsRefactorer::SearchInEvents(gd::Project & pro
 
         if ( inConditions )
         {
-            vector < vector<gd::Instruction>* > conditionsVectors =  events[i].GetAllConditionsVectors();
+            vector < gd::InstructionsList* > conditionsVectors =  events[i].GetAllConditionsVectors();
             for (unsigned int j = 0;j < conditionsVectors.size();++j)
             {
                 if (!eventAddedInResults && SearchStringInConditions(project, layout, *conditionsVectors[j], search, matchCase))
@@ -608,7 +608,7 @@ vector < EventsSearchResult > EventsRefactorer::SearchInEvents(gd::Project & pro
 
         if ( inActions )
         {
-            vector < vector<gd::Instruction>* > actionsVectors =  events[i].GetAllActionsVectors();
+            vector < gd::InstructionsList* > actionsVectors =  events[i].GetAllActionsVectors();
             for (unsigned int j = 0;j < actionsVectors.size();++j)
             {
                 if (!eventAddedInResults && SearchStringInActions(project, layout, *actionsVectors[j], search, matchCase))
@@ -628,7 +628,7 @@ vector < EventsSearchResult > EventsRefactorer::SearchInEvents(gd::Project & pro
     return results;
 }
 
-bool EventsRefactorer::SearchStringInActions(gd::Project & project, gd::Layout & layout, vector < gd::Instruction > & actions, std::string search, bool matchCase)
+bool EventsRefactorer::SearchStringInActions(gd::Project & project, gd::Layout & layout, gd::InstructionsList & actions, std::string search, bool matchCase)
 {
     if ( !matchCase ) search = gd::StrUppercase(search);
 
@@ -649,7 +649,7 @@ bool EventsRefactorer::SearchStringInActions(gd::Project & project, gd::Layout &
     return false;
 }
 
-bool EventsRefactorer::SearchStringInConditions(gd::Project & project, gd::Layout & layout, vector < gd::Instruction > & conditions, std::string search, bool matchCase)
+bool EventsRefactorer::SearchStringInConditions(gd::Project & project, gd::Layout & layout, gd::InstructionsList & conditions, std::string search, bool matchCase)
 {
     if ( !matchCase ) search = gd::StrUppercase(search);
 

--- a/Core/GDCore/IDE/EventsRefactorer.h
+++ b/Core/GDCore/IDE/EventsRefactorer.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include "GDCore/Events/Instruction.h"
 namespace gd { class EventsList; }
 namespace gd { class Layout; }
 namespace gd { class Platform; }
@@ -90,7 +91,7 @@ private:
      *
      * \return true if something was modified.
      */
-    static bool RenameObjectInActions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, std::vector < gd::Instruction > & instructions, std::string oldName, std::string newName);
+    static bool RenameObjectInActions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, gd::InstructionsList & instructions, std::string oldName, std::string newName);
 
     /**
      * Replace all occurences of an object name by another name in a condition
@@ -98,38 +99,38 @@ private:
      *
      * \return true if something was modified.
      */
-    static bool RenameObjectInConditions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, std::vector < gd::Instruction > & instructions, std::string oldName, std::string newName);
+    static bool RenameObjectInConditions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, gd::InstructionsList & instructions, std::string oldName, std::string newName);
 
     /**
      * Remove all conditions of the list using an object
      *
      * \return true if something was modified.
      */
-    static bool RemoveObjectInConditions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, std::vector < gd::Instruction > & conditions, std::string name);
+    static bool RemoveObjectInConditions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, gd::InstructionsList & conditions, std::string name);
 
     /**
      * Remove all actions of the list using an object
      *
      * \return true if something was modified.
      */
-    static bool RemoveObjectInActions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, std::vector < gd::Instruction > & conditions, std::string name);
+    static bool RemoveObjectInActions(const gd::Platform & platform, gd::Project & project, gd::Layout & layout, gd::InstructionsList & conditions, std::string name);
 
     /**
      * Replace all occurences of a string in conditions
      *
      * \return true if something was modified.
      */
-    static bool ReplaceStringInConditions(gd::Project & project, gd::Layout & layout, std::vector < gd::Instruction > & conditions, std::string toReplace, std::string newString, bool matchCase);
+    static bool ReplaceStringInConditions(gd::Project & project, gd::Layout & layout, gd::InstructionsList & conditions, std::string toReplace, std::string newString, bool matchCase);
 
     /**
      * Replace all occurences of a string in actions
      *
      * \return true if something was modified.
      */
-    static bool ReplaceStringInActions(gd::Project & project, gd::Layout & layout, std::vector < gd::Instruction > & conditions, std::string toReplace, std::string newString, bool matchCase);
+    static bool ReplaceStringInActions(gd::Project & project, gd::Layout & layout, gd::InstructionsList & conditions, std::string toReplace, std::string newString, bool matchCase);
 
-    static bool SearchStringInActions(gd::Project & project, gd::Layout & layout, std::vector < gd::Instruction > & actions, std::string search, bool matchCase);
-    static bool SearchStringInConditions(gd::Project & project, gd::Layout & layout, std::vector < gd::Instruction > & conditions, std::string search, bool matchCase);
+    static bool SearchStringInActions(gd::Project & project, gd::Layout & layout, gd::InstructionsList & actions, std::string search, bool matchCase);
+    static bool SearchStringInConditions(gd::Project & project, gd::Layout & layout, gd::InstructionsList & conditions, std::string search, bool matchCase);
 
     EventsRefactorer() {};
 };

--- a/Core/GDCore/IDE/EventsRenderingHelper.cpp
+++ b/Core/GDCore/IDE/EventsRenderingHelper.cpp
@@ -142,7 +142,7 @@ void EventsRenderingHelper::SetFont(const wxFont & font_)
     fontCharacterWidth = static_cast<float>(dc.GetTextExtent("abcdef").GetWidth())/6.0f;
 }
 
-int EventsRenderingHelper::DrawConditionsList(vector < gd::Instruction > & conditions, wxDC & dc, int x, int y, int width, gd::BaseEvent * event,
+int EventsRenderingHelper::DrawConditionsList(gd::InstructionsList & conditions, wxDC & dc, int x, int y, int width, gd::BaseEvent * event,
                                               gd::EventsEditorItemsAreas & areas, gd::EventsEditorSelection & selection, const gd::Platform & platform)
 {
     int initialYPosition = y;
@@ -243,7 +243,7 @@ int EventsRenderingHelper::DrawConditionsList(vector < gd::Instruction > & condi
     return y-initialYPosition;
 }
 
-int EventsRenderingHelper::DrawActionsList(vector < gd::Instruction > & actions, wxDC & dc, int x, int y, int width, gd::BaseEvent * event,
+int EventsRenderingHelper::DrawActionsList(gd::InstructionsList & actions, wxDC & dc, int x, int y, int width, gd::BaseEvent * event,
                                            gd::EventsEditorItemsAreas & areas, gd::EventsEditorSelection & selection, const gd::Platform & platform)
 {
     int initialYPosition = y;
@@ -336,7 +336,7 @@ int EventsRenderingHelper::DrawActionsList(vector < gd::Instruction > & actions,
     return y-initialYPosition;
 }
 
-unsigned int EventsRenderingHelper::GetRenderedConditionsListHeight(const vector < gd::Instruction > & conditions, int width, const gd::Platform & platform)
+unsigned int EventsRenderingHelper::GetRenderedConditionsListHeight(const gd::InstructionsList & conditions, int width, const gd::Platform & platform)
 {
     int y = 0;
 
@@ -367,7 +367,7 @@ unsigned int EventsRenderingHelper::GetRenderedConditionsListHeight(const vector
     return y;
 }
 
-unsigned int EventsRenderingHelper::GetRenderedActionsListHeight(const vector < gd::Instruction > & actions, int width, const gd::Platform & platform)
+unsigned int EventsRenderingHelper::GetRenderedActionsListHeight(const gd::InstructionsList & actions, int width, const gd::Platform & platform)
 {
     int y = 0;
 

--- a/Core/GDCore/IDE/EventsRenderingHelper.h
+++ b/Core/GDCore/IDE/EventsRenderingHelper.h
@@ -9,6 +9,7 @@
 #include <wx/dc.h>
 #include <wx/html/htmprint.h>
 #include <vector>
+#include "GDCore/Events/InstructionsList.h"
 
 namespace gd { class BaseEvent; }
 namespace gd { class Instruction; }
@@ -54,14 +55,14 @@ public:
      * \param platform The platform currently used
      * \return Height used for the drawing
      */
-    int DrawConditionsList(std::vector < gd::Instruction > & conditions, wxDC & dc, int x, int y, int width, gd::BaseEvent * event,
+    int DrawConditionsList(gd::InstructionsList & conditions, wxDC & dc, int x, int y, int width, gd::BaseEvent * event,
                            gd::EventsEditorItemsAreas & areas, gd::EventsEditorSelection & selection, const gd::Platform & platform);
 
     /**
      * \brief Draw the specified action list
      * \see gd::EventsRenderingHelper::DrawConditionsList
      */
-    int DrawActionsList(std::vector < gd::Instruction > & actions, wxDC & dc, int x, int y, int width, gd::BaseEvent * event,
+    int DrawActionsList(gd::InstructionsList & actions, wxDC & dc, int x, int y, int width, gd::BaseEvent * event,
                         gd::EventsEditorItemsAreas & areas, gd::EventsEditorSelection & selection, const gd::Platform & platform);
 
     /**
@@ -71,12 +72,12 @@ public:
      * \param platform The platform currently used
      * \return Height used for the drawing
      */
-    unsigned int GetRenderedConditionsListHeight(const std::vector < gd::Instruction > & conditions, int width, const gd::Platform & platform);
+    unsigned int GetRenderedConditionsListHeight(const gd::InstructionsList & conditions, int width, const gd::Platform & platform);
     /**
      * \brief Get the height taken by drawing a condition list
      * \see gd::EventsRenderingHelper::GetRenderedConditionsListHeight
      */
-    unsigned int GetRenderedActionsListHeight(const std::vector < gd::Instruction > & actions, int width, const gd::Platform & platform);
+    unsigned int GetRenderedActionsListHeight(const gd::InstructionsList & actions, int width, const gd::Platform & platform);
 
     inline unsigned int GetConditionsColumnWidth() const {return conditionsColumnWidth;};
     inline void SetConditionsColumnWidth(unsigned int conditionsColumnWidth_) { conditionsColumnWidth = conditionsColumnWidth_; };

--- a/Core/GDCore/IDE/EventsVariablesFinder.cpp
+++ b/Core/GDCore/IDE/EventsVariablesFinder.cpp
@@ -120,7 +120,7 @@ std::set < std::string > EventsVariablesFinder::FindAllObjectVariables(const gd:
 }
 
 std::set < std::string > EventsVariablesFinder::FindArgumentsInInstructions(const gd::Platform & platform,
-    const gd::Project & project, const gd::Layout & layout, const vector < gd::Instruction > & instructions,
+    const gd::Project & project, const gd::Layout & layout, const gd::InstructionsList & instructions,
     bool instructionsAreConditions, const std::string & parameterType, const std::string & objectName)
 {
     std::set < std::string > results;
@@ -177,14 +177,14 @@ std::set < std::string > EventsVariablesFinder::FindArgumentsInEvents(const gd::
     std::set < std::string > results;
     for (unsigned int i = 0;i<events.size();++i)
     {
-        vector < const vector<gd::Instruction>* > conditionsVectors =  events[i].GetAllConditionsVectors();
+        vector < const gd::InstructionsList* > conditionsVectors =  events[i].GetAllConditionsVectors();
         for (unsigned int j = 0;j < conditionsVectors.size();++j)
         {
             std::set < std::string > results2 = FindArgumentsInInstructions(platform, project, layout, *conditionsVectors[j], /*conditions=*/true, parameterType, objectName);
             results.insert(results2.begin(), results2.end());
         }
 
-        vector < const vector<gd::Instruction>* > actionsVectors =  events[i].GetAllActionsVectors();
+        vector < const gd::InstructionsList* > actionsVectors =  events[i].GetAllActionsVectors();
         for (unsigned int j = 0;j < actionsVectors.size();++j)
         {
             std::set < std::string > results2 = FindArgumentsInInstructions(platform, project, layout, *actionsVectors[j], /*conditions=*/false, parameterType, objectName);

--- a/Core/GDCore/IDE/EventsVariablesFinder.h
+++ b/Core/GDCore/IDE/EventsVariablesFinder.h
@@ -70,7 +70,7 @@ private:
      */
     static std::set < std::string > FindArgumentsInInstructions(const gd::Platform & platform,
         const gd::Project & project, const gd::Layout & layout,
-        const std::vector < gd::Instruction > & instructions, bool instructionsAreConditions,
+        const gd::InstructionsList & instructions, bool instructionsAreConditions,
         const std::string & parameterType, const std::string & objectName = "");
 
     /**

--- a/Core/GDCore/Tools/SPtrList.h
+++ b/Core/GDCore/Tools/SPtrList.h
@@ -1,0 +1,143 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2015 Florian Rival (Florian.Rival@gmail.com) 
+ 				   and Victor Levasseur (victorlevasseur52@gmail.com).
+ * This project is released under the MIT License.
+ */
+
+#ifndef GDCORE_SPTRLIST
+#define GDCORE_SPTRLIST
+
+#include <memory>
+#include <vector>
+
+namespace gd
+{
+
+template<typename T>
+class SPtrList
+{
+public:
+    SPtrList();
+    SPtrList(const SPtrList<T>&);
+    virtual ~SPtrList() {};
+    SPtrList<T>& operator=(const SPtrList<T> & rhs);
+
+    /**
+     * \brief Insert the specified element to the list
+     * \note The element passed by parameter is copied.
+     * \param element The element that must be copied and inserted into the list
+     * \param position Insertion position. If the position is invalid, the object is inserted at the end of the objects list.
+     * \return A reference to the element in the list
+     */
+    T & Insert(const T & element, size_t position = (size_t)-1);
+
+    /**
+     * \brief Insert the specified element to the list.
+     * \note The element passed by parameter is not copied.
+     * \param element The smart pointer to the element that must be inserted into the list
+     * \param position Insertion position. If the position is invalid, the object is inserted at the end of the objects list.
+     */
+    void Insert(std::shared_ptr<T> element, size_t position = (size_t)-1);
+
+    /**
+     * \brief Copy elements from another list
+     */
+    void Insert(const SPtrList<T> & otherEvents, size_t begin, size_t end, size_t position = (size_t)-1);
+
+    /**
+     * \brief Return the number of elements.
+     */
+    size_t GetCount() const { return elements.size(); };
+
+    /**
+     * \brief Return the smart pointer to the element at position \a index in the elements list.
+     */
+    std::shared_ptr<T> GetSmartPtr(size_t index) { return elements[index]; };
+
+    /**
+     * \brief Return a reference to the element at position \a index in the elements list.
+     */
+    T & Get(size_t index) { return *elements[index]; };
+
+    /**
+     * \brief Return a reference to the element at position \a index in the elements list.
+     */
+    const T & Get(size_t index) const { return *elements[index]; };
+
+    /**
+     * \brief Remove the specified element.
+     */
+    void Remove(const T & element);
+
+    /**
+     * \brief Remove the element at the specified index in the list.
+     */
+    void Remove(size_t index);
+
+    /**
+     * \brief Return true if there isn't any element in the list
+     */
+    bool IsEmpty() const { return elements.empty(); };
+
+    /**
+     * \brief Clear the list of elements.
+     */
+    void Clear() { return elements.clear(); };
+
+    /** \name Utilities
+     * Utility methods
+     */
+    ///@{
+    /**
+     * Return true if the specified element exists in the list.
+     * \param element The element to searched for
+     */
+    bool Contains(const T & elementToSearch) const;
+    ///@}
+
+    /** \name std::vector API compatibility
+     * These functions ensure that the class can be used just like a std::vector.
+     */
+    ///@{
+
+    /**
+     * \brief Alias for GetCount()
+     * \see SPtrList::GetCount.
+     */
+    size_t size() const { return GetCount(); }
+
+    /**
+     * \brief Alias for IsEmpty()
+     * \see SPtrList::IsEmpty.
+     */
+    bool empty() const { return IsEmpty(); }
+
+    /**
+     * \brief Alias for Get()
+     * \see SPtrList::Get.
+     */
+    T & operator[](size_t index) { return Get(index); };
+
+    /**
+     * \brief Alias for Get()
+     * \see SPtrList::Get.
+     */
+    const T & operator[](size_t index) const { return Get(index); };
+    ///@}
+
+protected:
+    std::vector< std::shared_ptr< T > > elements;
+
+    /**
+     * Initialize from another list of elements, copying elements. Used by copy-ctor and assign-op.
+     * Don't forget to update me if members were changed !
+     */
+    void Init(const SPtrList<T> & other);
+};
+
+}
+
+#include "SPtrList.inl"
+
+#endif

--- a/Core/GDCore/Tools/SPtrList.inl
+++ b/Core/GDCore/Tools/SPtrList.inl
@@ -1,0 +1,106 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2015 Florian Rival (Florian.Rival@gmail.com) 
+ 				   and Victor Levasseur (victorlevasseur52@gmail.com).
+ * This project is released under the MIT License.
+ */
+
+namespace gd
+{
+
+template<typename T>
+SPtrList<T>::SPtrList()
+{
+}
+
+template<typename T>
+void SPtrList<T>::Insert(const SPtrList<T> & otherElements, size_t begin, size_t end, size_t position)
+{
+	if (begin >= otherElements.size()) return;
+	if (end < begin) return;
+	if (end >= otherElements.size()) end = otherElements.size()-1;
+
+    for (unsigned int insertPos = 0;insertPos <= (end-begin);insertPos++)
+    {
+	    if (position != (size_t)-1 && position+insertPos < elements.size())
+	        elements.insert(elements.begin()+position+insertPos, CloneRememberingOriginalElement(otherElements.elements[begin+insertPos]));
+	    else
+	        elements.push_back(CloneRememberingOriginalElement(otherElements.elements[begin+insertPos]));
+	}
+}
+
+template<typename T>
+T & SPtrList<T>::Insert(const T & evt, size_t position)
+{
+	std::shared_ptr<T> element = std::make_shared<T>(evt);
+    if (position<elements.size())
+        elements.insert(elements.begin()+position, element);
+    else
+        elements.push_back(element);
+
+    return *element;
+}
+
+template<typename T>
+void SPtrList<T>::Insert(std::shared_ptr<T> element, size_t position)
+{
+    if (position<elements.size())
+        elements.insert(elements.begin()+position, element);
+    else
+        elements.push_back(element);
+}
+
+template<typename T>
+void SPtrList<T>::Remove(size_t index)
+{
+	elements.erase(elements.begin()+index);
+}
+
+template<typename T>
+void SPtrList<T>::Remove(const T & element)
+{
+	for (size_t i = 0; i < elements.size(); ++i)
+	{
+		if (elements[i].get() == &element)
+		{
+			elements.erase(elements.begin()+i);
+			return;
+		}
+	}
+}
+
+template<typename T>
+bool SPtrList<T>::Contains(const T & elementToSearch) const
+{
+    for (unsigned int i = 0;i<GetCount();++i)
+    {
+        if ( &Get(i) == &elementToSearch) return true;
+    }
+
+    return false;
+}
+
+template<typename T>
+SPtrList<T>::SPtrList(const SPtrList<T> & other)
+{
+    Init(other);
+}
+
+template<typename T>
+SPtrList<T> & SPtrList<T>::operator=(const SPtrList<T> & other)
+{
+    if ( this != &other )
+        Init(other);
+
+    return *this;
+}
+
+template<typename T>
+void SPtrList<T>::Init(const gd::SPtrList<T> & other)
+{
+	elements.clear();
+	for(size_t i = 0;i<other.elements.size();++i)
+		elements.push_back( std::make_shared<T>(other[i]) );
+}
+
+}

--- a/Core/tests/Events.cpp
+++ b/Core/tests/Events.cpp
@@ -23,7 +23,7 @@ TEST_CASE( "Events", "[common][events]" ) {
     SECTION("StandardEvent") {
         gd::Instruction instr("InstructionType");
         gd::StandardEvent event;
-        event.GetActions().push_back(instr);
+        event.GetActions().Insert(instr);
 
         //Ensuring cloning is working
         std::shared_ptr<gd::StandardEvent> cloned(event.Clone());
@@ -34,7 +34,7 @@ TEST_CASE( "Events", "[common][events]" ) {
     SECTION("ForEachEvent") {
         gd::Instruction instr("InstructionType");
         gd::ForEachEvent event;
-        event.GetActions().push_back(instr);
+        event.GetActions().Insert(instr);
         event.SetObjectToPick("Object");
 
         //Ensuring cloning is working

--- a/Extensions/Function/FunctionEvent.cpp
+++ b/Extensions/Function/FunctionEvent.cpp
@@ -34,32 +34,32 @@ nameSelected(false)
 {
 }
 
-vector < vector<gd::Instruction>* > FunctionEvent::GetAllConditionsVectors()
+vector < gd::InstructionsList* > FunctionEvent::GetAllConditionsVectors()
 {
-    vector < vector<gd::Instruction>* > allConditions;
+    vector < gd::InstructionsList* > allConditions;
     allConditions.push_back(&conditions);
 
     return allConditions;
 }
 
-vector < vector<gd::Instruction>* > FunctionEvent::GetAllActionsVectors()
+vector < gd::InstructionsList* > FunctionEvent::GetAllActionsVectors()
 {
-    vector < vector<gd::Instruction>* > allActions;
+    vector < gd::InstructionsList* > allActions;
     allActions.push_back(&actions);
 
     return allActions;
 }
-vector < const vector<gd::Instruction>* > FunctionEvent::GetAllConditionsVectors() const
+vector < const gd::InstructionsList* > FunctionEvent::GetAllConditionsVectors() const
 {
-    vector < const vector<gd::Instruction>* > allConditions;
+    vector < const gd::InstructionsList* > allConditions;
     allConditions.push_back(&conditions);
 
     return allConditions;
 }
 
-vector < const vector<gd::Instruction>* > FunctionEvent::GetAllActionsVectors() const
+vector < const gd::InstructionsList* > FunctionEvent::GetAllActionsVectors() const
 {
-    vector < const vector<gd::Instruction>* > allActions;
+    vector < const gd::InstructionsList* > allActions;
     allActions.push_back(&actions);
 
     return allActions;

--- a/Extensions/Function/FunctionEvent.h
+++ b/Extensions/Function/FunctionEvent.h
@@ -39,11 +39,11 @@ public:
     virtual const gd::EventsList & GetSubEvents() const {return events;};
     virtual gd::EventsList & GetSubEvents() {return events;};
 
-    const std::vector < gd::Instruction > & GetConditions() const { return conditions; };
-    std::vector < gd::Instruction > & GetConditions() { return conditions; };
+    const gd::InstructionsList & GetConditions() const { return conditions; };
+    gd::InstructionsList & GetConditions() { return conditions; };
 
-    const std::vector < gd::Instruction > & GetActions() const { return actions; };
-    std::vector < gd::Instruction > & GetActions() { return actions; };
+    const gd::InstructionsList & GetActions() const { return actions; };
+    gd::InstructionsList & GetActions() { return actions; };
 
     std::string GetName() const { return name; };
     void SetName(std::string name_) { name = name_; };
@@ -51,10 +51,10 @@ public:
     const std::string & GetObjectsPassedAsArgument() const { return objectsPassedAsArgument; };
     void SetObjectsPassedAsArgument(const std::string & objects) { objectsPassedAsArgument = objects; };
 
-    virtual std::vector < std::vector<gd::Instruction>* > GetAllConditionsVectors();
-    virtual std::vector < std::vector<gd::Instruction>* > GetAllActionsVectors();
-    virtual std::vector < const std::vector<gd::Instruction>* > GetAllConditionsVectors() const;
-    virtual std::vector < const std::vector<gd::Instruction>* > GetAllActionsVectors() const;
+    virtual std::vector < gd::InstructionsList* > GetAllConditionsVectors();
+    virtual std::vector < gd::InstructionsList* > GetAllActionsVectors();
+    virtual std::vector < const gd::InstructionsList* > GetAllConditionsVectors() const;
+    virtual std::vector < const gd::InstructionsList* > GetAllActionsVectors() const;
 
     virtual void SerializeTo(gd::SerializerElement & element) const;
     virtual void UnserializeFrom(gd::Project & project, const gd::SerializerElement & element);
@@ -89,8 +89,8 @@ public:
 private:
     std::string name;
     std::string objectsPassedAsArgument;
-    std::vector < gd::Instruction > conditions;
-    std::vector < gd::Instruction > actions;
+    gd::InstructionsList conditions;
+    gd::InstructionsList actions;
     gd::EventsList events;
 
     bool nameSelected;

--- a/Extensions/TimedEvent/TimedEvent.cpp
+++ b/Extensions/TimedEvent/TimedEvent.cpp
@@ -34,17 +34,17 @@ TimedEvent::~TimedEvent()
 {
 }
 
-vector < vector<gd::Instruction>* > TimedEvent::GetAllConditionsVectors()
+vector < gd::InstructionsList* > TimedEvent::GetAllConditionsVectors()
 {
-    vector < vector<gd::Instruction>* > allConditions;
+    vector < gd::InstructionsList* > allConditions;
     allConditions.push_back(&conditions);
 
     return allConditions;
 }
 
-vector < vector<gd::Instruction>* > TimedEvent::GetAllActionsVectors()
+vector < gd::InstructionsList* > TimedEvent::GetAllActionsVectors()
 {
-    vector < vector<gd::Instruction>* > allActions;
+    vector < gd::InstructionsList* > allActions;
     allActions.push_back(&actions);
 
     return allActions;
@@ -58,17 +58,17 @@ vector < gd::Expression* > TimedEvent::GetAllExpressions()
     return allExpressions;
 }
 
-vector < const vector<gd::Instruction>* > TimedEvent::GetAllConditionsVectors() const
+vector < const gd::InstructionsList* > TimedEvent::GetAllConditionsVectors() const
 {
-    vector < const vector<gd::Instruction>* > allConditions;
+    vector < const gd::InstructionsList* > allConditions;
     allConditions.push_back(&conditions);
 
     return allConditions;
 }
 
-vector < const vector<gd::Instruction>* > TimedEvent::GetAllActionsVectors() const
+vector < const gd::InstructionsList* > TimedEvent::GetAllActionsVectors() const
 {
-    vector < const vector<gd::Instruction>* > allActions;
+    vector < const gd::InstructionsList* > allActions;
     allActions.push_back(&actions);
 
     return allActions;

--- a/Extensions/TimedEvent/TimedEvent.h
+++ b/Extensions/TimedEvent/TimedEvent.h
@@ -11,6 +11,7 @@ This project is released under the MIT License.
 #define TIMEDEVENT_H
 #include "GDCore/Events/Event.h"
 #include "GDCore/Events/EventsList.h"
+#include "GDCore/Events/Instruction.h"
 #include <map>
 #include "GDCpp/ManualTimer.h"
 class RuntimeScene;
@@ -39,11 +40,11 @@ public:
     virtual const gd::EventsList & GetSubEvents() const {return events;};
     virtual gd::EventsList & GetSubEvents() {return events;};
 
-    const std::vector < gd::Instruction > & GetConditions() const { return conditions; };
-    std::vector < gd::Instruction > & GetConditions() { return conditions; };
+    const gd::InstructionsList & GetConditions() const { return conditions; };
+    gd::InstructionsList & GetConditions() { return conditions; };
 
-    const std::vector < gd::Instruction > & GetActions() const { return actions; };
-    std::vector < gd::Instruction > & GetActions() { return actions; };
+    const gd::InstructionsList & GetActions() const { return actions; };
+    gd::InstructionsList & GetActions() { return actions; };
 
     std::string GetName() const { return name; };
     void SetName(std::string name_) { name = name_; };
@@ -51,11 +52,11 @@ public:
     std::string GetTimeoutExpression() const { return timeout.GetPlainString(); };
     void SetTimeoutExpression(std::string timeout_) { timeout = gd::Expression(timeout_); };
 
-    virtual std::vector < std::vector<gd::Instruction>* > GetAllConditionsVectors();
-    virtual std::vector < std::vector<gd::Instruction>* > GetAllActionsVectors();
+    virtual std::vector < gd::InstructionsList* > GetAllConditionsVectors();
+    virtual std::vector < gd::InstructionsList* > GetAllActionsVectors();
     virtual std::vector < gd::Expression* > GetAllExpressions();
-    virtual std::vector < const std::vector<gd::Instruction>* > GetAllConditionsVectors() const;
-    virtual std::vector < const std::vector<gd::Instruction>* > GetAllActionsVectors() const;
+    virtual std::vector < const gd::InstructionsList* > GetAllConditionsVectors() const;
+    virtual std::vector < const gd::InstructionsList* > GetAllActionsVectors() const;
     virtual std::vector < const gd::Expression* > GetAllExpressions() const;
 
     virtual void SerializeTo(gd::SerializerElement & element) const;
@@ -81,8 +82,8 @@ public:
 private:
     std::string name;
     gd::Expression timeout;
-    std::vector < gd::Instruction > conditions;
-    std::vector < gd::Instruction > actions;
+    gd::InstructionsList conditions;
+    gd::InstructionsList actions;
     gd::EventsList events;
 
     bool nameSelected;

--- a/GDCpp/GDCpp/BuiltinExtensions/CommonInstructionsExtension.cpp
+++ b/GDCpp/GDCpp/BuiltinExtensions/CommonInstructionsExtension.cpp
@@ -50,7 +50,7 @@ CommonInstructionsExtension::CommonInstructionsExtension()
             {
                 //Conditions code
                 std::string conditionsCode;
-                std::vector<gd::Instruction> & conditions = instruction.GetSubInstructions();
+                gd::InstructionsList & conditions = instruction.GetSubInstructions();
 
                 //"OR" condition must declare objects list, but without picking the objects from the scene. Lists are either empty or come from a parent event.
                 set<string> emptyListsNeeded;
@@ -150,7 +150,7 @@ CommonInstructionsExtension::CommonInstructionsExtension()
         {
             virtual std::string GenerateCode(gd::Instruction & instruction, gd::EventsCodeGenerator & codeGenerator, gd::EventsCodeGenerationContext & parentContext)
             {
-                std::vector<gd::Instruction> & conditions = instruction.GetSubInstructions();
+                gd::InstructionsList & conditions = instruction.GetSubInstructions();
                 string outputCode;
 
                 for (unsigned int i = 0;i<conditions.size();++i)

--- a/GDJS/GDJS/BuiltinExtensions/CommonInstructionsExtension.cpp
+++ b/GDJS/GDJS/BuiltinExtensions/CommonInstructionsExtension.cpp
@@ -111,7 +111,7 @@ CommonInstructionsExtension::CommonInstructionsExtension()
 
                 //Conditions code
                 std::string conditionsCode;
-                std::vector<gd::Instruction> & conditions = instruction.GetSubInstructions();
+                gd::InstructionsList & conditions = instruction.GetSubInstructions();
 
                 //"OR" condition must declare objects list, but without picking the objects from the scene.
                 //Lists are either empty or come from a parent event.
@@ -221,7 +221,7 @@ CommonInstructionsExtension::CommonInstructionsExtension()
         {
             virtual std::string GenerateCode(gd::Instruction & instruction, gd::EventsCodeGenerator & codeGenerator, gd::EventsCodeGenerationContext & context)
             {
-                std::vector<gd::Instruction> & conditions = instruction.GetSubInstructions();
+                gd::InstructionsList & conditions = instruction.GetSubInstructions();
                 string outputCode;
 
                 for (unsigned int i = 0;i<conditions.size();++i)

--- a/IDE/EventsEditor.cpp
+++ b/IDE/EventsEditor.cpp
@@ -748,7 +748,7 @@ void EventsEditor::OneventsPanelLeftUp(wxMouseEvent& event)
 
     if (selection.EndDragEvent(!ctrlKeyDown, selection.IsEventHighlightedOnBottomPart()))
         ChangesMadeOnEvents();
-    else if (std::vector<gd::Instruction> * list = selection.EndDragInstruction(!ctrlKeyDown, selection.IsInstructionHighlightedOnBottomPart()))
+    else if (gd::InstructionsList * list = selection.EndDragInstruction(!ctrlKeyDown, selection.IsInstructionHighlightedOnBottomPart()))
     {
         EnsureTriggerOnceIsLastCondition(*list);
         ChangesMadeOnEvents();
@@ -887,7 +887,7 @@ void EventsEditor::OneventsPanelLeftDClick(wxMouseEvent& event)
             instruction.SetParameters( dialog.Param );
             instruction.SetInverted( dialog.isInverted );
 
-            item.instructionList->push_back(instruction);
+            item.instructionList->Insert(instruction);
             item.event->eventHeightNeedUpdate = true;
             Refresh();
             ChangesMadeOnEvents();
@@ -1197,10 +1197,10 @@ void EventsEditor::OnliveEditText(wxCommandEvent& event)
     liveEditingChangesMade = true;
 }
 
-void EventsEditor::EnsureTriggerOnceIsLastCondition(std::vector<gd::Instruction> & conditions) {
+void EventsEditor::EnsureTriggerOnceIsLastCondition(gd::InstructionsList & conditions) {
 	if (conditions.empty()) return;
 
-	bool endWithTriggerOnce = conditions.back().GetType() == "BuiltinCommonInstructions::Once";
+	bool endWithTriggerOnce = conditions.Get(conditions.GetCount()-1).GetType() == "BuiltinCommonInstructions::Once";
 	bool multipleOnce = false;
 	for (unsigned int i = 0;i<conditions.size()-1;)
 	{
@@ -1208,13 +1208,13 @@ void EventsEditor::EnsureTriggerOnceIsLastCondition(std::vector<gd::Instruction>
 		{
 			if (!endWithTriggerOnce)
 			{
-				conditions.push_back(conditions[i]); //"Move" the "Trigger once" condition at the end
+				conditions.Insert(conditions[i]); //"Move" the "Trigger once" condition at the end
 				endWithTriggerOnce = true;
 			}
 			else
 				multipleOnce = true;
 
-			conditions.erase(conditions.begin()+i); //In any case, remove the trigger once as it is not at the end.
+			conditions.Remove(i); //In any case, remove the trigger once as it is not at the end.
 		}
 		else
 			++i;
@@ -1237,7 +1237,7 @@ void EventsEditor::OnaddInstrBtClick(wxCommandEvent& event)
         instruction.SetParameters(dialog.Param);
         instruction.SetInverted(dialog.isInverted);
 
-        listHighlighted.instructionList->push_back(instruction);
+        listHighlighted.instructionList->Insert(instruction);
         listHighlighted.event->eventHeightNeedUpdate = true;
         EnsureTriggerOnceIsLastCondition(*listHighlighted.instructionList);
         Refresh();
@@ -1447,11 +1447,11 @@ void EventsEditor::OneventCopyMenuSelected(wxCommandEvent& event)
     if ( selection.HasSelectedConditions())
     {
         std::vector < gd::InstructionItem > itemsSelected = selection.GetAllSelectedInstructions();
-        std::vector < gd::Instruction > instructionsToCopy;
+        gd::InstructionsList instructionsToCopy;
         for (unsigned int i = 0;i<itemsSelected.size();++i)
         {
             if (itemsSelected[i].instruction != NULL)
-                instructionsToCopy.push_back(*itemsSelected[i].instruction);
+                instructionsToCopy.Insert(*itemsSelected[i].instruction);
         }
 
         gd::Clipboard::Get()->SetConditions(instructionsToCopy);
@@ -1459,11 +1459,11 @@ void EventsEditor::OneventCopyMenuSelected(wxCommandEvent& event)
     else if ( selection.HasSelectedActions())
     {
         std::vector < gd::InstructionItem > itemsSelected = selection.GetAllSelectedInstructions();
-        std::vector < gd::Instruction > instructionsToCopy;
+        gd::InstructionsList instructionsToCopy;
         for (unsigned int i = 0;i<itemsSelected.size();++i)
         {
             if (itemsSelected[i].instruction != NULL)
-                instructionsToCopy.push_back(*itemsSelected[i].instruction);
+                instructionsToCopy.Insert(*itemsSelected[i].instruction);
         }
 
         gd::Clipboard::Get()->SetActions(instructionsToCopy);
@@ -1503,19 +1503,19 @@ void EventsEditor::OneventPasteMenuSelected(wxCommandEvent& event)
         if ( !gd::Clipboard::Get()->HasCondition() ) return;
 
         //Get information about list where conditions must be pasted
-        std::vector<gd::Instruction> * instructionList = selection.HasSelectedConditions() ? selection.GetAllSelectedInstructions().back().instructionList : selection.GetHighlightedInstructionList().instructionList;
+        gd::InstructionsList * instructionList = selection.HasSelectedConditions() ? selection.GetAllSelectedInstructions().back().instructionList : selection.GetHighlightedInstructionList().instructionList;
         size_t positionInThisList = selection.HasSelectedConditions() ? selection.GetAllSelectedInstructions().back().positionInList : std::string::npos;
         gd::BaseEvent * event = selection.HasSelectedConditions() ? selection.GetAllSelectedInstructions().back().event : selection.GetHighlightedInstructionList().event;
         if (instructionList == NULL) return;
 
         //Paste all conditions
-        const vector < gd::Instruction > & instructions = gd::Clipboard::Get()->GetInstructions();
+        const gd::InstructionsList & instructions = gd::Clipboard::Get()->GetInstructions();
         for (unsigned int i = 0;i<instructions.size();++i)
         {
             if ( positionInThisList < instructionList->size() )
-                instructionList->insert(instructionList->begin()+positionInThisList, instructions[i]);
+                instructionList->Insert(instructions[i], positionInThisList);
             else
-                instructionList->push_back(instructions[i]);
+                instructionList->Insert(instructions[i]);
         }
         EnsureTriggerOnceIsLastCondition(*instructionList);
 
@@ -1528,19 +1528,19 @@ void EventsEditor::OneventPasteMenuSelected(wxCommandEvent& event)
         if ( !gd::Clipboard::Get()->HasAction() ) return;
 
         //Get information about list where actions must be pasted
-        std::vector<gd::Instruction> * instructionList = selection.HasSelectedActions() ? selection.GetAllSelectedInstructions().back().instructionList : selection.GetHighlightedInstructionList().instructionList;
+        gd::InstructionsList * instructionList = selection.HasSelectedActions() ? selection.GetAllSelectedInstructions().back().instructionList : selection.GetHighlightedInstructionList().instructionList;
         size_t positionInThisList = selection.HasSelectedActions() ? selection.GetAllSelectedInstructions().back().positionInList : std::string::npos;
         gd::BaseEvent * event = selection.HasSelectedActions() ? selection.GetAllSelectedInstructions().back().event : selection.GetHighlightedInstructionList().event;
         if (instructionList == NULL) return;
 
         //Paste all actions
-        const vector < gd::Instruction > & instructions = gd::Clipboard::Get()->GetInstructions();
+        const gd::InstructionsList & instructions = gd::Clipboard::Get()->GetInstructions();
         for (unsigned int i = 0;i<instructions.size();++i)
         {
             if ( positionInThisList < instructionList->size() )
-                instructionList->insert(instructionList->begin()+positionInThisList, instructions[i]);
+                instructionList->Insert(instructions[i], positionInThisList);
             else
-                instructionList->push_back(instructions[i]);
+                instructionList->Insert(instructions[i]);
         }
 
         if ( event != NULL ) event->eventHeightNeedUpdate = true;

--- a/IDE/EventsEditor.h
+++ b/IDE/EventsEditor.h
@@ -280,7 +280,7 @@ private:
     void AddSubEvent(gd::EventItem & parentEventItem);
     void AddCustomEventFromMenu(unsigned int menuID, gd::EventItem & previousEventItem);
 
-    void EnsureTriggerOnceIsLastCondition(std::vector<gd::Instruction> & conditions);
+    void EnsureTriggerOnceIsLastCondition(gd::InstructionsList & conditions);
     void RecomputeAllEventsWidth(gd::EventsList & eventsToRefresh);
     void DeleteSelection();
 


### PR DESCRIPTION
* Adds a gd::SPtrList template (gd::InstructionsList is just a typedef of SPtrList<gd::Instruction>).
* Replace all vectors of gd::Instruction with gd::InstructionsList.
* Fix the bug when moving a condition into an OR condition.