### PR TITLE
Fix search not working in the object editor

### DIFF
--- a/IDE/Dialogs/ObjectsEditor.cpp
+++ b/IDE/Dialogs/ObjectsEditor.cpp
@@ -443,6 +443,7 @@ void ObjectsEditor::Refresh()
     listsHelper.SetGroupExtraRendering([this](wxTreeItemId groupItem) {
         this->UpdateGroup(groupItem);
     });
+    listsHelper.SetSearchText(searchCtrl->GetValue());
     listsHelper.RefreshList(objectsList, &objectsRootItem, &groupsRootItem);
     objectsList->SetDropTarget(new ObjectsListDnd(objectsList, groupsRootItem, project, layout));
 }


### PR DESCRIPTION
The search text wasn't given to the ObjectListHelper object.
Fix #148.