### PR TITLE
Fix extra border condition of Destroy Outside Automatism

### DIFF
--- a/Extensions/DestroyOutsideAutomatism/Extension.cpp
+++ b/Extensions/DestroyOutsideAutomatism/Extension.cpp
@@ -43,7 +43,8 @@ void DeclareDestroyOutsideAutomatismExtension(gd::PlatformExtension & extension)
         .AddParameter("relationalOperator", _("Sign of the test"))
         .AddParameter("expression", _("Value to test"))
         .MarkAsAdvanced()
-        .SetFunctionName("GetExtraBorder").SetIncludeFile("DestroyOutsideAutomatism/DestroyOutsideAutomatism.h");
+        .SetFunctionName("GetExtraBorder").SetManipulatedType("number")
+        .SetIncludeFile("DestroyOutsideAutomatism/DestroyOutsideAutomatism.h");
 
     aut.AddAction("ExtraBorder",
                    _("Additional border"),


### PR DESCRIPTION
Fix extra border condition of Destroy Outside Automatism. The manipulated type wasn't declared.
Fix #171.