### PR TITLE
Fix TileSetConfigurationEditor crashing on Windows

### DIFF
--- a/Extensions/TileMapObject/TileSetConfigurationEditor.cpp
+++ b/Extensions/TileMapObject/TileSetConfigurationEditor.cpp
@@ -69,8 +69,16 @@ void TileSetConfigurationEditor::UpdatePreviewTileSetPanel()
     previewTileSet.LoadResources(game);
     previewTileSet.Generate();
 
-    m_tileWidthSpin->SetRange(1, previewTileSet.GetSize().x);
-    m_tileHeightSpin->SetRange(1, previewTileSet.GetSize().y);
+    if(previewTileSet.GetSize().x >= 1 && previewTileSet.GetSize().y >= 1)
+    {
+        m_tileWidthSpin->SetRange(1, previewTileSet.GetSize().x);
+        m_tileHeightSpin->SetRange(1, previewTileSet.GetSize().y);
+    }
+    else
+    {
+        m_tileWidthSpin->SetRange(1, 1);
+        m_tileHeightSpin->SetRange(1, 1);
+    }
 
     m_tileSetPreviewPanel->Refresh();
 }


### PR DESCRIPTION
Setting the range of the spinbox to (1,0) (it's the case when there are no textures assigned to the tilemap) causes GDevelop to crash (and not on Linux on which I tested the TileMap recently).

A hotfix is needed as this bug prevents the use of the TileMapObject (only for Windows as the bug doesn't happen on Linux).