### PR TITLE
The tile size cannot be bigger than the tileset texture size anymore

### DIFF
--- a/Extensions/TileMapObject/TileSetConfigurationEditor.cpp
+++ b/Extensions/TileMapObject/TileSetConfigurationEditor.cpp
@@ -69,6 +69,9 @@ void TileSetConfigurationEditor::UpdatePreviewTileSetPanel()
     previewTileSet.LoadResources(game);
     previewTileSet.Generate();
 
+    m_tileWidthSpin->SetRange(1, previewTileSet.GetSize().x);
+    m_tileHeightSpin->SetRange(1, previewTileSet.GetSize().y);
+
     m_tileSetPreviewPanel->Refresh();
 }
 


### PR DESCRIPTION
Fix #129 
It set the maximum of the spin controls to the texture width and height.