### PR TITLE
Fix some widgets not sized correctly under GTK3/Gnome 3

### DIFF
--- a/Core/GDCore.cbp
+++ b/Core/GDCore.cbp
@@ -487,15 +487,6 @@
 			<code_completion />
 			<envvars />
 			<debugger />
-			<DoxyBlocks>
-				<comment_style block="0" line="0" />
-				<doxyfile_project output_directory="doc" />
-				<doxyfile_build />
-				<doxyfile_warnings />
-				<doxyfile_output />
-				<doxyfile_dot have_dot="1" />
-				<general />
-			</DoxyBlocks>
 			<wxsmith version="1">
 				<resources>
 					<wxDialog wxs="wxsmith/ChooseVariableDialog.wxs" src="GDCore\IDE\Dialogs\ChooseVariableDialog.cpp" hdr="GDCore\IDE\Dialogs\ChooseVariableDialog.h" fwddecl="0" i18n="1" name="ChooseVariableDialog" language="CPP" />
@@ -523,12 +514,6 @@
 					<wxPanel wxs="wxsmith/ResourcesEditor.wxs" src="GDCore\IDE\Dialogs\ResourcesEditor.cpp" hdr="GDCore\IDE\Dialogs\ResourcesEditor.h" fwddecl="0" i18n="1" name="ResourcesEditor" language="CPP" />
 				</resources>
 			</wxsmith>
-			<AutoVersioning>
-				<Scheme minor_max="10" build_max="0" rev_max="0" rev_rand_max="10" build_times_to_increment_minor="100" />
-				<Settings autoincrement="0" date_declarations="1" update_manifest="0" do_auto_increment="1" ask_to_increment="0" language="C++" svn="0" svn_directory="" header_path="GDCore\Tools\Version.h" />
-				<Changes_Log show_changes_editor="0" app_title="released version %M.%m.%b of %p" changeslog_path="ChangesLog.txt" />
-				<Code header_guard="VERSION_H" namespace="AutoVersion" prefix="GDCore" />
-			</AutoVersioning>
 		</Extensions>
 	</Project>
 </CodeBlocks_project_file>

