### PR TITLE
[v4] Replace some indexing operators by iterators

### DIFF
--- a/Core/GDCore/Events/ExpressionParser.cpp
+++ b/Core/GDCore/Events/ExpressionParser.cpp
@@ -105,9 +105,10 @@ bool ExpressionParser::ValidSyntax(const gd::String & str)
     gd::String lastNumber;
     bool numberWasParsedLast = false;
 
-    for (unsigned int parsePos = 0;parsePos<str.length();++parsePos)
+    for( auto it = str.begin(); it != str.end(); ++it )
     {
-        if ( str[parsePos] == U' ' || str[parsePos] == U'\n' )
+        char32_t currentChar = *it;
+        if ( currentChar == U' ' || currentChar == U'\n' )
         {
             if ( requestNumber )
             {
@@ -126,11 +127,11 @@ bool ExpressionParser::ValidSyntax(const gd::String & str)
                 numberWasParsedLast = true;
             }
         }
-        else if ( numerics.find(str[parsePos]) != gd::String::npos )
+        else if ( numerics.find(currentChar) != gd::String::npos )
         {
             requestNumber = false;
 
-            if ( str[parsePos] == U'.' )
+            if ( currentChar == U'.' )
             {
                 if ( !parsingNumber )
                 {
@@ -149,7 +150,7 @@ bool ExpressionParser::ValidSyntax(const gd::String & str)
                 parsingDecimalNumber = true;
             }
 
-            if ( str[parsePos] == U'e' )
+            if ( currentChar == U'e' )
             {
                 if ( parsingScientificNotationNumber )
                 {
@@ -170,9 +171,9 @@ bool ExpressionParser::ValidSyntax(const gd::String & str)
             }
 
             parsingNumber = true;
-            lastNumber += str[parsePos];
+            lastNumber += currentChar;
         }
-        else if ( str[parsePos] == U')' )
+        else if ( currentChar == U')' )
         {
             if ( requestNumber )
             {
@@ -205,14 +206,15 @@ bool ExpressionParser::ValidSyntax(const gd::String & str)
                 return false;
             }
 
-            if ( str[parsePos-1] == U'(' )
+            auto previousIt = it; --previousIt;
+            if ( *previousIt == U'(' )
             {
                 firstErrorStr = _("Empty paranthesis");
 
                 return false;
             }
         }
-        else if ( str[parsePos] == U'(' )
+        else if ( currentChar == U'(' )
         {
             if ( requestNumber )
             {
@@ -240,11 +242,11 @@ bool ExpressionParser::ValidSyntax(const gd::String & str)
             parenthesisLevel++;
             numberWasParsedLast = false;
         }
-        else if ( operators.find(str[parsePos]) != gd::String::npos )
+        else if ( operators.find(currentChar) != gd::String::npos )
         {
-            if ( str[parsePos] == U'-' && parsingNumber && parsingScientificNotationNumber )
+            if ( currentChar == U'-' && parsingNumber && parsingScientificNotationNumber )
             {
-                lastNumber += str[parsePos];
+                lastNumber += currentChar;
                 requestNumber = true;
             }
             else
@@ -265,7 +267,7 @@ bool ExpressionParser::ValidSyntax(const gd::String & str)
                     numberWasParsedLast = true;
                 }
 
-                if ( str[parsePos] != U'-' && str[parsePos] != U'+' && !numberWasParsedLast )
+                if ( currentChar != U'-' && currentChar != U'+' && !numberWasParsedLast )
                 {
                     firstErrorStr = _("Operators without any number between them");
 

--- a/Core/GDCore/Events/VariableParser.h
+++ b/Core/GDCore/Events/VariableParser.h
@@ -50,7 +50,7 @@ public:
      * \brief Default constructor
      * \param expressionPlainString The string representing the expression to be parsed.
      */
-    VariableParser(const gd::String & expressionPlainString_) : currentPosition(0), expression(expressionPlainString_) {};
+    VariableParser(const gd::String & expressionPlainString_) : currentPositionIt(), expression(expressionPlainString_) {};
     virtual ~VariableParser();
 
     /**
@@ -87,7 +87,7 @@ private:
 
     TokenType currentTokenType;
     gd::String currentToken;
-    size_t currentPosition;
+    gd::String::const_iterator currentPositionIt;
     gd::String expression;
 
     VariableParserCallbacks * callbacks;

--- a/Core/GDCore/IDE/SceneNameMangler.cpp
+++ b/Core/GDCore/IDE/SceneNameMangler.cpp
@@ -11,24 +11,33 @@
 namespace gd
 {
 
-gd::String SceneNameMangler::GetMangledSceneName(const gd::String & originalSceneName)
+gd::String SceneNameMangler::GetMangledSceneName(gd::String sceneName)
 {
-    gd::String partiallyMangledName = originalSceneName;
     static const gd::String allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     static const gd::String allowedExceptFirst = "0123456789";
 
-    for (size_t i = 0;i<partiallyMangledName.size();++i) //Replace all unallowed letters by an underscore and the Unicode code point of the letter
+    std::size_t i = 0;
+    for( auto it = sceneName.begin(); it != sceneName.end(); ++it )
     {
-        if ( allowedCharacters.find_first_of(std::u32string(1, partiallyMangledName[i])) == gd::String::npos &&
-             (allowedExceptFirst.find_first_of(std::u32string(1, partiallyMangledName[i])) == gd::String::npos ||
+        char32_t character = *it;
+        if ( allowedCharacters.find(character) == gd::String::npos &&
+             (allowedExceptFirst.find(character) == gd::String::npos ||
               i == 0) ) //Also disallow some characters to be in first position
         {
-            char32_t unallowedChar = partiallyMangledName[i];
-            partiallyMangledName.replace(i, 1, "_"+gd::String::From(unallowedChar));
+            //Replace the character by an underscore and its unicode codepoint (in base 10)
+            auto it2 = it; ++it2;
+            sceneName.replace(it, it2, "_"+gd::String::From(character));
+
+            //The iterator it may have been invalidated:
+            //re-assign it with a new iterator pointing to the same position.
+            it = sceneName.begin();
+            std::advance(it, i);
         }
+
+        ++i;
     }
 
-    return partiallyMangledName;
+    return sceneName;
 }
 
 }

--- a/Core/GDCore/IDE/SceneNameMangler.h
+++ b/Core/GDCore/IDE/SceneNameMangler.h
@@ -25,7 +25,7 @@ public:
      * by "_"+UnicodeCodePointOfTheCharacter. The first character must be a letter, otherwise it is also
      * replaced in the same manner.
      */
-    static gd::String GetMangledSceneName(const gd::String & originalSceneName);
+    static gd::String GetMangledSceneName(gd::String sceneName);
 
 private:
     SceneNameMangler() {};

--- a/Core/tests/SceneNameMangler.cpp
+++ b/Core/tests/SceneNameMangler.cpp
@@ -1,0 +1,20 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2015 Florian Rival (Florian.Rival@gmail.com). All rights reserved.
+ * This project is released under the MIT License.
+ */
+/**
+ * @file Tests covering common features of GDevelop Core.
+ */
+#include "catch.hpp"
+#include "GDCore/IDE/SceneNameMangler.h"
+
+TEST_CASE( "SceneNameMangler", "[common]" ) {
+    SECTION("Basics") {
+        REQUIRE( gd::SceneNameMangler::GetMangledSceneName(u8"TotallyCorrectSceneName") == u8"TotallyCorrectSceneName" );
+        REQUIRE( gd::SceneNameMangler::GetMangledSceneName(u8"Totally NOT CorrectSceneName") == u8"Totally_32NOT_32CorrectSceneName" );
+        REQUIRE( gd::SceneNameMangler::GetMangledSceneName(u8"Nouvelle scène") == u8"Nouvelle_32sc_232ne" );
+        REQUIRE( gd::SceneNameMangler::GetMangledSceneName(u8"A test Ԙ") == u8"A_32test_32_1304" );
+        REQUIRE( gd::SceneNameMangler::GetMangledSceneName(u8"1 Nouvelle scène") == u8"_49_32Nouvelle_32sc_232ne" );
+    }
+}

--- a/Core/tests/VariableParser.cpp
+++ b/Core/tests/VariableParser.cpp
@@ -1,0 +1,67 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2015 Florian Rival (Florian.Rival@gmail.com). All rights reserved.
+ * This project is released under the MIT License.
+ */
+/**
+ * @file Tests covering common features of GDevelop Core.
+ */
+#include "catch.hpp"
+#include "GDCore/String.h"
+#include "GDCore/Events/VariableParser.h"
+
+namespace
+{
+    class TestVariableParserCallbacks : public gd::VariableParserCallbacks
+    {
+    public:
+        TestVariableParserCallbacks(gd::String &debugStr) : VariableParserCallbacks(), debugStr(debugStr) {}
+
+        virtual void OnRootVariable(gd::String variableName)
+        {
+            debugStr += "OnRootVariable(" + variableName + ")\n";
+        }
+
+        virtual void OnChildVariable(gd::String variableName)
+        {
+            debugStr += "OnChildVariable(" + variableName + ")\n";
+        }
+
+        virtual void OnChildSubscript(gd::String stringExpression)
+        {
+            debugStr += "OnChildSubscript(" + stringExpression + ")\n";
+        }
+
+    private:
+        gd::String &debugStr;
+    };
+}
+
+TEST_CASE( "VariableParser", "[common][events]" ) {
+    SECTION("Basics") {
+        {
+            gd::String str;
+            TestVariableParserCallbacks callbacks(str);
+            gd::VariableParser parser("myVar");
+            parser.Parse(callbacks);
+
+            REQUIRE( str == "OnRootVariable(myVar)\n" );
+        }
+        {
+            gd::String str;
+            TestVariableParserCallbacks callbacks(str);
+            gd::VariableParser parser("myVar.child1.child2");
+            parser.Parse(callbacks);
+
+            REQUIRE( str == "OnRootVariable(myVar)\nOnChildVariable(child1)\nOnChildVariable(child2)\n" );
+        }
+        {
+            gd::String str;
+            TestVariableParserCallbacks callbacks(str);
+            gd::VariableParser parser("myVar[ToString(i) + \"é\"].child");
+            parser.Parse(callbacks);
+
+            REQUIRE( str == "OnRootVariable(myVar)\nOnChildSubscript(ToString(i) + \"é\")\nOnChildVariable(child)\n" );
+        }
+    }
+}


### PR DESCRIPTION
Replace some indexing operators by iterators in : 
* gd::SceneNameMangler
* gd::VariableParser
* gd::ExpressionParser::ValidSyntax only

I also added tests for the first two classes (to be sure this change doesn't cause problems).