### PR TITLE
Use point size (instead of pixel size) for events rendering

### DIFF
--- a/Binaries/Output/Release_Windows/GDIDE.exe.Manifest
+++ b/Binaries/Output/Release_Windows/GDIDE.exe.Manifest
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly
   xmlns="urn:schemas-microsoft-com:asm.v1"
-  manifestVersion="1.0">
+  manifestVersion="1.0"
+  xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
 <assemblyIdentity
     name="GDevelop IDE.App"
     processorArchitecture="x86"
     version="1.0.0.0"
     type="win32"/>
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>true</dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
 <description>Executable</description>
 <dependency>
     <dependentAssembly>

--- a/Core/GDCore/IDE/EventsRenderingHelper.cpp
+++ b/Core/GDCore/IDE/EventsRenderingHelper.cpp
@@ -53,7 +53,7 @@ wxPoint EventsRenderingHelper::DrawTextInArea(gd::String text, wxDC & dc, wxRect
     wxString displayedText;
     for (unsigned int i = 0;i<cutCount;++i)
     {
-        if (i != 0 ) point.y += 15;
+        if (i != 0) point.y += fontCharacterHeight;
 
         #if defined(LINUX)
         try
@@ -87,7 +87,7 @@ unsigned int EventsRenderingHelper::GetTextHeightInArea(const gd::String & text,
     int cutCount = ceil(static_cast<double>(text.length())/static_cast<double>(charactersInALine));
     if ( cutCount <= 0 ) cutCount = 1;
 
-    return cutCount*15;
+    return cutCount * fontCharacterHeight;
 }
 
 EventsRenderingHelper::EventsRenderingHelper() :
@@ -121,16 +121,16 @@ conditionsRectangleFill(wxBrush(wxColour(252,252,255)))
 {
     fakeBmp.Create(10,10,-1);
 
-    //Setup fonts, with "retina" support.
-    int fontSize = gd::GUIContentScaleFactor::Get() > 1 ? 15 : 9;
-    int niceFontSize = gd::GUIContentScaleFactor::Get() > 1 ? 12 : 8;
+    niceFont = wxFont(8, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+    niceFont.SetPointSize(10);
 
-    niceFont = wxFont(niceFontSize, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
     #if defined(WINDOWS)
-    SetFont(wxFont(fontSize, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, "Consolas"));
+    wxFont font(8, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, "Consolas");
     #else
-    SetFont(wxFont(fontSize, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false));
+    wxFont font(8, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false);
     #endif
+    font.SetPointSize(10);
+    SetFont(font);
 }
 
 void EventsRenderingHelper::SetFont(const wxFont & font_)
@@ -142,6 +142,7 @@ void EventsRenderingHelper::SetFont(const wxFont & font_)
     dc.SelectObject(fakeBmp);
     dc.SetFont(font);
     fontCharacterWidth = static_cast<float>(dc.GetTextExtent("abcdef").GetWidth())/6.0f;
+    fontCharacterHeight = dc.GetTextExtent("abcdef").GetHeight();
 }
 
 int EventsRenderingHelper::DrawConditionsList(gd::InstructionsList & conditions, wxDC & dc, int x, int y, int width, gd::BaseEvent * event,
@@ -175,7 +176,7 @@ int EventsRenderingHelper::DrawConditionsList(gd::InstructionsList & conditions,
         dc.SetFont( niceFont.Italic() );
         dc.DrawText( _("No conditions"), x + 2, y + 1 );
 
-        return 15;
+        return fontCharacterHeight;
     }
 
     //Draw each conditions
@@ -276,7 +277,7 @@ int EventsRenderingHelper::DrawActionsList(gd::InstructionsList & actions, wxDC 
         dc.SetFont( niceFont.Italic() );
         dc.DrawText( _("No actions"), x + 2, y + 1 );
 
-        return 15;
+        return fontCharacterHeight;
     }
 
     //Draw each actions
@@ -345,7 +346,7 @@ unsigned int EventsRenderingHelper::GetRenderedConditionsListHeight(const gd::In
     const int iconWidth = 18;
 
     if ( conditions.empty() )
-        return 15;
+        return fontCharacterHeight;
 
     for ( unsigned int j = 0;j < conditions.size();j++ )
     {
@@ -377,7 +378,7 @@ unsigned int EventsRenderingHelper::GetRenderedActionsListHeight(const gd::Instr
 
     //Draw Actions rectangle
     if ( actions.empty() )
-        return 15;
+        return fontCharacterHeight;
 
     //Draw each actions
     for ( unsigned int j = 0;j < actions.size();j++ )
@@ -428,10 +429,10 @@ int EventsRenderingHelper::DrawInstruction(gd::Instruction & instruction, const 
             {
                 dc.SetBrush(wxBrush(wxColour(255, 163, 163)));
                 dc.SetPen(wxPen(wxColour(209, 0, 0)));
-                dc.DrawRectangle(lastPos.x, lastPos.y,  parameterWidth, 15);
+                dc.DrawRectangle(lastPos.x, lastPos.y,  parameterWidth, fontCharacterHeight);
             }
 
-            areas.AddParameterArea(wxRect(lastPos.x, lastPos.y, parameterWidth,15) ,item);
+            areas.AddParameterArea(wxRect(lastPos.x, lastPos.y, parameterWidth, fontCharacterHeight) ,item);
         }
 
         dc.SetFont(font);
@@ -445,7 +446,7 @@ int EventsRenderingHelper::DrawInstruction(gd::Instruction & instruction, const 
     font.SetStyle(wxFONTSTYLE_NORMAL);
     dc.SetFont(font);
 
-    return lastPos.y-point.y+15;
+    return lastPos.y-point.y + fontCharacterHeight;
 }
 
 void EventsRenderingHelper::DrawNiceRectangle(wxDC & dc, const wxRect & rect) const

--- a/Core/GDCore/IDE/EventsRenderingHelper.h
+++ b/Core/GDCore/IDE/EventsRenderingHelper.h
@@ -194,6 +194,7 @@ private:
 
     wxFont font; ///< Fixed width font
     float fontCharacterWidth;
+    float fontCharacterHeight;
 
     wxFont niceFont;
 


### PR DESCRIPTION
Also avoid relying on hardcoded size for instructions rendering,
and add manifest to support HDPI screens on Windows.

@victorlevasseur You might want to take a look at the changes I've made as you're working on improving the events editor.

