### PR TITLE
GDevelop and C++ games now prefer the powerful discrete GPU

### DIFF
--- a/GDCpp/Runtime/main.cpp
+++ b/GDCpp/Runtime/main.cpp
@@ -42,6 +42,17 @@ using namespace std;
 gd::String GetCurrentWorkingDirectory();
 int DisplayMessage(const gd::String & message);
 
+#if defined(WINDOWS)
+#include <windows.h>
+//On Windows computers, tells the Nvidia/AMD driver that GDevelop works better
+//with the more powerful discrete GPU (e.g. use the Nvidia card on an Optimus computer)
+extern "C"
+{
+    __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+    __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+#endif
+
 int main( int argc, char *p_argv[] )
 {
     GDLogBanner();

--- a/IDE/Launcher/MainWin.cpp
+++ b/IDE/Launcher/MainWin.cpp
@@ -7,6 +7,14 @@
 typedef HINSTANCE Handle;
 typedef int (*EntryPointType)(int, char**);
 
+//On Windows computers, tells the Nvidia/AMD driver that GDevelop works better
+//with the more powerful discrete GPU (e.g. use the Nvidia card on an Optimus computer)
+extern "C"
+{
+    __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+    __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+
 int AbortWithMessage(const std::string & message)
 {
     std::cout << message;


### PR DESCRIPTION
GDevelop and C++ games now prefer the powerful discrete GPU on Optimus computers (Intel+Nvidia GPU) and on Switchable Graphics computers (Intel+AMD/ATI GPU).
(got this idea from a pull request in SFML repo. It may not be needed anymore because it will get integrated in SFML **2.4**).