--- a/Core/GDCore/IDE/Dialogs/EditLayerDialog.cpp
+++ b/Core/GDCore/IDE/Dialogs/EditLayerDialog.cpp
@@ -78,7 +78,7 @@ tempLayer(layer_)
 	FlexGridSizer2 = new wxFlexGridSizer(0, 3, 0, 0);
 	StaticText1 = new wxStaticText(this, ID_STATICTEXT1, _("Name :"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT1"));
 	FlexGridSizer2->Add(StaticText1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	nameEdit = new wxTextCtrl(this, ID_TEXTCTRL1, wxEmptyString, wxDefaultPosition, wxSize(129,21), 0, wxDefaultValidator, _T("ID_TEXTCTRL1"));
+	nameEdit = new wxTextCtrl(this, ID_TEXTCTRL1, wxEmptyString, wxDefaultPosition, wxSize(129,-1), 0, wxDefaultValidator, _T("ID_TEXTCTRL1"));
 	FlexGridSizer2->Add(nameEdit, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	visibilityCheck = new wxCheckBox(this, ID_CHECKBOX1, _("Visible"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX1"));
 	visibilityCheck->SetValue(false);
@@ -89,7 +89,9 @@ tempLayer(layer_)
 	FlexGridSizer5 = new wxFlexGridSizer(0, 4, 0, 0);
 	StaticText2 = new wxStaticText(this, ID_STATICTEXT2, _("Camera No."), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT2"));
 	FlexGridSizer5->Add(StaticText2, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	cameraChoice = new wxChoice(this, ID_CHOICE1, wxDefaultPosition, wxSize(37,21), 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE1"));
+	cameraChoice = new wxChoice(this, ID_CHOICE1, wxDefaultPosition, wxSize(50,-1), 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE1"));
+	cameraChoice->Append("00");
+	cameraChoice->SetSelection(0);
 	FlexGridSizer5->Add(cameraChoice, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	deleteCameraBt = new wxButton(this, ID_BUTTON5, _("Delete"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON5"));
 	FlexGridSizer5->Add(deleteCameraBt, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
@@ -103,12 +105,12 @@ tempLayer(layer_)
 	sizeCheck = new wxCheckBox(this, ID_CHECKBOX2, _("Custom size :"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX2"));
 	sizeCheck->SetValue(false);
 	FlexGridSizer8->Add(sizeCheck, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	cameraWidthEdit = new wxTextCtrl(this, ID_TEXTCTRL2, wxEmptyString, wxDefaultPosition, wxSize(52,21), 0, wxDefaultValidator, _T("ID_TEXTCTRL2"));
+	cameraWidthEdit = new wxTextCtrl(this, ID_TEXTCTRL2, wxEmptyString, wxDefaultPosition, wxSize(60,-1), 0, wxDefaultValidator, _T("ID_TEXTCTRL2"));
 	cameraWidthEdit->Disable();
 	FlexGridSizer8->Add(cameraWidthEdit, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	StaticText4 = new wxStaticText(this, ID_STATICTEXT4, _("x"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT4"));
 	FlexGridSizer8->Add(StaticText4, 1, wxTOP|wxBOTTOM|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	cameraHeightEdit = new wxTextCtrl(this, ID_TEXTCTRL3, wxEmptyString, wxDefaultPosition, wxSize(52,21), 0, wxDefaultValidator, _T("ID_TEXTCTRL3"));
+	cameraHeightEdit = new wxTextCtrl(this, ID_TEXTCTRL3, wxEmptyString, wxDefaultPosition, wxSize(60,-1), 0, wxDefaultValidator, _T("ID_TEXTCTRL3"));
 	cameraHeightEdit->Disable();
 	FlexGridSizer8->Add(cameraHeightEdit, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer6->Add(FlexGridSizer8, 1, wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
@@ -119,22 +121,22 @@ tempLayer(layer_)
 	FlexGridSizer9 = new wxFlexGridSizer(0, 8, 0, 0);
 	StaticText7 = new wxStaticText(this, ID_STATICTEXT7, _("From"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT7"));
 	FlexGridSizer9->Add(StaticText7, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	viewportX1Edit = new wxTextCtrl(this, ID_TEXTCTRL4, _("0"), wxDefaultPosition, wxSize(35,21), 0, wxDefaultValidator, _T("ID_TEXTCTRL4"));
+	viewportX1Edit = new wxTextCtrl(this, ID_TEXTCTRL4, _("0"), wxDefaultPosition, wxSize(40,-1), 0, wxDefaultValidator, _T("ID_TEXTCTRL4"));
 	viewportX1Edit->Disable();
 	FlexGridSizer9->Add(viewportX1Edit, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	StaticText6 = new wxStaticText(this, ID_STATICTEXT6, _(";"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT6"));
 	FlexGridSizer9->Add(StaticText6, 1, wxTOP|wxBOTTOM|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	viewportY1Edit = new wxTextCtrl(this, ID_TEXTCTRL5, _("0"), wxDefaultPosition, wxSize(35,21), 0, wxDefaultValidator, _T("ID_TEXTCTRL5"));
+	viewportY1Edit = new wxTextCtrl(this, ID_TEXTCTRL5, _("0"), wxDefaultPosition, wxSize(40,-1), 0, wxDefaultValidator, _T("ID_TEXTCTRL5"));
 	viewportY1Edit->Disable();
 	FlexGridSizer9->Add(viewportY1Edit, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	StaticText8 = new wxStaticText(this, ID_STATICTEXT8, _("to"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT8"));
 	FlexGridSizer9->Add(StaticText8, 1, wxTOP|wxBOTTOM|wxRIGHT|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	viewportX2Edit = new wxTextCtrl(this, ID_TEXTCTRL6, _("1"), wxDefaultPosition, wxSize(35,21), 0, wxDefaultValidator, _T("ID_TEXTCTRL6"));
+	viewportX2Edit = new wxTextCtrl(this, ID_TEXTCTRL6, _("1"), wxDefaultPosition, wxSize(40,-1), 0, wxDefaultValidator, _T("ID_TEXTCTRL6"));
 	viewportX2Edit->Disable();
 	FlexGridSizer9->Add(viewportX2Edit, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	StaticText9 = new wxStaticText(this, ID_STATICTEXT9, _(";"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT9"));
 	FlexGridSizer9->Add(StaticText9, 1, wxTOP|wxBOTTOM|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	viewportY2Edit = new wxTextCtrl(this, ID_TEXTCTRL7, _("1"), wxDefaultPosition, wxSize(35,21), 0, wxDefaultValidator, _T("ID_TEXTCTRL7"));
+	viewportY2Edit = new wxTextCtrl(this, ID_TEXTCTRL7, _("1"), wxDefaultPosition, wxSize(40,-1), 0, wxDefaultValidator, _T("ID_TEXTCTRL7"));
 	viewportY2Edit->Disable();
 	FlexGridSizer9->Add(viewportY2Edit, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer7->Add(FlexGridSizer9, 1, wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
@@ -187,11 +189,14 @@ tempLayer(layer_)
 	nameEdit->ChangeValue(layer.GetName());
 	visibilityCheck->SetValue(layer.GetVisibility());
 
-	//Impossible de modifier le nom du calque de base
+	//Can't edit the base layer's name
 	if ( layer.GetName() == "" )
-        nameEdit->SetEditable(false);
+	{
+        nameEdit->Disable();
+        nameEdit->SetValue(_("Base layer"));
+	}
 
-
+    cameraChoice->Clear();
     for (unsigned int i = 0;i<layer.GetCameraCount();++i)
     	cameraChoice->Append(ToString(i));
 
@@ -214,13 +219,15 @@ void EditLayerDialog::OncancelBtClick(wxCommandEvent& event)
 void EditLayerDialog::OnokBtClick(wxCommandEvent& event)
 {
     //Obligation d'avoir un nom sauf pour le calque de base
-    if ( nameEdit->GetValue() == "" && nameEdit->IsEditable() )
+    if ( nameEdit->GetValue() == "" && nameEdit->IsEnabled() )
     {
         gd::LogWarning(_("The name is incorrect"));
         return;
     }
 
-    tempLayer.SetName(ToString(nameEdit->GetValue()));
+    if( layer.GetName() != "")
+    	tempLayer.SetName(ToString(nameEdit->GetValue()));
+    
     tempLayer.SetVisibility(visibilityCheck->GetValue());
 
     layer = tempLayer;

--- a/Core/GDCore/IDE/Dialogs/ParameterControlsHelper.cpp
+++ b/Core/GDCore/IDE/Dialogs/ParameterControlsHelper.cpp
@@ -48,6 +48,7 @@ void ParameterControlsHelper::UpdateControls(unsigned int count)
         paramSpacers2.push_back(new wxPanel(window));
         paramEdits.push_back(new wxTextCtrl( window, ID_EDITARRAY, "", wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T( "EditPara" + num )));
         paramBmpBts.push_back(new wxBitmapButton( window, id, gd::CommonBitmapManager::Get()->expressionBt, wxDefaultPosition, wxSize(32,-1), wxBU_AUTODRAW, wxDefaultValidator, num));
+        paramBmpBts.back()->SetMinSize(wxSize(32, 32));
 
         //Connecting events
         window->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &ParameterControlsHelper::OnParameterBtClick, this, id);
@@ -59,7 +60,7 @@ void ParameterControlsHelper::UpdateControls(unsigned int count)
         sizer->Add( paramSpacers1.back(), 0, 0 );
         sizer->Add( paramSpacers2.back(), 0, 0 );
         sizer->Add( paramEdits.back(), 1, wxALL | wxALIGN_LEFT | wxEXPAND | wxALIGN_CENTER_VERTICAL, 5 );
-        sizer->Add( paramBmpBts.back(), 0, wxALL | wxALIGN_LEFT | wxEXPAND | wxALIGN_CENTER_VERTICAL, 5 );
+        sizer->Add( paramBmpBts.back(), 0, wxALL | wxALIGN_LEFT | wxFIXED_MINSIZE | wxALIGN_CENTER_VERTICAL, 5 );
 
         paramSpacers1.back()->Show(false);
         paramSpacers2.back()->Show(false);

--- a/Core/wxsmith/EditLayerDialog.wxs
+++ b/Core/wxsmith/EditLayerDialog.wxs
@@ -18,7 +18,7 @@
 					</object>
 					<object class="sizeritem">
 						<object class="wxTextCtrl" name="ID_TEXTCTRL1" variable="nameEdit" member="yes">
-							<size>129,21</size>
+							<size>189,-1</size>
 						</object>
 						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 						<border>5</border>
@@ -55,9 +55,10 @@
 									</object>
 									<object class="sizeritem">
 										<object class="wxChoice" name="ID_CHOICE1" variable="cameraChoice" member="yes">
+											<content>
+												<item>00</item>
+											</content>
 											<selection>0</selection>
-											<size>37,21</size>
-											<handler function="OncameraChoiceSelect" entry="EVT_CHOICE" />
 										</object>
 										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 										<border>5</border>
@@ -98,7 +99,6 @@
 													<object class="sizeritem">
 														<object class="wxCheckBox" name="ID_CHECKBOX2" variable="sizeCheck" member="yes">
 															<label>Custom size :</label>
-															<handler function="OnsizeCheckClick" entry="EVT_CHECKBOX" />
 														</object>
 														<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 														<border>5</border>
@@ -106,9 +106,8 @@
 													</object>
 													<object class="sizeritem">
 														<object class="wxTextCtrl" name="ID_TEXTCTRL2" variable="cameraWidthEdit" member="yes">
-															<size>52,21</size>
+															<size>60,-1</size>
 															<enabled>0</enabled>
-															<handler function="OncameraWidthEditText" entry="EVT_TEXT" />
 														</object>
 														<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 														<border>5</border>
@@ -124,9 +123,8 @@
 													</object>
 													<object class="sizeritem">
 														<object class="wxTextCtrl" name="ID_TEXTCTRL3" variable="cameraHeightEdit" member="yes">
-															<size>52,21</size>
+															<size>60,-1</size>
 															<enabled>0</enabled>
-															<handler function="OncameraHeightEditText" entry="EVT_TEXT" />
 														</object>
 														<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 														<border>5</border>
@@ -162,9 +160,8 @@
 															<object class="sizeritem">
 																<object class="wxTextCtrl" name="ID_TEXTCTRL4" variable="viewportX1Edit" member="yes">
 																	<value>0</value>
-																	<size>35,21</size>
+																	<size>40,-1</size>
 																	<enabled>0</enabled>
-																	<handler function="OnviewportX1EditText" entry="EVT_TEXT" />
 																</object>
 																<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 																<border>5</border>
@@ -181,9 +178,8 @@
 															<object class="sizeritem">
 																<object class="wxTextCtrl" name="ID_TEXTCTRL5" variable="viewportY1Edit" member="yes">
 																	<value>0</value>
-																	<size>35,21</size>
+																	<size>40,-1</size>
 																	<enabled>0</enabled>
-																	<handler function="OnviewportX1EditText" entry="EVT_TEXT" />
 																</object>
 																<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 																<border>5</border>
@@ -200,9 +196,8 @@
 															<object class="sizeritem">
 																<object class="wxTextCtrl" name="ID_TEXTCTRL6" variable="viewportX2Edit" member="yes">
 																	<value>1</value>
-																	<size>35,21</size>
+																	<size>40,-1</size>
 																	<enabled>0</enabled>
-																	<handler function="OnviewportX1EditText" entry="EVT_TEXT" />
 																</object>
 																<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 																<border>5</border>
@@ -219,9 +214,8 @@
 															<object class="sizeritem">
 																<object class="wxTextCtrl" name="ID_TEXTCTRL7" variable="viewportY2Edit" member="yes">
 																	<value>1</value>
-																	<size>35,21</size>
+																	<size>40,-1</size>
 																	<enabled>0</enabled>
-																	<handler function="OnviewportX1EditText" entry="EVT_TEXT" />
 																</object>
 																<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 																<border>5</border>
@@ -240,6 +234,7 @@
 													<label>For example, a camera which takes the left side of the window would be defined with 0, 0, 0.5, 1.&#x0A;By default, a camera has a viewport which covers the entire window.</label>
 													<font>
 														<style>italic</style>
+														<sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
 													</font>
 													<style>wxALIGN_RIGHT</style>
 												</object>

--- a/IDE/IDE.cbp
+++ b/IDE/IDE.cbp
@@ -773,21 +773,6 @@
 					<wxPanel wxs="wxsmith/ObjectsEditor.wxs" src="Dialogs\ObjectsEditor.cpp" hdr="Dialogs\ObjectsEditor.h" fwddecl="0" i18n="1" name="ObjectsEditor" language="CPP" />
 				</resources>
 			</wxsmith>
-			<AutoVersioning>
-				<Scheme minor_max="1" build_max="0" rev_max="0" rev_rand_max="9" build_times_to_increment_minor="1" />
-				<Settings autoincrement="0" date_declarations="1" update_manifest="1" do_auto_increment="1" ask_to_increment="0" language="C++" svn="0" svn_directory="C:\Users\Florian\Programmation\GDevelop SVN\conf" header_path="" />
-				<Changes_Log show_changes_editor="0" app_title="released version %M.%m.%b of %p" changeslog_path="ChangesLog.txt" />
-				<Code header_guard="VERSION_H" namespace="AutoVersion" prefix="" />
-			</AutoVersioning>
-			<DoxyBlocks>
-				<comment_style block="0" line="0" />
-				<doxyfile_project output_directory="doc" />
-				<doxyfile_build />
-				<doxyfile_warnings />
-				<doxyfile_output html_help="1" />
-				<doxyfile_dot have_dot="1" />
-				<general />
-			</DoxyBlocks>
 		</Extensions>
 	</Project>
 </CodeBlocks_project_file>

--- a/IDE/IDE.layout
+++ b/IDE/IDE.layout
@@ -1,19 +1,29 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <CodeBlocks_layout_file>
 	<ActiveTarget name="Linux - Release - Edittime" />
-	<File name="ConsoleFrame.h" open="0" top="0" tabpos="110" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="SigneModification.h" open="0" top="0" tabpos="97" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1163" topLine="0" />
+			<Cursor1 position="698" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="TemplateEvents.cpp" open="0" top="0" tabpos="19" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="resource.rc" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="755" topLine="0" />
+			<Cursor1 position="976" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\include\wx\stedit\stenoteb.h" open="0" top="0" tabpos="185" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ChoiceJoyAxis.h" open="0" top="0" tabpos="58" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="8783" topLine="123" />
+			<Cursor1 position="1448" topLine="21" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stedefs.h" open="0" top="0" tabpos="161" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="42650" topLine="883" />
+		</Cursor>
+	</File>
+	<File name="DndTextObjectsEditor.h" open="0" top="0" tabpos="191" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="529" topLine="0" />
 		</Cursor>
 	</File>
 	<File name="ChoixBouton.cpp" open="0" top="0" tabpos="172" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -21,49 +31,89 @@
 			<Cursor1 position="4907" topLine="60" />
 		</Cursor>
 	</File>
+	<File name="ProjectManager.h" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="7477" topLine="195" />
+		</Cursor>
+	</File>
+	<File name="InitialPositionBrowserDlg.cpp" open="0" top="0" tabpos="57" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="2995" topLine="106" />
+		</Cursor>
+	</File>
+	<File name="CompilationChecker.cpp" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="258" topLine="9" />
+		</Cursor>
+	</File>
+	<File name="EventsEditor.cpp" open="0" top="0" tabpos="43" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1223" topLine="36" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stestyls.h" open="0" top="0" tabpos="200" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="20832" topLine="285" />
+		</Cursor>
+	</File>
+	<File name="StartHerePage.h" open="0" top="0" tabpos="112" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="4540" topLine="74" />
+		</Cursor>
+	</File>
 	<File name="EventsEditor.h" open="0" top="0" tabpos="27" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="11270" topLine="240" />
 		</Cursor>
 	</File>
-	<File name="CompilationChecker.h" open="0" top="0" tabpos="105" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/include/wx/stedit/setup0.h" open="0" top="0" tabpos="54" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="402" topLine="0" />
+			<Cursor1 position="4326" topLine="39" />
 		</Cursor>
 	</File>
-	<File name="TemplateEvents.h" open="0" top="0" tabpos="117" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Game_Develop_EditorApp.h" open="0" top="0" tabpos="14" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="762" topLine="0" />
+			<Cursor1 position="253" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\include\wx\stedit\steopts.h" open="0" top="0" tabpos="83" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="20912" topLine="324" />
-		</Cursor>
-	</File>
-	<File name="ConsoleManager.h" open="0" top="0" tabpos="115" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1005" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="ExtensionBugReportDlg.cpp" open="0" top="0" tabpos="44" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="7648" topLine="73" />
-		</Cursor>
-	</File>
-	<File name="TrueOrFalse.cpp" open="0" top="0" tabpos="23" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3297" topLine="17" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\HelpViewerDlg.h" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="519" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\steprefs.h" open="0" top="0" tabpos="190" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/include/wx/stedit/steprefs.h" open="0" top="0" tabpos="190" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="9658" topLine="140" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/steexprt.h" open="0" top="0" tabpos="68" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="4057" topLine="49" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/steshell.cpp" open="0" top="0" tabpos="132" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="12542" topLine="344" />
+		</Cursor>
+	</File>
+	<File name="ChoixTemplateEvent.cpp" open="0" top="0" tabpos="32" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="512" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/LayoutEditorPropertiesPnl.h" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="2033" topLine="39" />
+		</Cursor>
+	</File>
+	<File name="BuildMessagesPnl.cpp" open="0" top="0" tabpos="46" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="349" topLine="14" />
+		</Cursor>
+	</File>
+	<File name="ChoixBouton.h" open="0" top="0" tabpos="70" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1124" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="LogFileManager.cpp" open="0" top="0" tabpos="101" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1710" topLine="0" />
 		</Cursor>
 	</File>
 	<File name="ConsoleFrame.cpp" open="0" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -71,9 +121,49 @@
 			<Cursor1 position="3535" topLine="21" />
 		</Cursor>
 	</File>
-	<File name="ExtensionBugReportDlg.h" open="0" top="0" tabpos="151" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="EditorScene.h" open="0" top="0" tabpos="47" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1705" topLine="4" />
+			<Cursor1 position="3024" topLine="86" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stemenum.h" open="0" top="0" tabpos="78" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="21670" topLine="342" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/setup.h" open="0" top="0" tabpos="153" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="4326" topLine="39" />
+		</Cursor>
+	</File>
+	<File name="BuildMessagesPnl.h" open="0" top="0" tabpos="47" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="333" topLine="3" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/wx24defs.h" open="0" top="0" tabpos="98" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="2432" topLine="14" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/steopts.h" open="0" top="0" tabpos="83" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="20912" topLine="324" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stenoteb.cpp" open="0" top="0" tabpos="122" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="40666" topLine="1189" />
+		</Cursor>
+	</File>
+	<File name="MainFrame.h" open="0" top="0" tabpos="52" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="836" topLine="39" />
+		</Cursor>
+	</File>
+	<File name="CodeEditor.cpp" open="0" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="14044" topLine="292" />
 		</Cursor>
 	</File>
 	<File name="TrueOrFalse.h" open="0" top="0" tabpos="121" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -81,44 +171,94 @@
 			<Cursor1 position="1027" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="Dialogs\HtmlViewerPnl.cpp" open="0" top="0" tabpos="63" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/src/steframe.cpp" open="0" top="0" tabpos="20" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1119" topLine="0" />
+			<Cursor1 position="33736" topLine="921" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\include\wx\stedit\steprint.h" open="0" top="0" tabpos="88" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ChoixClavier.cpp" open="0" top="0" tabpos="177" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="3983" topLine="39" />
+			<Cursor1 position="6450" topLine="145" />
 		</Cursor>
 	</File>
-	<File name="BuildProgressPnl.h" open="0" top="0" tabpos="163" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="MainOutils.cpp" open="0" top="0" tabpos="120" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1449" topLine="2" />
+			<Cursor1 position="1439" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="LogFileManager.h" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ChoiceFile.cpp" open="0" top="0" tabpos="25" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1425" topLine="0" />
+			<Cursor1 position="412" topLine="17" />
 		</Cursor>
 	</File>
-	<File name="ExternalEventsEditor.cpp" open="0" top="0" tabpos="20" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/include/wx/stedit/stedit.h" open="0" top="0" tabpos="61" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="408" topLine="15" />
+			<Cursor1 position="43775" topLine="784" />
 		</Cursor>
 	</File>
-	<File name="Dialogs\HtmlViewerPnl.h" open="0" top="0" tabpos="170" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="SigneTest.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="660" topLine="0" />
+			<Cursor1 position="1724" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\include\wx\stedit\steshell.h" open="0" top="0" tabpos="195" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Dialogs/HelpViewerDlg.h" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="6577" topLine="95" />
+			<Cursor1 position="519" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="CreateTemplate.cpp" open="0" top="0" tabpos="22" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/src/steopts.cpp" open="0" top="0" tabpos="28" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="401" topLine="17" />
+			<Cursor1 position="16195" topLine="334" />
+		</Cursor>
+	</File>
+	<File name="ChoixCondition.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="26395" topLine="454" />
+		</Cursor>
+	</File>
+	<File name="SearchEvents.h" open="0" top="0" tabpos="92" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="881" topLine="27" />
+		</Cursor>
+	</File>
+	<File name="ChoiceJoyAxis.cpp" open="0" top="0" tabpos="26" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="5395" topLine="96" />
+		</Cursor>
+	</File>
+	<File name="Preferences.h" open="0" top="0" tabpos="143" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="7264" topLine="205" />
+		</Cursor>
+	</File>
+	<File name="ChoixAction.h" open="0" top="0" tabpos="65" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1040" topLine="27" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stestyls.cpp" open="0" top="0" tabpos="142" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="49004" topLine="919" />
+		</Cursor>
+	</File>
+	<File name="SearchEvents.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="259" topLine="11" />
+		</Cursor>
+	</File>
+	<File name="wxsmith/ProjectPropertiesPnl.wxs" open="0" top="0" tabpos="144" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="923" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="MainAide.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3620" topLine="95" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/ExternalLayoutEditor.cpp" open="0" top="0" tabpos="15" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="12034" topLine="213" />
 		</Cursor>
 	</File>
 	<File name="MAJ.cpp" open="0" top="0" tabpos="106" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -126,24 +266,449 @@
 			<Cursor1 position="437" topLine="18" />
 		</Cursor>
 	</File>
+	<File name="InitialPositionBrowserDlg.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1496" topLine="19" />
+		</Cursor>
+	</File>
+	<File name="ConsoleManager.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="440" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="LogFileManager.h" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1425" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="ChoixAction.cpp" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="24373" topLine="439" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stelangs.cpp" open="0" top="0" tabpos="118" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="310918" topLine="5459" />
+		</Cursor>
+	</File>
+	<File name="Preferences.cpp" open="0" top="0" tabpos="12" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="90793" topLine="1729" />
+		</Cursor>
+	</File>
+	<File name="GeneratePassword.h" open="0" top="0" tabpos="183" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1596" topLine="6" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/pairarr.h" open="0" top="0" tabpos="46" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="17051" topLine="279" />
+		</Cursor>
+	</File>
+	<File name="ChoixCondition.h" open="0" top="0" tabpos="80" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1003" topLine="25" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/steprint.cpp" open="0" top="0" tabpos="33" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="17183" topLine="386" />
+		</Cursor>
+	</File>
 	<File name="ExternalEventsEditor.h" open="0" top="0" tabpos="28" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="332" topLine="13" />
 		</Cursor>
 	</File>
-	<File name="Dialogs\LayoutEditorPropertiesPnl.cpp" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Dialogs/NewProjectDialog.h" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3187" topLine="55" />
+		</Cursor>
+	</File>
+	<File name="StartHerePage.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="25420" topLine="404" />
+		</Cursor>
+	</File>
+	<File name="RecentList.h" open="0" top="0" tabpos="167" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="78" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/HtmlViewerPnl.cpp" open="0" top="0" tabpos="63" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1119" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="TrueOrFalse.cpp" open="0" top="0" tabpos="23" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3297" topLine="17" />
+		</Cursor>
+	</File>
+	<File name="wxsmith/HtmlViewerPnl.wxs" open="0" top="0" tabpos="134" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="826" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/steshell.h" open="0" top="0" tabpos="195" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="6577" topLine="95" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/steprefs.cpp" open="0" top="0" tabpos="126" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="34424" topLine="626" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/HtmlViewerPnl.h" open="0" top="0" tabpos="170" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="660" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="SplashScreen.h" open="0" top="0" tabpos="107" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="897" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/ExternalLayoutEditor.h" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="2941" topLine="83" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stemenum.cpp" open="0" top="0" tabpos="24" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="47645" topLine="1116" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stenoteb.h" open="0" top="0" tabpos="185" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="8783" topLine="123" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/ObjectsEditor.h" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="5863" topLine="163" />
+		</Cursor>
+	</File>
+	<File name="ConsoleFrame.h" open="0" top="0" tabpos="110" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1163" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="ImportImage.cpp" open="0" top="0" tabpos="91" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="32697" topLine="503" />
+		</Cursor>
+	</File>
+	<File name="ExternalEventsEditor.cpp" open="0" top="0" tabpos="20" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="408" topLine="15" />
+		</Cursor>
+	</File>
+	<File name="TemplateEvents.cpp" open="0" top="0" tabpos="19" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="755" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stesplit.cpp" open="0" top="0" tabpos="38" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="22918" topLine="642" />
+		</Cursor>
+	</File>
+	<File name="mp3ogg.cpp" open="0" top="0" tabpos="32" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="8503" topLine="108" />
+		</Cursor>
+	</File>
+	<File name="ImportImage.h" open="0" top="0" tabpos="198" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="4801" topLine="100" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stedlgs.cpp" open="0" top="0" tabpos="103" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="85584" topLine="2085" />
+		</Cursor>
+	</File>
+	<File name="ChoiceFile.h" open="0" top="0" tabpos="51" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1933" topLine="32" />
+		</Cursor>
+	</File>
+	<File name="DnDFileEditor.cpp" open="0" top="0" tabpos="79" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="336" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="RecentList.cpp" open="0" top="0" tabpos="60" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="0" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="CreateTemplate.cpp" open="0" top="0" tabpos="22" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="401" topLine="17" />
+		</Cursor>
+	</File>
+	<File name="BuildToolsPnl.h" open="0" top="0" tabpos="171" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="989" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="DndTextObjectsEditor.cpp" open="0" top="0" tabpos="84" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="336" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="TemplateEvents.h" open="0" top="0" tabpos="117" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="762" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="EditObjectGroup.cpp" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="377" topLine="17" />
+		</Cursor>
+	</File>
+	<File name="wxsmith/ExternalLayoutEditor.wxs" open="0" top="0" tabpos="150" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="2300" topLine="39" />
+		</Cursor>
+	</File>
+	<File name="MainFichier.cpp" open="0" top="0" tabpos="51" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="843" topLine="27" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stedit.cpp" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="138814" topLine="4028" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stelangs.h" open="0" top="0" tabpos="180" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="14820" topLine="234" />
+		</Cursor>
+	</File>
+	<File name="BuildProgressPnl.cpp" open="0" top="0" tabpos="48" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="336" topLine="16" />
+		</Cursor>
+	</File>
+	<File name="CodeEditor.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="356" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stefindr.cpp" open="0" top="0" tabpos="113" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="35491" topLine="906" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stedlgs_wdr.cpp" open="0" top="0" tabpos="11" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="68838" topLine="1487" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/steframe.h" open="0" top="0" tabpos="73" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="13034" topLine="221" />
+		</Cursor>
+	</File>
+	<File name="EditPropScene.h" open="0" top="0" tabpos="17" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="515" topLine="22" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/LayoutEditorPropertiesPnl.cpp" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="4654" topLine="134" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\include\wx\stedit\stesplit.h" open="0" top="0" tabpos="93" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/include/wx/stedit/stefindr.h" open="0" top="0" tabpos="175" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="12595" topLine="239" />
+		</Cursor>
+	</File>
+	<File name="CheckMAJ.h" open="0" top="0" tabpos="176" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="683" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="CompilationChecker.h" open="0" top="0" tabpos="105" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="402" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/steprint.h" open="0" top="0" tabpos="88" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3983" topLine="39" />
+		</Cursor>
+	</File>
+	<File name="SplashScreen.cpp" open="0" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3507" topLine="80" />
+		</Cursor>
+	</File>
+	<File name="BugReport.cpp" open="0" top="0" tabpos="41" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="14870" topLine="255" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/ObjectsEditor.cpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="59746" topLine="1293" />
+		</Cursor>
+	</File>
+	<File name="ExtensionBugReportDlg.h" open="0" top="0" tabpos="151" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1705" topLine="4" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/ProjectPropertiesPnl.h" open="0" top="0" tabpos="181" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="359" topLine="14" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stesplit.h" open="0" top="0" tabpos="93" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="6286" topLine="82" />
+		</Cursor>
+	</File>
+	<File name="EditPropScene.cpp" open="0" top="0" tabpos="109" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="12028" topLine="186" />
+		</Cursor>
+	</File>
+	<File name="ConsoleManager.h" open="0" top="0" tabpos="115" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1005" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Credits.h" open="0" top="0" tabpos="136" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3690" topLine="66" />
+		</Cursor>
+	</File>
+	<File name="ProjectManager.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="90453" topLine="2007" />
+		</Cursor>
+	</File>
+	<File name="GeneratePassword.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="230" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="SigneModification.cpp" open="0" top="0" tabpos="199" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1802" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="EditorScene.cpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="11841" topLine="220" />
+		</Cursor>
+	</File>
+	<File name="ChoixClavier.h" open="0" top="0" tabpos="75" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1102" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="ExtensionBugReportDlg.cpp" open="0" top="0" tabpos="44" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="7648" topLine="73" />
+		</Cursor>
+	</File>
+	<File name="EditObjectGroup.h" open="0" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="953" topLine="26" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/steexprt.cpp" open="0" top="0" tabpos="16" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="58409" topLine="1539" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stedlgs.h" open="0" top="0" tabpos="168" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="20498" topLine="467" />
+		</Cursor>
+	</File>
+	<File name="mp3ogg.h" open="0" top="0" tabpos="130" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1364" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="EntryPoint.cpp" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="248" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/NewProjectDialog.cpp" open="0" top="0" tabpos="56" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="8169" topLine="127" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stedlgs_wdr.h" open="0" top="0" tabpos="108" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="8672" topLine="132" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/ProjectPropertiesPnl.cpp" open="0" top="0" tabpos="74" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="2027" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="SigneTest.h" open="0" top="0" tabpos="102" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="626" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="BugReport.h" open="0" top="0" tabpos="147" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="2533" topLine="34" />
+		</Cursor>
+	</File>
+	<File name="DnDFileEditor.h" open="0" top="0" tabpos="186" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="554" topLine="0" />
 		</Cursor>
 	</File>
 	<File name="CreateTemplate.h" open="0" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="427" topLine="19" />
+		</Cursor>
+	</File>
+	<File name="ChoixTemplateEvent.h" open="0" top="0" tabpos="45" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="340" topLine="15" />
+		</Cursor>
+	</File>
+	<File name="Credits.cpp" open="0" top="0" tabpos="60" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="19751" topLine="246" />
+		</Cursor>
+	</File>
+	<File name="CheckMAJ.cpp" open="0" top="0" tabpos="69" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="465" topLine="19" />
+		</Cursor>
+	</File>
+	<File name="MainFrame.cpp" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="23875" topLine="406" />
+		</Cursor>
+	</File>
+	<File name="BuildToolsPnl.cpp" open="0" top="0" tabpos="49" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="225" topLine="9" />
+		</Cursor>
+	</File>
+	<File name="BuildProgressPnl.h" open="0" top="0" tabpos="163" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1449" topLine="2" />
 		</Cursor>
 	</File>
 	<File name="MAJ.h" open="0" top="0" tabpos="14" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -154,571 +719,6 @@
 	<File name="Game_Develop_EditorApp.cpp" open="0" top="0" tabpos="62" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="1374" topLine="33" />
-		</Cursor>
-	</File>
-	<File name="mp3ogg.cpp" open="0" top="0" tabpos="32" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="8503" topLine="108" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\LayoutEditorPropertiesPnl.h" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2033" topLine="39" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stestyls.h" open="0" top="0" tabpos="200" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="20832" topLine="285" />
-		</Cursor>
-	</File>
-	<File name="ChoixAction.cpp" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="24373" topLine="439" />
-		</Cursor>
-	</File>
-	<File name="MainAide.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3620" topLine="95" />
-		</Cursor>
-	</File>
-	<File name="Game_Develop_EditorApp.h" open="0" top="0" tabpos="14" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="253" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="mp3ogg.h" open="0" top="0" tabpos="130" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1364" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\NewProjectDialog.cpp" open="0" top="0" tabpos="56" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="8169" topLine="127" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\wx24defs.h" open="0" top="0" tabpos="98" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2432" topLine="14" />
-		</Cursor>
-	</File>
-	<File name="CheckMAJ.cpp" open="0" top="0" tabpos="69" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="465" topLine="19" />
-		</Cursor>
-	</File>
-	<File name="MainFichier.cpp" open="0" top="0" tabpos="51" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="843" topLine="27" />
-		</Cursor>
-	</File>
-	<File name="GeneratePassword.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="230" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="resource.rc" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="976" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\NewProjectDialog.h" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3187" topLine="55" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stedit.cpp" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="138814" topLine="4028" />
-		</Cursor>
-	</File>
-	<File name="CodeEditor.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="356" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="MainFrame.cpp" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="23875" topLine="406" />
-		</Cursor>
-	</File>
-	<File name="GeneratePassword.h" open="0" top="0" tabpos="183" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1596" topLine="6" />
-		</Cursor>
-	</File>
-	<File name="wxsmith\ExternalLayoutEditor.wxs" open="0" top="0" tabpos="150" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2300" topLine="39" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\ObjectsEditor.cpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="59746" topLine="1293" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stedlgs.cpp" open="0" top="0" tabpos="103" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="85584" topLine="2085" />
-		</Cursor>
-	</File>
-	<File name="Credits.cpp" open="0" top="0" tabpos="60" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="19751" topLine="246" />
-		</Cursor>
-	</File>
-	<File name="MainFrame.h" open="0" top="0" tabpos="52" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="836" topLine="39" />
-		</Cursor>
-	</File>
-	<File name="ImportImage.cpp" open="0" top="0" tabpos="91" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="32697" topLine="503" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\ObjectsEditor.h" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="5863" topLine="163" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stedlgs_wdr.cpp" open="0" top="0" tabpos="11" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="68838" topLine="1487" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\ExternalLayoutEditor.cpp" open="0" top="0" tabpos="15" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="12034" topLine="213" />
-		</Cursor>
-	</File>
-	<File name="MainOutils.cpp" open="0" top="0" tabpos="120" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1439" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="ImportImage.h" open="0" top="0" tabpos="198" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4801" topLine="100" />
-		</Cursor>
-	</File>
-	<File name="wxsmith\HtmlViewerPnl.wxs" open="0" top="0" tabpos="134" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="826" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\ProjectPropertiesPnl.cpp" open="0" top="0" tabpos="74" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2027" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stedlgs_wdr.h" open="0" top="0" tabpos="108" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="8672" topLine="132" />
-		</Cursor>
-	</File>
-	<File name="Preferences.cpp" open="0" top="0" tabpos="12" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="90793" topLine="1729" />
-		</Cursor>
-	</File>
-	<File name="InitialPositionBrowserDlg.cpp" open="0" top="0" tabpos="57" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2995" topLine="106" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\ProjectPropertiesPnl.h" open="0" top="0" tabpos="181" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="359" topLine="14" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\steexprt.cpp" open="0" top="0" tabpos="16" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="58409" topLine="1539" />
-		</Cursor>
-	</File>
-	<File name="BugReport.cpp" open="0" top="0" tabpos="41" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="14870" topLine="255" />
-		</Cursor>
-	</File>
-	<File name="Preferences.h" open="0" top="0" tabpos="143" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="7264" topLine="205" />
-		</Cursor>
-	</File>
-	<File name="InitialPositionBrowserDlg.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1496" topLine="19" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stefindr.cpp" open="0" top="0" tabpos="113" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="35491" topLine="906" />
-		</Cursor>
-	</File>
-	<File name="ChoiceJoyAxis.cpp" open="0" top="0" tabpos="26" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="5395" topLine="96" />
-		</Cursor>
-	</File>
-	<File name="ProjectManager.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="90453" topLine="2007" />
-		</Cursor>
-	</File>
-	<File name="LogFileManager.cpp" open="0" top="0" tabpos="101" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1710" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\steframe.cpp" open="0" top="0" tabpos="20" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="33736" topLine="921" />
-		</Cursor>
-	</File>
-	<File name="CodeEditor.cpp" open="0" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="14044" topLine="292" />
-		</Cursor>
-	</File>
-	<File name="ProjectManager.h" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="7477" topLine="195" />
-		</Cursor>
-	</File>
-	<File name="wxsmith\ProjectPropertiesPnl.wxs" open="0" top="0" tabpos="144" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="923" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="DnDFileEditor.cpp" open="0" top="0" tabpos="79" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="336" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stelangs.cpp" open="0" top="0" tabpos="118" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="310918" topLine="5459" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\ExternalLayoutEditor.h" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2941" topLine="83" />
-		</Cursor>
-	</File>
-	<File name="RecentList.cpp" open="0" top="0" tabpos="60" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="0" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="DnDFileEditor.h" open="0" top="0" tabpos="186" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="554" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stemenum.cpp" open="0" top="0" tabpos="24" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="47645" topLine="1116" />
-		</Cursor>
-	</File>
-	<File name="ChoiceJoyAxis.h" open="0" top="0" tabpos="58" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1448" topLine="21" />
-		</Cursor>
-	</File>
-	<File name="RecentList.h" open="0" top="0" tabpos="167" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="78" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\pairarr.h" open="0" top="0" tabpos="46" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="17051" topLine="279" />
-		</Cursor>
-	</File>
-	<File name="DndTextObjectsEditor.cpp" open="0" top="0" tabpos="84" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="336" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stenoteb.cpp" open="0" top="0" tabpos="122" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="40666" topLine="1189" />
-		</Cursor>
-	</File>
-	<File name="ChoiceFile.h" open="0" top="0" tabpos="51" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1933" topLine="32" />
-		</Cursor>
-	</File>
-	<File name="SearchEvents.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="259" topLine="11" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\setup.h" open="0" top="0" tabpos="153" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4326" topLine="39" />
-		</Cursor>
-	</File>
-	<File name="CompilationChecker.cpp" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="258" topLine="9" />
-		</Cursor>
-	</File>
-	<File name="DndTextObjectsEditor.h" open="0" top="0" tabpos="191" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="529" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\steopts.cpp" open="0" top="0" tabpos="28" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="16195" topLine="334" />
-		</Cursor>
-	</File>
-	<File name="ChoiceFile.cpp" open="0" top="0" tabpos="25" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="412" topLine="17" />
-		</Cursor>
-	</File>
-	<File name="SearchEvents.h" open="0" top="0" tabpos="92" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="881" topLine="27" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\setup0.h" open="0" top="0" tabpos="54" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4326" topLine="39" />
-		</Cursor>
-	</File>
-	<File name="ChoixCondition.h" open="0" top="0" tabpos="80" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1003" topLine="25" />
-		</Cursor>
-	</File>
-	<File name="EditObjectGroup.cpp" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="377" topLine="17" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\steprefs.cpp" open="0" top="0" tabpos="126" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="34424" topLine="626" />
-		</Cursor>
-	</File>
-	<File name="BugReport.h" open="0" top="0" tabpos="147" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2533" topLine="34" />
-		</Cursor>
-	</File>
-	<File name="SigneModification.cpp" open="0" top="0" tabpos="199" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1802" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stedefs.h" open="0" top="0" tabpos="161" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="42650" topLine="883" />
-		</Cursor>
-	</File>
-	<File name="BuildMessagesPnl.h" open="0" top="0" tabpos="47" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="333" topLine="3" />
-		</Cursor>
-	</File>
-	<File name="EditObjectGroup.h" open="0" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="953" topLine="26" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\steprint.cpp" open="0" top="0" tabpos="33" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="17183" topLine="386" />
-		</Cursor>
-	</File>
-	<File name="Credits.h" open="0" top="0" tabpos="136" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3690" topLine="66" />
-		</Cursor>
-	</File>
-	<File name="SigneModification.h" open="0" top="0" tabpos="97" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="698" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stedit.h" open="0" top="0" tabpos="61" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="43775" topLine="784" />
-		</Cursor>
-	</File>
-	<File name="ConsoleManager.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="440" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="EditPropScene.cpp" open="0" top="0" tabpos="109" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="12028" topLine="186" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\steshell.cpp" open="0" top="0" tabpos="132" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="12542" topLine="344" />
-		</Cursor>
-	</File>
-	<File name="ChoixTemplateEvent.h" open="0" top="0" tabpos="45" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="340" topLine="15" />
-		</Cursor>
-	</File>
-	<File name="SigneTest.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1724" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stedlgs.h" open="0" top="0" tabpos="168" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="20498" topLine="467" />
-		</Cursor>
-	</File>
-	<File name="BuildProgressPnl.cpp" open="0" top="0" tabpos="48" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="336" topLine="16" />
-		</Cursor>
-	</File>
-	<File name="EditPropScene.h" open="0" top="0" tabpos="17" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="515" topLine="22" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stesplit.cpp" open="0" top="0" tabpos="38" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="22918" topLine="642" />
-		</Cursor>
-	</File>
-	<File name="ChoixCondition.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="26395" topLine="454" />
-		</Cursor>
-	</File>
-	<File name="SigneTest.h" open="0" top="0" tabpos="102" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="626" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\steexprt.h" open="0" top="0" tabpos="68" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4057" topLine="49" />
-		</Cursor>
-	</File>
-	<File name="BuildMessagesPnl.cpp" open="0" top="0" tabpos="46" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="349" topLine="14" />
-		</Cursor>
-	</File>
-	<File name="EditorScene.cpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="11841" topLine="220" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stestyls.cpp" open="0" top="0" tabpos="142" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="49004" topLine="919" />
-		</Cursor>
-	</File>
-	<File name="ChoixClavier.cpp" open="0" top="0" tabpos="177" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="6450" topLine="145" />
-		</Cursor>
-	</File>
-	<File name="SplashScreen.cpp" open="0" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3507" topLine="80" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stefindr.h" open="0" top="0" tabpos="175" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="12595" topLine="239" />
-		</Cursor>
-	</File>
-	<File name="ChoixBouton.h" open="0" top="0" tabpos="70" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1124" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="EditorScene.h" open="0" top="0" tabpos="47" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3024" topLine="86" />
-		</Cursor>
-	</File>
-	<File name="ChoixAction.h" open="0" top="0" tabpos="65" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1040" topLine="27" />
-		</Cursor>
-	</File>
-	<File name="SplashScreen.h" open="0" top="0" tabpos="107" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="897" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\steframe.h" open="0" top="0" tabpos="73" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="13034" topLine="221" />
-		</Cursor>
-	</File>
-	<File name="ChoixClavier.h" open="0" top="0" tabpos="75" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1102" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="EntryPoint.cpp" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="248" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="CheckMAJ.h" open="0" top="0" tabpos="176" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="683" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="StartHerePage.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="25420" topLine="404" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stelangs.h" open="0" top="0" tabpos="180" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="14820" topLine="234" />
-		</Cursor>
-	</File>
-	<File name="BuildToolsPnl.cpp" open="0" top="0" tabpos="49" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="225" topLine="9" />
-		</Cursor>
-	</File>
-	<File name="ChoixTemplateEvent.cpp" open="0" top="0" tabpos="32" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="512" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="StartHerePage.h" open="0" top="0" tabpos="112" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4540" topLine="74" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stemenum.h" open="0" top="0" tabpos="78" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="21670" topLine="342" />
-		</Cursor>
-	</File>
-	<File name="BuildToolsPnl.h" open="0" top="0" tabpos="171" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="989" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="EventsEditor.cpp" open="0" top="0" tabpos="43" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1223" topLine="36" />
 		</Cursor>
 	</File>
 </CodeBlocks_layout_file>

--- a/IDE/InstructionSelectorDialog.cpp
+++ b/IDE/InstructionSelectorDialog.cpp
@@ -208,7 +208,7 @@ InstructionSelectorDialog::InstructionSelectorDialog(wxWindow* parent, gd::Proje
     if (editingAction) invertBox->Show(false);
     RefreshList();
     Center();
-    SetSize(800, 600);
+    SetSize(-1, 600);
 }
 
 InstructionSelectorDialog::~InstructionSelectorDialog()

--- a/IDE/Preferences.cpp
+++ b/IDE/Preferences.cpp
@@ -1,11 +1,11 @@
 #include "Preferences.h"
 
 //(*InternalHeaders(Preferences)
-#include <wx/bitmap.h>
 #include <wx/settings.h>
-#include <wx/intl.h>
-#include <wx/image.h>
 #include <wx/string.h>
+#include <wx/intl.h>
+#include <wx/bitmap.h>
+#include <wx/image.h>
 //*)
 #include <wx/propgrid/advprops.h>
 #include <wx/imaglist.h>
@@ -140,65 +140,65 @@ Preferences::Preferences( wxWindow* parent ) :
 changesNeedRestart(false)
 {
     //(*Initialize(Preferences)
+    wxStaticBoxSizer* StaticBoxSizer17;
+    wxFlexGridSizer* FlexGridSizer30;
     wxStaticBoxSizer* StaticBoxSizer2;
-    wxFlexGridSizer* FlexGridSizer4;
-    wxFlexGridSizer* FlexGridSizer16;
-    wxFlexGridSizer* FlexGridSizer24;
+    wxFlexGridSizer* FlexGridSizer21;
+    wxFlexGridSizer* FlexGridSizer28;
+    wxFlexGridSizer* FlexGridSizer8;
+    wxStaticBoxSizer* StaticBoxSizer10;
+    wxFlexGridSizer* FlexGridSizer1;
+    wxFlexGridSizer* FlexGridSizer25;
+    wxFlexGridSizer* FlexGridSizer2;
+    wxFlexGridSizer* FlexGridSizer15;
+    wxStaticBoxSizer* StaticBoxSizer19;
+    wxStaticBoxSizer* StaticBoxSizer7;
+    wxStaticBoxSizer* StaticBoxSizer5;
+    wxFlexGridSizer* FlexGridSizer17;
+    wxFlexGridSizer* FlexGridSizer29;
+    wxFlexGridSizer* FlexGridSizer11;
     wxFlexGridSizer* FlexGridSizer19;
     wxStaticBoxSizer* StaticBoxSizer12;
-    wxFlexGridSizer* FlexGridSizer23;
-    wxFlexGridSizer* FlexGridSizer38;
-    wxStaticBoxSizer* StaticBoxSizer15;
-    wxStaticBoxSizer* StaticBoxSizer14;
-    wxStaticBoxSizer* StaticBoxSizer4;
-    wxFlexGridSizer* FlexGridSizer10;
-    wxFlexGridSizer* FlexGridSizer3;
-    wxFlexGridSizer* FlexGridSizer27;
-    wxStaticBoxSizer* StaticBoxSizer16;
-    wxFlexGridSizer* FlexGridSizer37;
-    wxFlexGridSizer* FlexGridSizer5;
-    wxFlexGridSizer* FlexGridSizer25;
-    wxFlexGridSizer* FlexGridSizer22;
-    wxFlexGridSizer* FlexGridSizer9;
-    wxFlexGridSizer* FlexGridSizer2;
-    wxStaticBoxSizer* StaticBoxSizer9;
     wxFlexGridSizer* FlexGridSizer7;
-    wxStaticBoxSizer* StaticBoxSizer7;
-    wxStaticBoxSizer* StaticBoxSizer17;
-    wxStaticBoxSizer* StaticBoxSizer13;
-    wxStaticBoxSizer* StaticBoxSizer10;
-    wxStaticBoxSizer* StaticBoxSizer19;
-    wxFlexGridSizer* FlexGridSizer29;
-    wxFlexGridSizer* FlexGridSizer34;
-    wxStaticBoxSizer* StaticBoxSizer8;
+    wxFlexGridSizer* FlexGridSizer4;
+    wxStaticBoxSizer* StaticBoxSizer16;
+    wxFlexGridSizer* FlexGridSizer26;
+    wxFlexGridSizer* FlexGridSizer9;
     wxStaticBoxSizer* StaticBoxSizer3;
-    wxStaticBoxSizer* StaticBoxSizer6;
-    wxFlexGridSizer* FlexGridSizer15;
-    wxFlexGridSizer* FlexGridSizer18;
-    wxFlexGridSizer* FlexGridSizer8;
-    wxStaticBoxSizer* StaticBoxSizer20;
-    wxFlexGridSizer* FlexGridSizer21;
     wxFlexGridSizer* FlexGridSizer14;
-    wxStaticBoxSizer* StaticBoxSizer11;
-    wxFlexGridSizer* FlexGridSizer20;
-    wxFlexGridSizer* FlexGridSizer13;
-    wxFlexGridSizer* FlexGridSizer35;
-    wxFlexGridSizer* FlexGridSizer12;
-    wxFlexGridSizer* FlexGridSizer36;
-    wxFlexGridSizer* FlexGridSizer6;
-    wxStaticBoxSizer* StaticBoxSizer1;
-    wxFlexGridSizer* FlexGridSizer1;
     wxFlexGridSizer* FlexGridSizer33;
-    wxFlexGridSizer* FlexGridSizer11;
-    wxFlexGridSizer* FlexGridSizer17;
-    wxStaticBoxSizer* StaticBoxSizer5;
-    wxFlexGridSizer* FlexGridSizer32;
+    wxFlexGridSizer* FlexGridSizer6;
+    wxStaticBoxSizer* StaticBoxSizer20;
+    wxStaticBoxSizer* StaticBoxSizer13;
+    wxFlexGridSizer* FlexGridSizer38;
+    wxFlexGridSizer* FlexGridSizer27;
+    wxFlexGridSizer* FlexGridSizer37;
+    wxFlexGridSizer* FlexGridSizer3;
+    wxFlexGridSizer* FlexGridSizer22;
+    wxStaticBoxSizer* StaticBoxSizer15;
+    wxStaticBoxSizer* StaticBoxSizer8;
     wxFlexGridSizer* FlexGridSizer31;
     wxFlexGridSizer* FlexGridSizer39;
+    wxStaticBoxSizer* StaticBoxSizer9;
+    wxStaticBoxSizer* StaticBoxSizer4;
+    wxStaticBoxSizer* StaticBoxSizer6;
+    wxStaticBoxSizer* StaticBoxSizer14;
     wxStaticBoxSizer* StaticBoxSizer18;
-    wxFlexGridSizer* FlexGridSizer28;
-    wxFlexGridSizer* FlexGridSizer26;
-    wxFlexGridSizer* FlexGridSizer30;
+    wxFlexGridSizer* FlexGridSizer16;
+    wxFlexGridSizer* FlexGridSizer34;
+    wxFlexGridSizer* FlexGridSizer23;
+    wxFlexGridSizer* FlexGridSizer10;
+    wxStaticBoxSizer* StaticBoxSizer11;
+    wxFlexGridSizer* FlexGridSizer13;
+    wxFlexGridSizer* FlexGridSizer18;
+    wxFlexGridSizer* FlexGridSizer36;
+    wxFlexGridSizer* FlexGridSizer12;
+    wxFlexGridSizer* FlexGridSizer35;
+    wxFlexGridSizer* FlexGridSizer5;
+    wxFlexGridSizer* FlexGridSizer24;
+    wxFlexGridSizer* FlexGridSizer32;
+    wxStaticBoxSizer* StaticBoxSizer1;
+    wxFlexGridSizer* FlexGridSizer20;
 
     Create(parent, wxID_ANY, _("GDevelop settings"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxMINIMIZE_BOX, _T("wxID_ANY"));
     FlexGridSizer1 = new wxFlexGridSizer(0, 1, 0, 0);
@@ -226,7 +226,7 @@ changesNeedRestart(false)
     FlexGridSizer14->AddGrowableCol(0);
     StaticBoxSizer1 = new wxStaticBoxSizer(wxVERTICAL, Panel2, _("Startup"));
     FlexGridSizer39 = new wxFlexGridSizer(0, 1, 0, 0);
-    MAJCheck = new wxCheckBox(Panel2, ID_CHECKBOX4, _("Check for updates and the news"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX4"));
+    MAJCheck = new wxCheckBox(Panel2, ID_CHECKBOX4, _("Check for updates"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX4"));
     MAJCheck->SetValue(false);
     FlexGridSizer39->Add(MAJCheck, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
     sendInfoCheck = new wxCheckBox(Panel2, ID_CHECKBOX10, _("Send anonymous statistics about GDevelop ( version, language used )"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX10"));
@@ -242,7 +242,7 @@ changesNeedRestart(false)
     autosaveActivatedCheck = new wxCheckBox(Panel2, ID_CHECKBOX3, _("Make a backup of opened projects every"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX3"));
     autosaveActivatedCheck->SetValue(false);
     FlexGridSizer19->Add(autosaveActivatedCheck, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-    autosaveTimeEdit = new wxTextCtrl(Panel2, ID_TEXTCTRL1, _("3"), wxDefaultPosition, wxSize(44,21), 0, wxDefaultValidator, _T("ID_TEXTCTRL1"));
+    autosaveTimeEdit = new wxTextCtrl(Panel2, ID_TEXTCTRL1, _("3"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_TEXTCTRL1"));
     FlexGridSizer19->Add(autosaveTimeEdit, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
     StaticText5 = new wxStaticText(Panel2, ID_STATICTEXT5, _("minutes"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT5"));
     FlexGridSizer19->Add(StaticText5, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
@@ -268,6 +268,7 @@ changesNeedRestart(false)
     StaticText13 = new wxStaticText(Panel5, ID_STATICTEXT13, _("Language:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT13"));
     FlexGridSizer9->Add(StaticText13, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
     langChoice = new wxChoice(Panel5, ID_CHOICE2, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE2"));
+    langChoice->SetSelection( langChoice->Append(_("English")) );
     FlexGridSizer9->Add(langChoice, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
     Panel5->SetSizer(FlexGridSizer9);
     FlexGridSizer9->Fit(Panel5);
@@ -507,7 +508,7 @@ changesNeedRestart(false)
     FlexGridSizer28 = new wxFlexGridSizer(0, 3, 0, 0);
     StaticText17 = new wxStaticText(Panel8, ID_STATICTEXT17, _("Default width of the condition column:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT17"));
     FlexGridSizer28->Add(StaticText17, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-    conditionsColumnWidthEdit = new wxTextCtrl(Panel8, ID_TEXTCTRL5, wxEmptyString, wxDefaultPosition, wxSize(65,21), 0, wxDefaultValidator, _T("ID_TEXTCTRL5"));
+    conditionsColumnWidthEdit = new wxTextCtrl(Panel8, ID_TEXTCTRL5, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_TEXTCTRL5"));
     FlexGridSizer28->Add(conditionsColumnWidthEdit, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
     StaticText18 = new wxStaticText(Panel8, ID_STATICTEXT18, _("pixels"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT18"));
     FlexGridSizer28->Add(StaticText18, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
@@ -582,7 +583,6 @@ changesNeedRestart(false)
     	wxFontData fontData_1;
     	fontData_1.EnableEffects(false);
     	fontData_1.SetInitialFont(*wxNORMAL_FONT);
-    	fontData_1.SetAllowSymbols(false);
     eventsEditorFontDialog = new wxFontDialog(this, fontData_1);
     FlexGridSizer1->Fit(this);
     FlexGridSizer1->SetSizeHints(this);
@@ -844,6 +844,8 @@ changesNeedRestart(false)
             languagesAvailables.push_back(string(filename.mb_str()));
             cont = dir.GetNext(&filename);
         }
+
+        langChoice->Clear();
 
         //Add languages to list and retrieve selected language
         for (unsigned int i = 0;i<languagesAvailables.size();++i)

--- a/IDE/Preferences.h
+++ b/IDE/Preferences.h
@@ -2,23 +2,23 @@
 #define PREFERENCES_H
 
 //(*Headers(Preferences)
-#include <wx/fontdlg.h>
-#include <wx/notebook.h>
-#include <wx/sizer.h>
-#include <wx/stattext.h>
-#include <wx/radiobox.h>
-#include <wx/textctrl.h>
-#include <wx/checkbox.h>
 #include <wx/spinctrl.h>
-#include <wx/propgrid/propgrid.h>
-#include <wx/statline.h>
+#include <wx/checkbox.h>
+#include <wx/dialog.h>
+#include <wx/sizer.h>
+#include <wx/notebook.h>
+#include <wx/button.h>
 #include <wx/radiobut.h>
 #include <wx/panel.h>
-#include <wx/choice.h>
-#include <wx/statbmp.h>
-#include <wx/button.h>
-#include <wx/dialog.h>
 #include <wx/listbook.h>
+#include <wx/statline.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/propgrid/propgrid.h>
+#include <wx/radiobox.h>
+#include <wx/statbmp.h>
+#include <wx/fontdlg.h>
 //*)
 
 class Preferences: public wxDialog
@@ -29,100 +29,100 @@ class Preferences: public wxDialog
 		virtual ~Preferences();
 
 		//(*Declarations(Preferences)
-		wxStaticText* StaticText10;
-		wxRadioButton* externalCodeEditorCheck;
-		wxButton* eventsEditorFontBt;
-		wxPanel* InactifColorPnl;
-		wxStaticText* StaticText22;
-		wxButton* OkBt;
-		wxStaticText* StaticText9;
-		wxStaticText* StaticText20;
-		wxPanel* backColorPnl;
-		wxPanel* Panel5;
-		wxCheckBox* hideLabelsCheck;
-		wxCheckBox* avertOnSaveCheck;
-		wxCheckBox* MAJCheck;
-		wxRadioBox* ribbonStyleBox;
 		wxButton* gdStyleBt;
-		wxButton* BrowseDossierTempBt;
-		wxTextCtrl* newProjectFolderEdit;
-		wxTextCtrl* codeEditorEdit;
-		wxButton* oxygenStyleBt;
-		wxStaticText* StaticText13;
-		wxPanel* ActifColor2Pnl;
-		wxStaticText* StaticText2;
-		wxPanel* Panel4;
-		wxChoice* sceneEventsTabPosition;
-		wxStaticText* StaticText14;
-		wxCheckBox* logCheck;
-		wxCheckBox* deleteTemporariesCheck;
-		wxButton* Button1;
-		wxStaticText* StaticText6;
-		wxPanel* activeTabColorPnl;
-		wxPanel* borderColorPnl;
-		wxSpinCtrl* codeCompilerThreadEdit;
-		wxStaticText* StaticText19;
-		wxStaticText* StaticText8;
-		wxPanel* toolbarColorPanel;
-		wxStaticText* StaticText11;
-		wxStaticText* StaticText18;
-		wxTextCtrl* autosaveTimeEdit;
-		wxPanel* Panel8;
-		wxPanel* tabColorPnl;
-		wxTextCtrl* eventsCompilerTempDirEdit;
-		wxFontDialog* eventsEditorFontDialog;
+		wxStaticText* StaticText24;
+		wxButton* newProjectFolderBrowseBt;
+		wxStaticText* StaticText22;
+		wxButton* AideBt;
+		wxPanel* ActifColorPnl;
+		wxPanel* Panel6;
 		wxPanel* Panel1;
-		wxTextCtrl* conditionsColumnWidthEdit;
+		wxButton* browseCompilationTempDir;
+		wxStaticText* StaticText21;
+		wxStaticText* StaticText13;
+		wxStaticText* StaticText14;
+		wxPanel* Panel7;
+		wxRadioButton* internalCodeEditorCheck;
+		wxStaticText* StaticText15;
+		wxChoice* sceneEventsTabPosition;
+		wxStaticLine* StaticLine2;
+		wxCheckBox* hideLabelsCheck;
+		wxChoice* langChoice;
+		wxStaticText* StaticText17;
+		wxButton* oxygenStyleBt;
+		wxButton* BrowseDossierTempBt;
+		wxFontDialog* eventsEditorFontDialog;
+		wxPanel* ActifColor2Pnl;
+		wxPanel* inactiveTextColorPnl;
+		wxRadioBox* tabBox;
+		wxCheckBox* autosaveActivatedCheck;
+		wxButton* Button1;
+		wxButton* Button2;
+		wxTextCtrl* autosaveTimeEdit;
 		wxPanel* activeTextColorPnl;
+		wxPanel* activeTabColorPnl;
+		wxPanel* Panel8;
+		wxStaticText* StaticText20;
+		wxStaticText* StaticText18;
+		wxCheckBox* hideContextPanelsLabels;
 		wxStaticText* StaticText1;
+		wxStaticText* StaticText10;
+		wxTextCtrl* newProjectFolderEdit;
+		wxStaticText* StaticText16;
+		wxPanel* ribbonColor2Pnl;
+		wxPanel* Panel2;
+		wxCheckBox* deleteTemporariesCheck;
+		wxTextCtrl* DossierTempCompEdit;
+		wxCheckBox* MAJCheck;
+		wxSpinCtrl* codeCompilerThreadEdit;
 		wxStaticText* StaticText3;
 		wxTextCtrl* EditeurImageEdit;
-		wxPanel* inactiveTextColorPnl;
-		wxButton* browseJavaBt;
-		wxButton* newProjectFolderBrowseBt;
-		wxButton* Button2;
-		wxPanel* InactifColor2Pnl;
-		wxCheckBox* hidePageTabsCheck;
-		wxPanel* Panel6;
-		wxPanel* Panel3;
-		wxStaticText* StaticText21;
-		wxStaticLine* StaticLine2;
+		wxPanel* Panel4;
 		wxStaticText* StaticText23;
-		wxStaticText* StaticText24;
 		wxCheckBox* customToolbarColorCheck;
-		wxRadioBox* tabBox;
-		wxPanel* ActifColorPnl;
-		wxCheckBox* sendInfoCheck;
-		wxCheckBox* hideContextPanelsLabels;
+		wxStaticLine* StaticLine1;
+		wxPanel* Panel5;
+		wxStaticText* StaticText8;
+		wxStaticText* StaticText12;
+		wxButton* officeStyleBt;
+		wxTextCtrl* conditionsColumnWidthEdit;
+		wxButton* AnnulerBt;
+		wxPanel* Panel3;
+		wxStaticText* StaticText7;
+		wxTextCtrl* codeEditorEdit;
+		wxPanel* borderColorPnl;
+		wxPanel* InactifColorPnl;
+		wxRadioBox* ribbonStyleBox;
+		wxTextCtrl* eventsCompilerTempDirEdit;
+		wxCheckBox* logCheck;
+		wxTextCtrl* javaDirEdit;
+		wxStaticText* StaticText4;
+		wxPanel* toolbarColorPanel;
+		wxStaticText* StaticText5;
+		wxButton* eventsEditorFontBt;
+		wxStaticText* StaticText2;
+		wxStaticBitmap* StaticBitmap3;
+		wxCheckBox* avertOnSaveCheck;
+		wxButton* OkBt;
+		wxPanel* fileBtColorPnl;
+		wxStaticText* StaticText6;
+		wxCheckBox* hidePageTabsCheck;
+		wxPanel* backColorPnl;
+		wxButton* browseJavaBt;
+		wxPanel* ribbonColor1Pnl;
+		wxButton* radianceStyleBt;
+		wxStaticText* StaticText19;
+		wxButton* BrowseEditionImage;
+		wxRadioButton* externalCodeEditorCheck;
+		wxPanel* tabColorPnl;
+		wxStaticText* StaticText9;
+		wxRadioBox* toolbarBox;
+		wxPanel* InactifColor2Pnl;
+		wxButton* browseCodeEditorBt;
 		wxPropertyGrid* eventsEditorParametersProperties;
 		wxListbook* Listbook1;
-		wxStaticText* StaticText5;
-		wxStaticText* StaticText7;
-		wxPanel* Panel7;
-		wxPanel* fileBtColorPnl;
-		wxCheckBox* autosaveActivatedCheck;
-		wxStaticLine* StaticLine1;
-		wxButton* BrowseEditionImage;
-		wxTextCtrl* javaDirEdit;
-		wxStaticText* StaticText15;
-		wxStaticText* StaticText12;
-		wxButton* AnnulerBt;
-		wxPanel* Panel2;
-		wxChoice* langChoice;
-		wxButton* radianceStyleBt;
-		wxTextCtrl* DossierTempCompEdit;
-		wxPanel* ribbonColor1Pnl;
-		wxPanel* ribbonColor2Pnl;
-		wxStaticText* StaticText17;
-		wxStaticText* StaticText4;
-		wxButton* browseCodeEditorBt;
-		wxRadioBox* toolbarBox;
-		wxButton* browseCompilationTempDir;
-		wxButton* officeStyleBt;
-		wxStaticText* StaticText16;
-		wxStaticBitmap* StaticBitmap3;
-		wxRadioButton* internalCodeEditorCheck;
-		wxButton* AideBt;
+		wxStaticText* StaticText11;
+		wxCheckBox* sendInfoCheck;
 		//*)
 
 	protected:

--- a/IDE/wxsmith/Preferences.wxs
+++ b/IDE/wxsmith/Preferences.wxs
@@ -115,7 +115,6 @@
 														<object class="sizeritem">
 															<object class="wxTextCtrl" name="ID_TEXTCTRL1" variable="autosaveTimeEdit" member="yes">
 																<value>3</value>
-																<size>44,21</size>
 															</object>
 															<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 															<border>5</border>
@@ -195,6 +194,10 @@
 								</object>
 								<object class="sizeritem">
 									<object class="wxChoice" name="ID_CHOICE2" variable="langChoice" member="yes">
+										<content>
+											<item>English</item>
+										</content>
+										<selection>0</selection>
 										<handler function="OnlangChoiceSelect" entry="EVT_CHOICE" />
 									</object>
 									<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
@@ -1017,9 +1020,7 @@
 											<option>1</option>
 										</object>
 										<object class="sizeritem">
-											<object class="wxTextCtrl" name="ID_TEXTCTRL5" variable="conditionsColumnWidthEdit" member="yes">
-												<size>65,21</size>
-											</object>
+											<object class="wxTextCtrl" name="ID_TEXTCTRL5" variable="conditionsColumnWidthEdit" member="yes" />
 											<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 											<border>5</border>
 											<option>1</option>
@@ -1232,7 +1233,6 @@
 			</object>
 		</object>
 		<object class="wxFontDialog" variable="eventsEditorFontDialog" member="yes">
-			<allow_symbols>0</allow_symbols>
 			<enable_effects>0</enable_effects>
 		</object>
 	</object>


### PR DESCRIPTION
Replace some wxTextCtrl/wxChoice custom height by -1 so as the widget's height is now automatic.