### PR TITLE
Use wxLaunchDefaultBrowser() in HelpProvider

### DIFF
--- a/IDE/Dialogs/HelpProvider.cpp
+++ b/IDE/Dialogs/HelpProvider.cpp
@@ -11,23 +11,5 @@ HelpProvider * HelpProvider::_singleton = NULL;
 
 void HelpProvider::OpenLink(wxString link)
 {
-    wxString mimetype = wxEmptyString;
-    if (link.StartsWith (_T("http://"))) {
-        mimetype = _T("text/html");
-    }else if (link.StartsWith (_T("ftp://"))) {
-        mimetype = _T("text/html");
-    }else if (link.StartsWith (_T("mailto:"))) {
-        mimetype = _T("message/rfc822");
-    }else{
-        return;
-    }
-    wxFileType *filetype = wxTheMimeTypesManager->GetFileTypeFromMimeType (mimetype);
-    if (filetype) {
-        wxString cmd;
-        if (filetype->GetOpenCommand (&cmd, wxFileType::MessageParameters (link))) {
-            cmd.Replace(_T("file://"), wxEmptyString);
-            ::wxExecute(cmd);
-        }
-        delete filetype;
-    }
+    wxLaunchDefaultBrowser(link);
 }


### PR DESCRIPTION
Fix web browser not launching on Windows 10. Still need to be tested under other platforms.