### PR TITLE
Fix compilation output not interpreted as UTF8

### DIFF
--- a/GDCpp/GDCpp/IDE/CodeCompiler.cpp
+++ b/GDCpp/GDCpp/IDE/CodeCompiler.cpp
@@ -627,7 +627,7 @@ void CodeCompilerProcess::WatchOutput()
 
 void CodeCompilerProcess::ReadOutput()
 {
-    wxChar c;
+    char c;
 
     if(IsInputAvailable())
     {
@@ -637,12 +637,12 @@ void CodeCompilerProcess::ReadOutput()
             c = GetInputStream()->GetC();
             if ( GetInputStream()->Eof() ) break; // Check we've not just overrun
 
-            line += c;
-            if ( c==wxT('\n') ) break; // If \n, break to print the line
+            if ( c=='\n' ) break; // If \n, break to print the line
+            line.Raw() += c;
         }
         while ( IsInputAvailable() ); // Unless \n, loop to get another char
 
-        output.push_back(line); // Either there's a full line in 'line', or we've run out of input. Either way, print it
+        output.push_back(line.ReplaceInvalid()); // Either there's a full line in 'line', or we've run out of input. Either way, print it
     }
     if(IsErrorAvailable())
     {
@@ -652,12 +652,12 @@ void CodeCompilerProcess::ReadOutput()
             c = GetErrorStream()->GetC();
             if ( GetErrorStream()->Eof() ) break; // Check we've not just overrun
 
-            line += c;
-            if ( c==wxT('\n') ) break; // If \n, break to print the line
+            if ( c=='\n' ) break; // If \n, break to print the line
+            line.Raw() += c;
         }
         while ( IsErrorAvailable() );                           // Unless \n, loop to get another char
 
-        outputErrors.push_back(line); // Either there's a full line in 'line', or we've run out of input. Either way, print it
+        outputErrors.push_back(line.ReplaceInvalid()); // Either there's a full line in 'line', or we've run out of input. Either way, print it
     }
 }
 


### PR DESCRIPTION
Fix compilation output not interpreted as UTF8. Also fix the blank lines in compilation output listview. Fix #168 