### PR TITLE
Fix HTML5 games not working with the new instructions container

### DIFF
--- a/GDJS/GDJS/EventsCodeGenerator.cpp
+++ b/GDJS/GDJS/EventsCodeGenerator.cpp
@@ -442,7 +442,7 @@ std::string EventsCodeGenerator::GenerateObjectsDeclarationCode(gd::EventsCodeGe
     return declarationsCode ;
 }
 
-string EventsCodeGenerator::GenerateConditionsListCode(vector < gd::Instruction > & conditions, gd::EventsCodeGenerationContext & context)
+string EventsCodeGenerator::GenerateConditionsListCode(gd::InstructionsList & conditions, gd::EventsCodeGenerationContext & context)
 {
     string outputCode;
 

--- a/GDJS/GDJS/EventsCodeGenerator.h
+++ b/GDJS/GDJS/EventsCodeGenerator.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <set>
 #include "GDCore/Events/Event.h"
+#include "GDCore/Events/InstructionsList.h"
 #include "GDCore/Events/EventsCodeGenerator.h"
 namespace gd { class ObjectMetadata; }
 namespace gd { class AutomatismMetadata; }
@@ -52,7 +53,7 @@ public:
      * \param context Context used for generation
      * \return JS code.
      */
-    virtual std::string GenerateConditionsListCode(std::vector < gd::Instruction > & conditions, gd::EventsCodeGenerationContext & context);
+    virtual std::string GenerateConditionsListCode(gd::InstructionsList & conditions, gd::EventsCodeGenerationContext & context);
 
     /**
      * \brief Generate the full name for accessing to a boolean variable used for conditions.


### PR DESCRIPTION
Fix the bug preventing HTML5 to compile with the new gd::InstructionsList.

Warning : I don't think this will merge correctly. **You have to revert again your revert.**