### PR TITLE
Support for saving project in multiple files ("Folder project")

### DIFF
--- a/Core/GDCore/IDE/ProjectFileWriter.cpp
+++ b/Core/GDCore/IDE/ProjectFileWriter.cpp
@@ -1,0 +1,305 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2015 Florian Rival (Florian.Rival@gmail.com). All rights reserved.
+ * This project is released under the MIT License.
+ */
+#if !defined(EMSCRIPTEN)
+#include "ProjectFileWriter.h"
+#include <fstream>
+#include "GDCore/Serialization/Serializer.h"
+#include "GDCore/Serialization/Splitter.h"
+#include "GDCore/PlatformDefinition/Project.h"
+#include "GDCore/IDE/wxTools/RecursiveMkDir.h"
+#include "GDCore/Tools/Log.h"
+#include "GDCore/String.h"
+
+#include "GDCore/TinyXml/tinyxml.h"
+#include <SFML/System.hpp>
+#include <wx/wx.h>
+#include <wx/stdpaths.h>
+#include <wx/filename.h>
+
+
+#if defined(GD_IDE_ONLY)
+namespace {
+
+gd::String MakeFileNameSafe(gd::String str)
+{
+    static const gd::String allowedCharacters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-";
+
+    std::size_t i = 0;
+    for( auto it = str.begin(); it != str.end(); ++it )
+    {
+        char32_t character = *it;
+        if (allowedCharacters.find(character) == gd::String::npos)
+        {
+            //Replace the character by an underscore and its unicode codepoint (in base 10)
+            auto it2 = it; ++it2;
+            str.replace(it, it2, "_"+gd::String::From(character));
+
+            //The iterator it may have been invalidated:
+            //re-assign it with a new iterator pointing to the same position.
+            it = str.begin();
+            std::advance(it, i);
+        }
+
+        ++i;
+    }
+
+    return str;
+}
+
+}
+#endif
+
+
+namespace gd
+{
+
+#if defined(GD_IDE_ONLY)
+
+bool ProjectFileWriter::SaveToFile(const gd::Project & project, const gd::String & filename)
+{
+    //Serialize the whole project
+    gd::SerializerElement rootElement;
+    project.SerializeTo(rootElement);
+
+    if (project.IsFolderProject()) //Optionally split the project
+    {
+        wxString projectPath = wxFileName::FileName(filename).GetPath();
+        gd::Splitter splitter;
+        auto splitElements = splitter.Split(rootElement, {
+            "/layouts/layout",
+            "/externalEvents/externalEvents",
+            "/externalLayouts/externalLayout",
+        });
+        for (auto & element : splitElements)
+        {
+            //Create a partial XML document
+            TiXmlDocument doc;
+            doc.LinkEndChild(new TiXmlDeclaration("1.0", "UTF-8", ""));
+
+            TiXmlElement * root = new TiXmlElement("projectPartial");
+            doc.LinkEndChild(root);
+            gd::Serializer::ToXML(element.element, root);
+
+            //And write the element in it
+            gd::String filename = projectPath + element.path + "-" + MakeFileNameSafe(element.name);
+            gd::RecursiveMkDir::MkDir(wxFileName::FileName(filename).GetPath());
+            if (!doc.SaveFile(filename.ToLocale().c_str()))
+            {
+                gd::LogError( _( "Unable to save file ") + filename + _("!\nCheck that the drive has enough free space, is not write-protected and that you have read/write permissions." ) );
+                return false;
+            }
+        }
+    }
+
+    //Create the main XML document
+    TiXmlDocument doc;
+    doc.LinkEndChild(new TiXmlDeclaration( "1.0", "UTF-8", "" ));
+
+    TiXmlElement * root = new TiXmlElement( "project" );
+    doc.LinkEndChild(root);
+    gd::Serializer::ToXML(rootElement, root);
+
+    //Write XML to file
+    if ( !doc.SaveFile( filename.ToLocale().c_str() ) )
+    {
+        gd::LogError( _( "Unable to save file ") + filename + _("!\nCheck that the drive has enough free space, is not write-protected and that you have read/write permissions." ) );
+        return false;
+    }
+
+    return true;
+}
+
+bool ProjectFileWriter::SaveToJSONFile(const gd::Project & project, const gd::String & filename)
+{
+    //Serialize the whole project
+    gd::SerializerElement rootElement;
+    project.SerializeTo(rootElement);
+
+    //Write JSON to file
+    std::string str = gd::Serializer::ToJSON(rootElement);
+    std::ofstream ofs(filename.ToLocale().c_str());
+    if (!ofs.is_open())
+    {
+        gd::LogError( _( "Unable to save file ")+ filename + _("!\nCheck that the drive has enough free space, is not write-protected and that you have read/write permissions." ) );
+        return false;
+    }
+
+    ofs << str;
+    ofs.close();
+    return true;
+}
+
+bool ProjectFileWriter::LoadFromJSONFile(gd::Project & project, const gd::String & filename)
+{
+    std::ifstream ifs(filename.ToLocale().c_str());
+    if (!ifs.is_open())
+    {
+        gd::String error = _( "Unable to open the file.") + _("Make sure the file exists and that you have the right to open the file.");
+        gd::LogError(error);
+        return false;
+    }
+
+    project.SetProjectFile(filename);
+    project.SetDirty(false);
+
+    std::string str((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    gd::SerializerElement rootElement = gd::Serializer::FromJSON(str);
+    project.UnserializeFrom(rootElement);
+
+    return true;
+}
+#endif
+
+bool ProjectFileWriter::LoadFromFile(gd::Project & project, const gd::String & filename)
+{
+    //Load the XML document structure
+    TiXmlDocument doc;
+    if ( !doc.LoadFile(filename.ToLocale().c_str()) )
+    {
+        gd::String errorTinyXmlDesc = doc.ErrorDesc();
+        gd::String error = _( "Error while loading :" ) + "\n" + errorTinyXmlDesc + "\n\n" +_("Make sure the file exists and that you have the right to open the file.");
+
+        gd::LogError( error );
+        return false;
+    }
+
+    #if defined(GD_IDE_ONLY)
+    project.SetProjectFile(filename);
+    project.SetDirty(false);
+    #endif
+
+    TiXmlHandle hdl( &doc );
+    gd::SerializerElement rootElement;
+
+    ConvertANSIXMLFile(hdl, doc, filename);
+
+    //Load the root element
+    TiXmlElement * rootXmlElement = hdl.FirstChildElement("project").ToElement();
+    //Compatibility with GD <= 3.3
+    if (!rootXmlElement) rootXmlElement = hdl.FirstChildElement("Project").ToElement();
+    if (!rootXmlElement) rootXmlElement = hdl.FirstChildElement("Game").ToElement();
+    //End of compatibility code
+    gd::Serializer::FromXML(rootElement, rootXmlElement);
+
+    //Unsplit the project
+    #if defined(GD_IDE_ONLY)
+    wxString projectPath = wxFileName::FileName(filename).GetPath();
+    gd::Splitter splitter;
+    splitter.Unsplit(rootElement, [&projectPath](gd::String path, gd::String name) {
+        TiXmlDocument doc;
+        gd::SerializerElement rootElement;
+
+        gd::String filename = projectPath + path + "-" + MakeFileNameSafe(name);
+        if (!doc.LoadFile(filename.ToLocale().c_str()))
+        {
+            gd::String errorTinyXmlDesc = doc.ErrorDesc();
+            gd::String error = _( "Error while loading :" ) + "\n" + errorTinyXmlDesc + "\n\n" +_("Make sure the file exists and that you have the right to open the file.");
+
+            gd::LogError(error);
+            return rootElement;
+        }
+
+        TiXmlHandle hdl( &doc );
+        gd::Serializer::FromXML(rootElement, hdl.FirstChildElement().ToElement());
+        return rootElement;
+    });
+    #endif
+
+    //Unserialize the whole project
+    project.UnserializeFrom(rootElement);
+
+    return true;
+}
+
+void ProjectFileWriter::ConvertANSIXMLFile(TiXmlHandle & hdl, TiXmlDocument & doc, const gd::String & filename)
+{
+    //COMPATIBILITY CODE WITH ANSI GDEVELOP ( <= 3.6.83 )
+    #if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI) //There should not be any problem with encoding in compiled games
+    //Get the declaration element
+    TiXmlDeclaration * declXmlElement = hdl.FirstChild().ToNode()->ToDeclaration();
+    if(strcmp(declXmlElement->Encoding(), "UTF-8") != 0)
+    {
+        std::cout << "This is a legacy GDevelop project, checking if it is already encoded in UTF8..." << std::endl;
+
+        //The document has not been converted for/saved by GDevelop UTF8, now, try to determine if the project
+        //was saved on Linux and is already in UTF8 or on Windows and still in the locale encoding.
+        bool isNotInUTF8 = false;
+        std::ifstream docStream;
+        docStream.open(filename.ToLocale(), std::ios::in);
+
+        while( !docStream.eof() )
+        {
+            std::string docLine;
+            std::getline(docStream, docLine);
+
+            if( !gd::String::FromUTF8(docLine).IsValid() )
+            {
+                //The file contains an invalid character,
+                //the file has been saved by the legacy ANSI Windows version of GDevelop
+                // -> stop reading the file and start converting from the locale to UTF8
+                isNotInUTF8 = true;
+                break;
+            }
+        }
+
+        docStream.close();
+
+        //If the file is not encoded in UTF8, encode it
+        if(isNotInUTF8)
+        {
+            std::cout << "The project file is not encoded in UTF8, conversion started... ";
+
+            //Create a temporary file
+            #if defined(WINDOWS)
+            //Convert using the current locale
+            wxString tmpFileName = wxFileName::CreateTempFileName("");
+            std::ofstream outStream;
+            docStream.open(filename.ToLocale(), std::ios::in);
+
+            outStream.open(tmpFileName, std::ios::out | std::ios::trunc);
+
+            while( !docStream.eof() )
+            {
+                std::string docLine;
+                std::string convLine;
+
+                std::getline(docStream, docLine);
+                sf::Utf8::fromAnsi(docLine.begin(), docLine.end(), std::back_inserter(convLine));
+
+                outStream << convLine << '\n';
+            }
+
+            outStream.close();
+            docStream.close();
+
+            #else
+            //Convert using iconv command tool
+            wxString tmpFileName = wxStandardPaths::Get().GetUserConfigDir() + "/gdevelop_converted_project";
+            gd::String iconvCall = gd::String("iconv -f LATIN1 -t UTF-8 \"") + filename.ToLocale() + "\" ";
+            #if defined(MACOS)
+            iconvCall += "> \"" + tmpFileName + "\"";
+            #else
+            iconvCall += "-o \"" + tmpFileName + "\"";
+            #endif
+
+            std::cout << "Executing " << iconvCall  << std::endl;
+            system(iconvCall.c_str());
+            #endif
+
+            //Reload the converted file, forcing UTF8 encoding as the XML header is false (still written ISO-8859-1)
+            doc.LoadFile(std::string(tmpFileName).c_str(), TIXML_ENCODING_UTF8);
+
+            std::cout << "Finished." << std::endl;
+            gd::LogMessage(_("Your project has been upgraded to be used with GDevelop 4.\nIf you save it, you won't be able to open it with an older version: please do a backup of your project file if you want to go back to GDevelop 3."));
+        }
+    }
+    #endif
+    //END OF COMPATIBILITY CODE
+}
+
+}
+
+#endif

--- a/Core/GDCore/IDE/ProjectFileWriter.cpp
+++ b/Core/GDCore/IDE/ProjectFileWriter.cpp
@@ -6,6 +6,7 @@
 #if !defined(EMSCRIPTEN)
 #include "ProjectFileWriter.h"
 #include <fstream>
+#include "GDCore/Tools/Localization.h"
 #include "GDCore/Serialization/Serializer.h"
 #include "GDCore/Serialization/Splitter.h"
 #include "GDCore/PlatformDefinition/Project.h"
@@ -15,12 +16,13 @@
 
 #include "GDCore/TinyXml/tinyxml.h"
 #include <SFML/System.hpp>
+#if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
 #include <wx/wx.h>
 #include <wx/stdpaths.h>
 #include <wx/filename.h>
+#endif
 
-
-#if defined(GD_IDE_ONLY)
+#if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
 namespace {
 
 gd::String MakeFileNameSafe(gd::String str)
@@ -64,6 +66,7 @@ bool ProjectFileWriter::SaveToFile(const gd::Project & project, const gd::String
     gd::SerializerElement rootElement;
     project.SerializeTo(rootElement);
 
+    #if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
     if (project.IsFolderProject()) //Optionally split the project
     {
         wxString projectPath = wxFileName::FileName(filename).GetPath();
@@ -93,6 +96,7 @@ bool ProjectFileWriter::SaveToFile(const gd::Project & project, const gd::String
             }
         }
     }
+    #endif
 
     //Create the main XML document
     TiXmlDocument doc;
@@ -185,7 +189,7 @@ bool ProjectFileWriter::LoadFromFile(gd::Project & project, const gd::String & f
     gd::Serializer::FromXML(rootElement, rootXmlElement);
 
     //Unsplit the project
-    #if defined(GD_IDE_ONLY)
+    #if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
     wxString projectPath = wxFileName::FileName(filename).GetPath();
     gd::Splitter splitter;
     splitter.Unsplit(rootElement, [&projectPath](gd::String path, gd::String name) {

--- a/Core/GDCore/IDE/ProjectFileWriter.h
+++ b/Core/GDCore/IDE/ProjectFileWriter.h
@@ -1,0 +1,66 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2015 Florian Rival (Florian.Rival@gmail.com). All rights reserved.
+ * This project is released under the MIT License.
+ */
+#if !defined(EMSCRIPTEN)
+#ifndef GDCORE_PROJECTFILEWRITER_H
+#define GDCORE_PROJECTFILEWRITER_H
+#include "GDCore/String.h"
+namespace gd { class Project; }
+class TiXmlHandle;
+class TiXmlDocument;
+
+namespace gd
+{
+
+/**
+ * \brief Read and write project to file(s) using wxWidgets.
+ *
+ * \note gd::Project provides you with gd::Project::SerializeTo
+ * and gd::Project::UnserializeFrom member functions (like other classes
+ * that are part of a project). This class provides tool functions
+ * that write the "real" project file.
+ */
+class ProjectFileWriter
+{
+public:
+
+    #if defined(GD_IDE_ONLY)
+    /**
+     * \brief Save the project to a XML file.
+     *
+     * "Dirty" flag is set to false when save is done.
+     */
+    static bool SaveToFile(const gd::Project & project, const gd::String & filename);
+
+    /**
+     * \brief Save the project to a JSON file.
+     *
+     * "Dirty" flag is set to false when save is done.
+     */
+    static bool SaveToJSONFile(const gd::Project & project, const gd::String & filename);
+
+    /**
+     * \brief Load the project from a JSON file.
+     */
+    static bool LoadFromJSONFile(gd::Project & project, const gd::String & filename);
+    #endif
+
+    /**
+     * \brief Load the project from a XML file.
+     */
+    static bool LoadFromFile(gd::Project & project, const gd::String & filename);
+private:
+
+    /**
+     * \brief Check if the current TinyXML file (represented by hdl and doc) is in UTF8.
+     * If not, the file is converted to UTF8 and reopened.
+     */
+    static void ConvertANSIXMLFile(TiXmlHandle & hdl, TiXmlDocument & doc, const gd::String & filename);
+};
+
+}
+
+#endif // GDCORE_PROJECTFILEWRITER_H
+#endif

--- a/Core/GDCore/PlatformDefinition/Project.h
+++ b/Core/GDCore/PlatformDefinition/Project.h
@@ -73,7 +73,7 @@ public:
      * \brief Get project author name.
      */
     const gd::String & GetAuthor() const { return author; }
-    
+
     /**
      * \brief Change project package name.
      */
@@ -94,6 +94,18 @@ public:
      * \see gd::Project::SetProjectFile
      */
     const gd::String & GetProjectFile() const { return gameFile; }
+
+    /**
+     * Set that the project should be saved as a folder project.
+     * \param enable True to flag as a folder project, false to set it as single file project.
+     */
+    void SetFolderProject(bool enable = true) { folderProject = enable; }
+
+    /**
+     * Check if the project is saved as a folder project.
+     * \see gd::Project::SetFolderProject
+     */
+    bool IsFolderProject() const { return folderProject; }
 
     /**
      * Called when project file has changed.
@@ -358,46 +370,12 @@ public:
 
     ///@}
 
-    /** \name Saving and loading
-     * Members functions related to saving and loading the project.
-     */
-    ///@{
-    #if !defined(EMSCRIPTEN)
-    /**
-     * \brief Load the project from a XML file.
-     */
-    bool LoadFromFile(const gd::String & filename);
-
-    #if defined(GD_IDE_ONLY)
-    /**
-     * \brief Load the project from a JSON file.
-     */
-    bool LoadFromJSONFile(const gd::String & filename);
-    #endif
-    #endif
-
     /**
      * \brief Unserialize the project from an element.
      */
     void UnserializeFrom(const SerializerElement & element);
 
     #if defined(GD_IDE_ONLY)
-    #if !defined(EMSCRIPTEN)
-    /**
-     * \brief Save the project to a XML file.
-     *
-     * "Dirty" flag is set to false when save is done.
-     */
-    bool SaveToFile(const gd::String & filename);
-
-    /**
-     * \brief Save the project to a JSON file.
-     *
-     * "Dirty" flag is set to false when save is done.
-     */
-    bool SaveToJSONFile(const gd::String & filename);
-    #endif
-
     /**
      * \brief Called to serialize the project to a TiXmlElement.
      *
@@ -407,13 +385,13 @@ public:
 
     /**
      * \brief Return true if the project is marked as being modified (The IDE or application
-     * using the project should ask for save the project if the project is closed).
+     * using the project should ask to save the project if the project is closed).
      */
     bool IsDirty() { return dirty; }
 
     /**
      * \brief Mark the project as being modified (The IDE or application
-     * using the project should ask for save the project if the project is closed).
+     * using the project should ask to save the project if the project is closed).
      */
     void SetDirty(bool enable = true) { dirty = enable; }
 
@@ -427,7 +405,6 @@ public:
      */
     unsigned int GetLastSaveGDMinorVersion() { return GDMinorVersion; };
     #endif
-    ///@}
 
     /** \name External events management
      * Members functions related to external events management.
@@ -759,6 +736,7 @@ private:
     std::vector<ObjectGroup>                            objectGroups; ///< Global objects groups
     gd::String                                         author; ///< Game author name
     gd::String                                         packageName; ///< Game package name
+    bool                                                folderProject; ///< True if folder project, false if single file project.
     gd::String                                         gameFile; ///< File of the game
     gd::String                                         latestCompilationDirectory; ///< File of the game
     gd::Platform*                                       currentPlatform; ///< The platform being used to edit the project.

--- a/Core/GDCore/Serialization/Splitter.cpp
+++ b/Core/GDCore/Serialization/Splitter.cpp
@@ -1,0 +1,74 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2015 Florian Rival (Florian.Rival@gmail.com). All rights reserved.
+ * This project is released under the MIT License.
+ */
+
+#include "Splitter.h"
+#include "GDCore/Serialization/SerializerElement.h"
+#include "GDCore/Serialization/Serializer.h"
+#include "GDCore/String.h"
+#include "GDCore/CommonTools.h"
+#include <iostream>
+#include <string>
+#include <vector>
+#include <utility>
+#include <iomanip>
+
+namespace gd
+{
+
+std::vector<Splitter::SplitElement> Splitter::Split(SerializerElement & element,
+	const std::set<gd::String> & tags,
+	gd::String path)
+{
+	std::vector<Splitter::SplitElement> elements;
+	for(auto & child : element.GetAllChildren())
+	{
+		auto & childElement = child.second;
+		gd::String ref = path + pathSeparator + child.first;
+
+		if (tags.find(ref) != tags.end())
+		{
+			gd::String refName = childElement->GetStringAttribute(nameAttribute);
+			SplitElement splitElement = {
+				ref,
+				refName,
+				*childElement
+			};
+			elements.push_back(splitElement);
+
+			SerializerElement refElement;
+			refElement.SetAttribute("referenceTo", ref);
+			refElement.SetAttribute("name", refName);
+			*childElement = refElement;
+		}
+		else
+		{
+			auto newElements = Split(*childElement, tags, ref);
+			elements.insert(elements.end(), newElements.begin(), newElements.end());
+		}
+	}
+
+	return elements;
+}
+
+void Splitter::Unsplit(SerializerElement & element,
+    std::function<SerializerElement(gd::String path, gd::String name)> cb)
+{
+	for(auto & child : element.GetAllChildren())
+	{
+		auto & childElement = child.second;
+		if ((childElement->HasAttribute("referenceTo") && childElement->HasAttribute("name")) ||
+			(childElement->HasChild("referenceTo") && childElement->HasChild("name")))
+		{
+			SerializerElement newElement = cb(childElement->GetStringAttribute("referenceTo"),
+				childElement->GetStringAttribute("name"));
+			*childElement = newElement;
+		}
+
+		Unsplit(*childElement, cb);
+	}
+}
+
+}

--- a/Core/GDCore/Serialization/Splitter.h
+++ b/Core/GDCore/Serialization/Splitter.h
@@ -1,0 +1,65 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2015 Florian Rival (Florian.Rival@gmail.com). All rights reserved.
+ * This project is released under the MIT License.
+ */
+
+#ifndef GDCORE_SPLITTER_H
+#define GDCORE_SPLITTER_H
+#include <functional>
+#include <vector>
+#include <set>
+#include "GDCore/String.h"
+#include "GDCore/Serialization/SerializerElement.h"
+
+namespace gd
+{
+
+/**
+ * \brief Split a tree of SerializerElement according to tags name.
+ * It replaces cut subtree by a SerializerElement containing a reference to the
+ * cut subtree.
+ */
+class GD_CORE_API Splitter
+{
+public:
+    virtual ~Splitter() {};
+    Splitter(gd::String pathSeparator_ = "/", gd::String nameAttribute_ = "name") :
+        pathSeparator(pathSeparator_),
+        nameAttribute(nameAttribute_)
+    {};
+
+    /**
+     * \brief Represents an element as returned by gd::Splitter:Split
+     */
+    struct SplitElement {
+        gd::String path;
+        gd::String name;
+        SerializerElement element;
+    };
+
+    /**
+     * \brief Split the tree of SerializerElement into a vector of subtrees,
+     * replacing the cut subtrees by a placeholder (a new SerializerElement containing attributes
+     * referencing the subtree).
+     */
+	std::vector<SplitElement> Split(SerializerElement & element,
+        const std::set<gd::String> & tags,
+        gd::String path = "");
+
+    /**
+     * \brief Browse the tree of SerializerElement, calling the callback function
+     * each time a SerializerElement with a reference to a subtree is found.
+     * \param cb The callback. It must return the SerializerElement containing the
+     * subtree that will be used to replace the placeholder SerializerElement.
+     */
+	void Unsplit(SerializerElement & element,
+        std::function<SerializerElement(gd::String path, gd::String name)> cb);
+private:
+    gd::String pathSeparator;
+    gd::String nameAttribute;
+};
+
+}
+
+#endif

--- a/Core/tests/Serializer.cpp
+++ b/Core/tests/Serializer.cpp
@@ -18,6 +18,7 @@
 #include "GDCore/Events/Builtin/StandardEvent.h"
 #include "GDCore/Events/Serialization.h"
 #include "GDCore/Serialization/Serializer.h"
+#include "GDCore/Serialization/Splitter.h"
 
 using namespace gd;
 
@@ -42,5 +43,64 @@ TEST_CASE( "Serializer", "[common]" ) {
 
         std::string json = Serializer::ToJSON(element);
         REQUIRE(json == originalJSON);
+    }
+
+    SECTION("Splitter") {
+        SECTION("Split elements") {
+            //Create some elements
+            SerializerElement root;
+            root.AddChild("a").AddChild("a1").SetValue(gd::String("hello"));
+            root.AddChild("b").AddChild("b1").SetValue(gd::String("world"));
+            root.AddChild("c").AddChild("c1").SetValue(3);
+            auto & layouts = root.AddChild("layouts");
+            layouts.ConsiderAsArrayOf("layout");
+            for(auto i = 0;i<5;++i) {
+                auto & layout = layouts.AddChild("layout");
+                layout.SetAttribute("name", "layout" + gd::String::From(i));
+                layout.AddChild("child").SetValue(42);
+            }
+
+            //And split them
+            gd::Splitter splitter;
+            auto splitElements = splitter.Split(root, {"/a/a1", "/layouts/layout"});
+            REQUIRE(splitElements.size() == 6);
+            REQUIRE(splitElements[0].path == "/a/a1");
+            REQUIRE(splitElements[1].path == "/layouts/layout");
+            REQUIRE(splitElements[1].name == "layout0");
+            REQUIRE(Serializer::ToJSON(splitElements[0].element) ==
+                "\"hello\""
+            );
+            REQUIRE(Serializer::ToJSON(splitElements[1].element) ==
+                "{\"name\": \"layout0\",\"child\": 42}"
+            );
+            REQUIRE(Serializer::ToJSON(root) ==
+                "{\"a\": {\"a1\": {\"name\": \"\",\"referenceTo\": \"/a/a1\"}},\"b\": {\"b1\": \"world\"},\"c\": {\"c1\": 3},\"layouts\": [{\"name\": \"layout0\",\"referenceTo\": \"/layouts/layout\"},{\"name\": \"layout1\",\"referenceTo\": \"/layouts/layout\"},{\"name\": \"layout2\",\"referenceTo\": \"/layouts/layout\"},{\"name\": \"layout3\",\"referenceTo\": \"/layouts/layout\"},{\"name\": \"layout4\",\"referenceTo\": \"/layouts/layout\"}]}"
+            );
+        }
+        SECTION("Unsplit elements") {
+            //Get a JSON with elements being reference to split elements
+            std::string originalJSON = "{\"a\": {\"a1\": {\"name\": \"\",\"referenceTo\": \"/a/a1\"}},\"b\": {\"b1\": \"world\"},\"c\": {\"c1\": 3},\"layouts\": [{\"name\": \"layout0\",\"referenceTo\": \"/layouts/layout\"},{\"name\": \"layout1\",\"referenceTo\": \"/layouts/layout\"},{\"name\": \"layout2\",\"referenceTo\": \"/layouts/layout\"},{\"name\": \"layout3\",\"referenceTo\": \"/layouts/layout\"},{\"name\": \"layout4\",\"referenceTo\": \"/layouts/layout\"}]}";
+            SerializerElement root = Serializer::FromJSON(originalJSON);
+
+            gd::Splitter splitter;
+            splitter.Unsplit(root, [](gd::String path, gd::String name) {
+                //Return new elements to replace the split elements
+                SerializerElement element;
+                element.SetAttribute("path", path);
+                element.SetAttribute("name", name);
+                element.AddChild("child").SetValue(name == "" ? 41 : 42);
+
+                return element;
+            });
+
+            //Check that we can now get elements, with all split elements
+            //replaced by the new ones.
+            root.GetChild("layouts").ConsiderAsArrayOf("layout");
+            REQUIRE(root.GetChild("a").GetChild("a1").GetStringAttribute("name") == "");
+            REQUIRE(root.GetChild("a").GetChild("a1").GetChild("child").GetValue().GetInt() == 41);
+            REQUIRE(root.GetChild("layouts").GetChild(0).GetStringAttribute("path") == "/layouts/layout");
+            REQUIRE(root.GetChild("layouts").GetChild(1).GetStringAttribute("name") == "layout1");
+            REQUIRE(root.GetChild("layouts").GetChild(2).GetChild("child").GetValue().GetInt() == 42);
+        }
     }
 }

--- a/GDCpp/GDCpp/IDE/FullProjectCompiler.cpp
+++ b/GDCpp/GDCpp/IDE/FullProjectCompiler.cpp
@@ -24,6 +24,7 @@
 #include "GDCore/PlatformDefinition/ExternalEvents.h"
 #include "GDCore/Tools/Localization.h"
 #include "GDCore/IDE/AbstractFileSystem.h"
+#include "GDCore/IDE/ProjectFileWriter.h"
 #include "GDCpp/IDE/CodeCompiler.h"
 #include "GDCpp/Events/CodeCompilationHelpers.h"
 #include "GDCpp/DatFile.h"
@@ -279,7 +280,7 @@ void FullProjectCompiler::LaunchProjectCompilation()
     diagnosticManager.OnMessage(_( "Copying resources..." ), _( "Step 1 out of 3" ));
     gd::Project strippedProject = game;
     gd::ProjectStripper::StripProject(strippedProject);
-    strippedProject.SaveToFile( tempDir + "/GDProjectSrcFile.gdg" );
+    gd::ProjectFileWriter::SaveToFile(strippedProject, tempDir + "/GDProjectSrcFile.gdg");
     diagnosticManager.OnPercentUpdate(80);
 
     gd::SafeYield::Do();

--- a/IDE/GDevelopIDEApp.cpp
+++ b/IDE/GDevelopIDEApp.cpp
@@ -41,6 +41,7 @@
 #include "GDCore/Tools/VersionWrapper.h"
 #include "GDCore/Tools/Locale/LocaleManager.h"
 #include "GDCore/IDE/SkinHelper.h"
+#include "GDCore/IDE/ProjectFileWriter.h"
 #include "GDCore/IDE/Analytics/AnalyticsSender.h"
 #include "GDCore/IDE/wxTools/GUIContentScaleFactor.h"
 #include "GDCore/IDE/Clipboard.h"
@@ -461,7 +462,7 @@ void GDevelopIDEApp::OnUnhandledException()
     try
     {
         for (std::size_t i = 0;i<mainEditor->games.size();++i)
-            mainEditor->games[i]->SaveToFile("gameDump"+gd::String::From(i)+".gdg");
+            gd::ProjectFileWriter::SaveToFile(*mainEditor->games[i], "gameDump"+gd::String::From(i)+".gdg");
     }
     catch(...)
     {
@@ -484,7 +485,7 @@ bool GDevelopIDEApp::OnExceptionInMainLoop()
     try
     {
         for (std::size_t i = 0;i<mainEditor->games.size();++i)
-            mainEditor->games[i]->SaveToFile("gameDump"+gd::String::From(i)+".gdg");
+            gd::ProjectFileWriter::SaveToFile(*mainEditor->games[i], "gameDump"+gd::String::From(i)+".gdg");
     }
     catch(...)
     {

--- a/IDE/IDE.layout
+++ b/IDE/IDE.layout
@@ -1,24 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <CodeBlocks_layout_file>
 	<ActiveTarget name="Linux - Release - Edittime" />
-	<File name="SearchEvents.h" open="0" top="0" tabpos="92" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ChoiceJoyAxis.h" open="0" top="0" tabpos="58" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="881" topLine="27" />
+			<Cursor1 position="1448" topLine="21" />
 		</Cursor>
 	</File>
-	<File name="Dialogs\NewProjectDialog.h" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/include/wx/stedit/pairarr.h" open="0" top="0" tabpos="46" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="3187" topLine="55" />
-		</Cursor>
-	</File>
-	<File name="ConsoleManager.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="440" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stemenum.cpp" open="0" top="0" tabpos="24" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="47645" topLine="1116" />
+			<Cursor1 position="17051" topLine="279" />
 		</Cursor>
 	</File>
 	<File name="GeneratePassword.h" open="0" top="0" tabpos="183" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -26,59 +16,39 @@
 			<Cursor1 position="1596" topLine="6" />
 		</Cursor>
 	</File>
-	<File name="CodeEditor.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ExtensionBugReportDlg.h" open="0" top="0" tabpos="151" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="356" topLine="0" />
+			<Cursor1 position="1705" topLine="4" />
 		</Cursor>
 	</File>
-	<File name="SigneModification.cpp" open="0" top="0" tabpos="199" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="EventsEditor.cpp" open="0" top="0" tabpos="43" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1802" topLine="0" />
+			<Cursor1 position="1223" topLine="36" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\include\wx\stedit\pairarr.h" open="0" top="0" tabpos="46" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Credits.h" open="0" top="0" tabpos="136" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="17051" topLine="279" />
+			<Cursor1 position="3690" topLine="66" />
 		</Cursor>
 	</File>
-	<File name="Dialogs\ObjectsEditor.cpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="CompilationChecker.h" open="0" top="0" tabpos="105" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="59746" topLine="1293" />
+			<Cursor1 position="402" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="ChoixCondition.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="InitialPositionBrowserDlg.cpp" open="0" top="0" tabpos="57" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="26395" topLine="454" />
+			<Cursor1 position="2995" topLine="106" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\src\stenoteb.cpp" open="0" top="0" tabpos="122" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Dialogs/LayoutEditorPropertiesPnl.h" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="40666" topLine="1189" />
+			<Cursor1 position="2033" topLine="39" />
 		</Cursor>
 	</File>
-	<File name="ImportImage.cpp" open="0" top="0" tabpos="91" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/src/stedlgs_wdr.cpp" open="0" top="0" tabpos="11" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="32697" topLine="503" />
-		</Cursor>
-	</File>
-	<File name="BuildMessagesPnl.h" open="0" top="0" tabpos="47" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="333" topLine="3" />
-		</Cursor>
-	</File>
-	<File name="SigneModification.h" open="0" top="0" tabpos="97" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="698" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\setup.h" open="0" top="0" tabpos="153" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4326" topLine="39" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\ObjectsEditor.h" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="5863" topLine="163" />
+			<Cursor1 position="68838" topLine="1487" />
 		</Cursor>
 	</File>
 	<File name="ChoixClavier.cpp" open="0" top="0" tabpos="177" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -86,14 +56,314 @@
 			<Cursor1 position="6450" topLine="145" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\src\steopts.cpp" open="0" top="0" tabpos="28" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/src/stenoteb.cpp" open="0" top="0" tabpos="122" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="40666" topLine="1189" />
+		</Cursor>
+	</File>
+	<File name="Game_Develop_EditorApp.cpp" open="0" top="0" tabpos="62" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1374" topLine="33" />
+		</Cursor>
+	</File>
+	<File name="MainFrame.cpp" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="23875" topLine="406" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/HtmlViewerPnl.cpp" open="0" top="0" tabpos="63" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1119" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="ChoiceJoyAxis.cpp" open="0" top="0" tabpos="26" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="5395" topLine="96" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/HtmlViewerPnl.h" open="0" top="0" tabpos="170" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="660" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stedefs.h" open="0" top="0" tabpos="161" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="42650" topLine="883" />
+		</Cursor>
+	</File>
+	<File name="resource.rc" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="976" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="SigneTest.h" open="0" top="0" tabpos="102" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="626" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="MainFichier.cpp" open="0" top="0" tabpos="51" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="843" topLine="27" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stedit.h" open="0" top="0" tabpos="61" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="43775" topLine="784" />
+		</Cursor>
+	</File>
+	<File name="ChoixTemplateEvent.cpp" open="0" top="0" tabpos="32" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="512" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="EventsEditor.h" open="0" top="0" tabpos="27" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="11270" topLine="240" />
+		</Cursor>
+	</File>
+	<File name="DndTextObjectsEditor.h" open="0" top="0" tabpos="191" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="529" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="SearchEvents.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="259" topLine="11" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/steshell.cpp" open="0" top="0" tabpos="132" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="12542" topLine="344" />
+		</Cursor>
+	</File>
+	<File name="RecentList.cpp" open="0" top="0" tabpos="60" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="0" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="MainOutils.cpp" open="0" top="0" tabpos="120" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1439" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="MainFrame.h" open="0" top="0" tabpos="52" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="836" topLine="39" />
+		</Cursor>
+	</File>
+	<File name="SigneModification.cpp" open="0" top="0" tabpos="199" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1802" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="EditorScene.cpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="11841" topLine="220" />
+		</Cursor>
+	</File>
+	<File name="EditObjectGroup.cpp" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="377" topLine="17" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stedit.cpp" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="138814" topLine="4028" />
+		</Cursor>
+	</File>
+	<File name="RecentList.h" open="0" top="0" tabpos="167" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="78" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="CreateTemplate.h" open="0" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="427" topLine="19" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/steprint.cpp" open="0" top="0" tabpos="33" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="17183" topLine="386" />
+		</Cursor>
+	</File>
+	<File name="CompilationChecker.cpp" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="258" topLine="9" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/steframe.h" open="0" top="0" tabpos="73" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="13034" topLine="221" />
+		</Cursor>
+	</File>
+	<File name="LogFileManager.cpp" open="0" top="0" tabpos="101" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1710" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stefindr.h" open="0" top="0" tabpos="175" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="12595" topLine="239" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stedlgs.h" open="0" top="0" tabpos="168" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="20498" topLine="467" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stelangs.h" open="0" top="0" tabpos="180" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="14820" topLine="234" />
+		</Cursor>
+	</File>
+	<File name="BuildProgressPnl.cpp" open="0" top="0" tabpos="48" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="336" topLine="16" />
+		</Cursor>
+	</File>
+	<File name="EditPropScene.cpp" open="0" top="0" tabpos="109" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="12028" topLine="186" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/LayoutEditorPropertiesPnl.cpp" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="4654" topLine="134" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stemenum.cpp" open="0" top="0" tabpos="24" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="47645" topLine="1116" />
+		</Cursor>
+	</File>
+	<File name="ChoixTemplateEvent.h" open="0" top="0" tabpos="45" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="340" topLine="15" />
+		</Cursor>
+	</File>
+	<File name="CheckMAJ.h" open="0" top="0" tabpos="176" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="683" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Preferences.cpp" open="0" top="0" tabpos="12" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="90793" topLine="1729" />
+		</Cursor>
+	</File>
+	<File name="GeneratePassword.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="230" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stestyls.h" open="0" top="0" tabpos="200" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="20832" topLine="285" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/ObjectsEditor.cpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="59746" topLine="1293" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stesplit.h" open="0" top="0" tabpos="93" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="6286" topLine="82" />
+		</Cursor>
+	</File>
+	<File name="LogFileManager.h" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1425" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/steprefs.cpp" open="0" top="0" tabpos="126" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="34424" topLine="626" />
+		</Cursor>
+	</File>
+	<File name="TemplateEvents.cpp" open="0" top="0" tabpos="19" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="755" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="BugReport.cpp" open="0" top="0" tabpos="41" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="14870" topLine="255" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stedlgs_wdr.h" open="0" top="0" tabpos="108" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="8672" topLine="132" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stedlgs.cpp" open="0" top="0" tabpos="103" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="85584" topLine="2085" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/steopts.cpp" open="0" top="0" tabpos="28" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="16195" topLine="334" />
 		</Cursor>
 	</File>
-	<File name="BugReport.h" open="0" top="0" tabpos="147" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="BuildProgressPnl.h" open="0" top="0" tabpos="163" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="2533" topLine="34" />
+			<Cursor1 position="1449" topLine="2" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/setup.h" open="0" top="0" tabpos="153" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="4326" topLine="39" />
+		</Cursor>
+	</File>
+	<File name="TrueOrFalse.cpp" open="0" top="0" tabpos="23" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3297" topLine="17" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/stemenum.h" open="0" top="0" tabpos="78" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="21670" topLine="342" />
+		</Cursor>
+	</File>
+	<File name="ConsoleManager.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="440" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="ChoixClavier.h" open="0" top="0" tabpos="75" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1102" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stelangs.cpp" open="0" top="0" tabpos="118" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="310918" topLine="5459" />
+		</Cursor>
+	</File>
+	<File name="mp3ogg.cpp" open="0" top="0" tabpos="32" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="8503" topLine="108" />
+		</Cursor>
+	</File>
+	<File name="wxsmith/ProjectPropertiesPnl.wxs" open="0" top="0" tabpos="144" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="923" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="EditPropScene.h" open="0" top="0" tabpos="17" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="515" topLine="22" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/ExternalLayoutEditor.cpp" open="0" top="0" tabpos="15" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="12034" topLine="213" />
+		</Cursor>
+	</File>
+	<File name="ExternalEventsEditor.h" open="0" top="0" tabpos="28" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="332" topLine="13" />
 		</Cursor>
 	</File>
 	<File name="SigneTest.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -101,12 +371,77 @@
 			<Cursor1 position="1724" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\include\wx\stedit\setup0.h" open="0" top="0" tabpos="54" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="DndTextObjectsEditor.cpp" open="0" top="0" tabpos="84" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="4326" topLine="39" />
+			<Cursor1 position="336" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="Dialogs\ProjectPropertiesPnl.cpp" open="0" top="0" tabpos="74" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Preferences.h" open="0" top="0" tabpos="143" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="7264" topLine="205" />
+		</Cursor>
+	</File>
+	<File name="CodeEditor.cpp" open="0" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="14044" topLine="292" />
+		</Cursor>
+	</File>
+	<File name="ExtensionBugReportDlg.cpp" open="0" top="0" tabpos="44" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="7648" topLine="73" />
+		</Cursor>
+	</File>
+	<File name="SigneModification.h" open="0" top="0" tabpos="97" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="698" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="ProjectManager.h" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="7477" topLine="195" />
+		</Cursor>
+	</File>
+	<File name="ProjectManager.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="90453" topLine="2007" />
+		</Cursor>
+	</File>
+	<File name="InitialPositionBrowserDlg.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1496" topLine="19" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/ExternalLayoutEditor.h" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="2941" topLine="83" />
+		</Cursor>
+	</File>
+	<File name="StartHerePage.h" open="0" top="0" tabpos="112" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="4540" topLine="74" />
+		</Cursor>
+	</File>
+	<File name="BuildMessagesPnl.h" open="0" top="0" tabpos="47" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="333" topLine="3" />
+		</Cursor>
+	</File>
+	<File name="StartHerePage.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="25420" topLine="404" />
+		</Cursor>
+	</File>
+	<File name="BuildToolsPnl.cpp" open="0" top="0" tabpos="49" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="225" topLine="9" />
+		</Cursor>
+	</File>
+	<File name="SplashScreen.h" open="0" top="0" tabpos="107" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="897" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/ProjectPropertiesPnl.cpp" open="0" top="0" tabpos="74" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="2027" topLine="0" />
 		</Cursor>
@@ -116,92 +451,52 @@
 			<Cursor1 position="4907" topLine="60" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\src\steprefs.cpp" open="0" top="0" tabpos="126" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ChoixAction.cpp" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="34424" topLine="626" />
+			<Cursor1 position="24373" topLine="439" />
 		</Cursor>
 	</File>
-	<File name="ChoixAction.h" open="0" top="0" tabpos="65" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="mp3ogg.h" open="0" top="0" tabpos="130" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1040" topLine="27" />
+			<Cursor1 position="1364" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="SigneTest.h" open="0" top="0" tabpos="102" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/include/wx/stedit/steprefs.h" open="0" top="0" tabpos="190" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="626" topLine="0" />
+			<Cursor1 position="9658" topLine="140" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\include\wx\stedit\stedefs.h" open="0" top="0" tabpos="161" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="EditorScene.h" open="0" top="0" tabpos="47" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="42650" topLine="883" />
+			<Cursor1 position="3024" topLine="86" />
 		</Cursor>
 	</File>
-	<File name="Dialogs\ProjectPropertiesPnl.h" open="0" top="0" tabpos="181" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ConsoleFrame.h" open="0" top="0" tabpos="110" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="359" topLine="14" />
+			<Cursor1 position="1163" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="ChoiceJoyAxis.h" open="0" top="0" tabpos="58" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="BugReport.h" open="0" top="0" tabpos="147" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1448" topLine="21" />
+			<Cursor1 position="2533" topLine="34" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\src\steprint.cpp" open="0" top="0" tabpos="33" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ChoiceFile.h" open="0" top="0" tabpos="51" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="17183" topLine="386" />
+			<Cursor1 position="1933" topLine="32" />
 		</Cursor>
 	</File>
-	<File name="ChoixBouton.h" open="0" top="0" tabpos="70" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ExternalEventsEditor.cpp" open="0" top="0" tabpos="20" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1124" topLine="0" />
+			<Cursor1 position="408" topLine="15" />
 		</Cursor>
 	</File>
-	<File name="SplashScreen.cpp" open="0" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ChoixCondition.h" open="0" top="0" tabpos="80" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="3507" topLine="80" />
+			<Cursor1 position="1003" topLine="25" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\include\wx\stedit\stedit.h" open="0" top="0" tabpos="61" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="43775" topLine="784" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\steshell.cpp" open="0" top="0" tabpos="132" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="12542" topLine="344" />
-		</Cursor>
-	</File>
-	<File name="BuildProgressPnl.h" open="0" top="0" tabpos="163" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1449" topLine="2" />
-		</Cursor>
-	</File>
-	<File name="SplashScreen.h" open="0" top="0" tabpos="107" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="897" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stedlgs.h" open="0" top="0" tabpos="168" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="20498" topLine="467" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stesplit.cpp" open="0" top="0" tabpos="38" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="22918" topLine="642" />
-		</Cursor>
-	</File>
-	<File name="BuildToolsPnl.cpp" open="0" top="0" tabpos="49" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="225" topLine="9" />
-		</Cursor>
-	</File>
-	<File name="StartHerePage.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="25420" topLine="404" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\steexprt.h" open="0" top="0" tabpos="68" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/include/wx/stedit/steexprt.h" open="0" top="0" tabpos="68" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="4057" topLine="49" />
 		</Cursor>
@@ -211,459 +506,9 @@
 			<Cursor1 position="336" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\src\stestyls.cpp" open="0" top="0" tabpos="142" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="49004" topLine="919" />
-		</Cursor>
-	</File>
-	<File name="ChoixAction.cpp" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="24373" topLine="439" />
-		</Cursor>
-	</File>
-	<File name="StartHerePage.h" open="0" top="0" tabpos="112" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4540" topLine="74" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stefindr.h" open="0" top="0" tabpos="175" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="12595" topLine="239" />
-		</Cursor>
-	</File>
-	<File name="DnDFileEditor.h" open="0" top="0" tabpos="186" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="554" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="ImportImage.h" open="0" top="0" tabpos="198" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4801" topLine="100" />
-		</Cursor>
-	</File>
-	<File name="CompilationChecker.cpp" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="258" topLine="9" />
-		</Cursor>
-	</File>
-	<File name="TemplateEvents.cpp" open="0" top="0" tabpos="19" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="755" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\steframe.h" open="0" top="0" tabpos="73" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="13034" topLine="221" />
-		</Cursor>
-	</File>
-	<File name="DndTextObjectsEditor.cpp" open="0" top="0" tabpos="84" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="336" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="InitialPositionBrowserDlg.cpp" open="0" top="0" tabpos="57" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2995" topLine="106" />
-		</Cursor>
-	</File>
-	<File name="CodeEditor.cpp" open="0" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="14044" topLine="292" />
-		</Cursor>
-	</File>
-	<File name="TemplateEvents.h" open="0" top="0" tabpos="117" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="762" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stelangs.h" open="0" top="0" tabpos="180" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="14820" topLine="234" />
-		</Cursor>
-	</File>
-	<File name="DndTextObjectsEditor.h" open="0" top="0" tabpos="191" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="529" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="InitialPositionBrowserDlg.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1496" topLine="19" />
-		</Cursor>
-	</File>
-	<File name="BuildProgressPnl.cpp" open="0" top="0" tabpos="48" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="336" topLine="16" />
-		</Cursor>
-	</File>
-	<File name="TrueOrFalse.cpp" open="0" top="0" tabpos="23" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3297" topLine="17" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stemenum.h" open="0" top="0" tabpos="78" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="21670" topLine="342" />
-		</Cursor>
-	</File>
-	<File name="EditObjectGroup.cpp" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="377" topLine="17" />
-		</Cursor>
-	</File>
-	<File name="LogFileManager.cpp" open="0" top="0" tabpos="101" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1710" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="CompilationChecker.h" open="0" top="0" tabpos="105" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="402" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="TrueOrFalse.h" open="0" top="0" tabpos="121" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1027" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stenoteb.h" open="0" top="0" tabpos="185" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="8783" topLine="123" />
-		</Cursor>
-	</File>
-	<File name="EditObjectGroup.h" open="0" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="953" topLine="26" />
-		</Cursor>
-	</File>
-	<File name="LogFileManager.h" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1425" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="ConsoleFrame.cpp" open="0" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3535" topLine="21" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\steopts.h" open="0" top="0" tabpos="83" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="20912" topLine="324" />
-		</Cursor>
-	</File>
-	<File name="EditPropScene.cpp" open="0" top="0" tabpos="109" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="12028" topLine="186" />
-		</Cursor>
-	</File>
-	<File name="MAJ.cpp" open="0" top="0" tabpos="106" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="437" topLine="18" />
-		</Cursor>
-	</File>
-	<File name="ChoiceJoyAxis.cpp" open="0" top="0" tabpos="26" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="5395" topLine="96" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\steprefs.h" open="0" top="0" tabpos="190" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="9658" topLine="140" />
-		</Cursor>
-	</File>
-	<File name="EditPropScene.h" open="0" top="0" tabpos="17" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="515" topLine="22" />
-		</Cursor>
-	</File>
-	<File name="MAJ.h" open="0" top="0" tabpos="14" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1873" topLine="15" />
-		</Cursor>
-	</File>
-	<File name="BuildToolsPnl.h" open="0" top="0" tabpos="171" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="989" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="mp3ogg.cpp" open="0" top="0" tabpos="32" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="8503" topLine="108" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\steprint.h" open="0" top="0" tabpos="88" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3983" topLine="39" />
-		</Cursor>
-	</File>
-	<File name="EditorScene.cpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="11841" topLine="220" />
-		</Cursor>
-	</File>
-	<File name="MainAide.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3620" topLine="95" />
-		</Cursor>
-	</File>
-	<File name="ChoixTemplateEvent.cpp" open="0" top="0" tabpos="32" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="512" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="mp3ogg.h" open="0" top="0" tabpos="130" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1364" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\steshell.h" open="0" top="0" tabpos="195" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="6577" topLine="95" />
-		</Cursor>
-	</File>
-	<File name="EditorScene.h" open="0" top="0" tabpos="47" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3024" topLine="86" />
-		</Cursor>
-	</File>
-	<File name="MainFichier.cpp" open="0" top="0" tabpos="51" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="843" topLine="27" />
-		</Cursor>
-	</File>
-	<File name="ConsoleFrame.h" open="0" top="0" tabpos="110" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1163" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="resource.rc" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="976" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stesplit.h" open="0" top="0" tabpos="93" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="6286" topLine="82" />
-		</Cursor>
-	</File>
 	<File name="EntryPoint.cpp" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="248" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="MainFrame.cpp" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="23875" topLine="406" />
-		</Cursor>
-	</File>
-	<File name="Credits.h" open="0" top="0" tabpos="136" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3690" topLine="66" />
-		</Cursor>
-	</File>
-	<File name="ConsoleManager.h" open="0" top="0" tabpos="115" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1005" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxsmith\ExternalLayoutEditor.wxs" open="0" top="0" tabpos="150" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2300" topLine="39" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\stestyls.h" open="0" top="0" tabpos="200" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="20832" topLine="285" />
-		</Cursor>
-	</File>
-	<File name="MainFrame.h" open="0" top="0" tabpos="52" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="836" topLine="39" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\ExternalLayoutEditor.cpp" open="0" top="0" tabpos="15" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="12034" topLine="213" />
-		</Cursor>
-	</File>
-	<File name="CreateTemplate.h" open="0" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="427" topLine="19" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\include\wx\stedit\wx24defs.h" open="0" top="0" tabpos="98" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2432" topLine="14" />
-		</Cursor>
-	</File>
-	<File name="EventsEditor.cpp" open="0" top="0" tabpos="43" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1223" topLine="36" />
-		</Cursor>
-	</File>
-	<File name="MainOutils.cpp" open="0" top="0" tabpos="120" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1439" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\ExternalLayoutEditor.h" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2941" topLine="83" />
-		</Cursor>
-	</File>
-	<File name="Credits.cpp" open="0" top="0" tabpos="60" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="19751" topLine="246" />
-		</Cursor>
-	</File>
-	<File name="wxsmith\HtmlViewerPnl.wxs" open="0" top="0" tabpos="134" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="826" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stedit.cpp" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="138814" topLine="4028" />
-		</Cursor>
-	</File>
-	<File name="EventsEditor.h" open="0" top="0" tabpos="27" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="11270" topLine="240" />
-		</Cursor>
-	</File>
-	<File name="Preferences.cpp" open="0" top="0" tabpos="12" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="90793" topLine="1729" />
-		</Cursor>
-	</File>
-	<File name="ChoiceFile.cpp" open="0" top="0" tabpos="25" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="412" topLine="17" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stedlgs.cpp" open="0" top="0" tabpos="103" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="85584" topLine="2085" />
-		</Cursor>
-	</File>
-	<File name="ExtensionBugReportDlg.cpp" open="0" top="0" tabpos="44" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="7648" topLine="73" />
-		</Cursor>
-	</File>
-	<File name="Preferences.h" open="0" top="0" tabpos="143" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="7264" topLine="205" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\HelpViewerDlg.h" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="519" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="ChoixCondition.h" open="0" top="0" tabpos="80" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1003" topLine="25" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stedlgs_wdr.cpp" open="0" top="0" tabpos="11" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="68838" topLine="1487" />
-		</Cursor>
-	</File>
-	<File name="ExtensionBugReportDlg.h" open="0" top="0" tabpos="151" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1705" topLine="4" />
-		</Cursor>
-	</File>
-	<File name="ProjectManager.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="90453" topLine="2007" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\HtmlViewerPnl.cpp" open="0" top="0" tabpos="63" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1119" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="CreateTemplate.cpp" open="0" top="0" tabpos="22" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="401" topLine="17" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stedlgs_wdr.h" open="0" top="0" tabpos="108" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="8672" topLine="132" />
-		</Cursor>
-	</File>
-	<File name="ExternalEventsEditor.cpp" open="0" top="0" tabpos="20" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="408" topLine="15" />
-		</Cursor>
-	</File>
-	<File name="ProjectManager.h" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="7477" topLine="195" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\HtmlViewerPnl.h" open="0" top="0" tabpos="170" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="660" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="ChoiceFile.h" open="0" top="0" tabpos="51" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1933" topLine="32" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\steexprt.cpp" open="0" top="0" tabpos="16" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="58409" topLine="1539" />
-		</Cursor>
-	</File>
-	<File name="ExternalEventsEditor.h" open="0" top="0" tabpos="28" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="332" topLine="13" />
-		</Cursor>
-	</File>
-	<File name="RecentList.cpp" open="0" top="0" tabpos="60" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="0" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\LayoutEditorPropertiesPnl.cpp" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4654" topLine="134" />
-		</Cursor>
-	</File>
-	<File name="CheckMAJ.h" open="0" top="0" tabpos="176" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="683" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="wxstedit\src\stefindr.cpp" open="0" top="0" tabpos="113" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="35491" topLine="906" />
-		</Cursor>
-	</File>
-	<File name="Game_Develop_EditorApp.cpp" open="0" top="0" tabpos="62" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1374" topLine="33" />
-		</Cursor>
-	</File>
-	<File name="ChoixTemplateEvent.h" open="0" top="0" tabpos="45" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="340" topLine="15" />
-		</Cursor>
-	</File>
-	<File name="RecentList.h" open="0" top="0" tabpos="167" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="78" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Dialogs\LayoutEditorPropertiesPnl.h" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2033" topLine="39" />
 		</Cursor>
 	</File>
 	<File name="CheckMAJ.cpp" open="0" top="0" tabpos="69" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -671,9 +516,69 @@
 			<Cursor1 position="465" topLine="19" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\src\steframe.cpp" open="0" top="0" tabpos="20" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Dialogs/ProjectPropertiesPnl.h" open="0" top="0" tabpos="181" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="33736" topLine="921" />
+			<Cursor1 position="359" topLine="14" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/HelpViewerDlg.h" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="519" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="EditObjectGroup.h" open="0" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="953" topLine="26" />
+		</Cursor>
+	</File>
+	<File name="MainAide.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3620" topLine="95" />
+		</Cursor>
+	</File>
+	<File name="wxsmith/HtmlViewerPnl.wxs" open="0" top="0" tabpos="134" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="826" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="ConsoleFrame.cpp" open="0" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3535" topLine="21" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/NewProjectDialog.h" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3187" topLine="55" />
+		</Cursor>
+	</File>
+	<File name="ChoixBouton.h" open="0" top="0" tabpos="70" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1124" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/steopts.h" open="0" top="0" tabpos="83" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="20912" topLine="324" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/setup0.h" open="0" top="0" tabpos="54" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="4326" topLine="39" />
+		</Cursor>
+	</File>
+	<File name="TemplateEvents.h" open="0" top="0" tabpos="117" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="762" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="SplashScreen.cpp" open="0" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3507" topLine="80" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/steshell.h" open="0" top="0" tabpos="195" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="6577" topLine="95" />
 		</Cursor>
 	</File>
 	<File name="Game_Develop_EditorApp.h" open="0" top="0" tabpos="14" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -681,44 +586,139 @@
 			<Cursor1 position="253" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="ChoixClavier.h" open="0" top="0" tabpos="75" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="BuildMessagesPnl.cpp" open="0" top="0" tabpos="46" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1102" topLine="0" />
+			<Cursor1 position="349" topLine="14" />
 		</Cursor>
 	</File>
-	<File name="SearchEvents.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ChoiceFile.cpp" open="0" top="0" tabpos="25" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="259" topLine="11" />
+			<Cursor1 position="412" topLine="17" />
 		</Cursor>
 	</File>
-	<File name="wxsmith\ProjectPropertiesPnl.wxs" open="0" top="0" tabpos="144" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/include/wx/stedit/stenoteb.h" open="0" top="0" tabpos="185" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="923" topLine="0" />
+			<Cursor1 position="8783" topLine="123" />
 		</Cursor>
 	</File>
-	<File name="Dialogs\NewProjectDialog.cpp" open="0" top="0" tabpos="56" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ChoixAction.h" open="0" top="0" tabpos="65" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1040" topLine="27" />
+		</Cursor>
+	</File>
+	<File name="MAJ.cpp" open="0" top="0" tabpos="106" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="437" topLine="18" />
+		</Cursor>
+	</File>
+	<File name="ConsoleManager.h" open="0" top="0" tabpos="115" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1005" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="CodeEditor.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="356" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/ObjectsEditor.h" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="5863" topLine="163" />
+		</Cursor>
+	</File>
+	<File name="SearchEvents.h" open="0" top="0" tabpos="92" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="881" topLine="27" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/wx24defs.h" open="0" top="0" tabpos="98" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="2432" topLine="14" />
+		</Cursor>
+	</File>
+	<File name="TrueOrFalse.h" open="0" top="0" tabpos="121" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1027" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="BuildToolsPnl.h" open="0" top="0" tabpos="171" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="989" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/stefindr.cpp" open="0" top="0" tabpos="113" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="35491" topLine="906" />
+		</Cursor>
+	</File>
+	<File name="MAJ.h" open="0" top="0" tabpos="14" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1873" topLine="15" />
+		</Cursor>
+	</File>
+	<File name="ImportImage.cpp" open="0" top="0" tabpos="91" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="32697" topLine="503" />
+		</Cursor>
+	</File>
+	<File name="ImportImage.h" open="0" top="0" tabpos="198" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="4801" topLine="100" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/steexprt.cpp" open="0" top="0" tabpos="16" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="58409" topLine="1539" />
+		</Cursor>
+	</File>
+	<File name="CreateTemplate.cpp" open="0" top="0" tabpos="22" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="401" topLine="17" />
+		</Cursor>
+	</File>
+	<File name="wxsmith/ExternalLayoutEditor.wxs" open="0" top="0" tabpos="150" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="2300" topLine="39" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/src/steframe.cpp" open="0" top="0" tabpos="20" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="33736" topLine="921" />
+		</Cursor>
+	</File>
+	<File name="DnDFileEditor.h" open="0" top="0" tabpos="186" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="554" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="wxstedit/include/wx/stedit/steprint.h" open="0" top="0" tabpos="88" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3983" topLine="39" />
+		</Cursor>
+	</File>
+	<File name="Dialogs/NewProjectDialog.cpp" open="0" top="0" tabpos="56" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="8169" topLine="127" />
 		</Cursor>
 	</File>
-	<File name="BugReport.cpp" open="0" top="0" tabpos="41" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Credits.cpp" open="0" top="0" tabpos="60" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="14870" topLine="255" />
+			<Cursor1 position="19751" topLine="246" />
 		</Cursor>
 	</File>
-	<File name="wxstedit\src\stelangs.cpp" open="0" top="0" tabpos="118" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/src/stestyls.cpp" open="0" top="0" tabpos="142" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="310918" topLine="5459" />
+			<Cursor1 position="49004" topLine="919" />
 		</Cursor>
 	</File>
-	<File name="GeneratePassword.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="wxstedit/src/stesplit.cpp" open="0" top="0" tabpos="38" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="230" topLine="0" />
+			<Cursor1 position="22918" topLine="642" />
 		</Cursor>
 	</File>
-	<File name="BuildMessagesPnl.cpp" open="0" top="0" tabpos="46" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ChoixCondition.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="349" topLine="14" />
+			<Cursor1 position="26395" topLine="454" />
 		</Cursor>
 	</File>
 </CodeBlocks_layout_file>

--- a/IDE/MainFrame.cpp
+++ b/IDE/MainFrame.cpp
@@ -40,6 +40,7 @@
 #include "GDCore/IDE/Dialogs/ChooseObjectDialog.h"
 #include "GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.h"
 #include "GDCore/IDE/SkinHelper.h"
+#include "GDCore/IDE/ProjectFileWriter.h"
 #include "GDCore/IDE/ProjectExporter.h"
 #include "GDCore/IDE/PlatformManager.h"
 #include "GDCore/CommonTools.h"
@@ -79,6 +80,7 @@ const long MainFrame::toBeDeletedMenuItem = wxNewId();
 const long MainFrame::ID_MENUITEM26 = wxNewId();
 const long MainFrame::ID_MENUITEM12 = wxNewId();
 const long MainFrame::ID_MENUITEM13 = wxNewId();
+const long MainFrame::ID_MENUITEM8 = wxNewId();
 const long MainFrame::ID_MENUITEM16 = wxNewId();
 const long MainFrame::ID_MENUITEM19 = wxNewId();
 const long MainFrame::ID_MENUITEM17 = wxNewId();
@@ -200,6 +202,9 @@ MainFrame::MainFrame( wxWindow* parent ) :
     MenuItem7 = new wxMenuItem((&fileMenu), ID_MENUITEM13, _("Save as..."), wxEmptyString, wxITEM_NORMAL);
     MenuItem7->SetBitmap(gd::SkinHelper::GetIcon("saveas", 16));
     fileMenu.Append(MenuItem7);
+    MenuItem5 = new wxMenuItem((&fileMenu), ID_MENUITEM8, _("Save as folder project"), wxEmptyString, wxITEM_NORMAL);
+    MenuItem5->SetBitmap(gd::SkinHelper::GetIcon("open", 16));
+    fileMenu.Append(MenuItem5);
     MenuItem12 = new wxMenuItem((&fileMenu), ID_MENUITEM16, _("Save all\tCtrl+Shift+S"), wxEmptyString, wxITEM_NORMAL);
     MenuItem12->SetBitmap(gd::SkinHelper::GetIcon("save_all", 16));
     fileMenu.Append(MenuItem12);
@@ -255,6 +260,7 @@ MainFrame::MainFrame( wxWindow* parent ) :
     Connect(ID_MENUITEM10,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnOpenExampleSelected);
     Connect(ID_MENUITEM12,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnMenuSaveSelected);
     Connect(ID_MENUITEM13,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnMenuSaveAsSelected);
+    Connect(ID_MENUITEM8,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnMenuSaveAsFolderSelected);
     Connect(ID_MENUITEM16,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnMenuSaveAllSelected);
     Connect(ID_MENUITEM19,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnCloseCurrentProjectSelected);
     Connect(ID_MENUITEM17,wxEVT_COMMAND_MENU_SELECTED,(wxObjectEventFunction)&MainFrame::OnMenuPrefSelected);
@@ -299,7 +305,7 @@ MainFrame::MainFrame( wxWindow* parent ) :
         {
             long id = wxNewId();
 
-            fileMenu.Insert(10, id, exporter->GetProjectExportButtonLabel());
+            fileMenu.Insert(11, id, exporter->GetProjectExportButtonLabel());
             Connect( id, wxEVT_COMMAND_MENU_SELECTED, ( wxObjectEventFunction )&MainFrame::OnMenuCompilationSelected );
             idToPlatformExportMenuMap[id] = gd::PlatformManager::Get()->GetAllPlatforms()[i].get();
         }
@@ -810,7 +816,7 @@ void MainFrame::OnautoSaveTimerTrigger(wxTimerEvent& event)
         if (!filename.IsFileWritable()) continue;
 
         wxString autosaveFilename = filename.GetPath() + "/" + filename.GetName()+".gdg.autosave";
-        if ( !games[i]->SaveToFile(autosaveFilename) )
+        if (!gd::ProjectFileWriter::SaveToFile(*games[i], autosaveFilename))
             gd::LogStatus( _("Autosave failed!") );
     }
 }

--- a/IDE/MainFrame.h
+++ b/IDE/MainFrame.h
@@ -214,6 +214,7 @@ public:
     void OnMenuSaveAllSelected(wxCommandEvent& event);
     void OnCloseCurrentProjectSelected(wxCommandEvent& event);
     void OnResize(wxSizeEvent& event);
+    void OnMenuSaveAsFolderSelected(wxCommandEvent& event);
     //*)
     void OnRibbonPageChanging(wxRibbonBarEvent& evt);
     void OnRibbonHelpBtClick(wxRibbonBarEvent& evt);
@@ -233,7 +234,7 @@ public:
     void OnRibbonFileBtEnter(wxMouseEvent& event);
     void OnRibbonHelpBtLeave(wxMouseEvent& event);
     void OnRibbonHelpBtEnter(wxMouseEvent& event);
-    void SaveAs();
+    void SaveAs(std::shared_ptr<gd::Project> project = nullptr);
     void OnRecentClicked(wxCommandEvent& event );
     void UpdateNotebook();
     void MakeImagesEditorRibbon();
@@ -261,6 +262,7 @@ private:
     static const long ID_MENUITEM26;
     static const long ID_MENUITEM12;
     static const long ID_MENUITEM13;
+    static const long ID_MENUITEM8;
     static const long ID_MENUITEM16;
     static const long ID_MENUITEM19;
     static const long ID_MENUITEM17;
@@ -296,6 +298,7 @@ private:
     wxMenuItem* MenuItem8;
     wxMenu disabledFileMenu;
     wxMenuItem* MenuItem7;
+    wxMenuItem* MenuItem5;
     wxMenuItem* MenuItem2;
     wxTimer autoSaveTimer;
     wxMenuItem* MenuItem4;

--- a/IDE/wxsmith/MainFrame.wxs
+++ b/IDE/wxsmith/MainFrame.wxs
@@ -120,6 +120,11 @@
 				<bitmap code='gd::SkinHelper::GetIcon(&quot;saveas&quot;, 16)' />
 				<handler function="OnMenuSaveAsSelected" entry="EVT_MENU" />
 			</object>
+			<object class="wxMenuItem" name="ID_MENUITEM8" variable="MenuItem5" member="yes">
+				<label>Save as folder project</label>
+				<bitmap code='gd::SkinHelper::GetIcon(&quot;open&quot;, 16)' />
+				<handler function="OnMenuSaveAsFolderSelected" entry="EVT_MENU" />
+			</object>
 			<object class="wxMenuItem" name="ID_MENUITEM16" variable="MenuItem12" member="yes">
 				<label>Save all</label>
 				<accel>Ctrl+Shift+S</accel>


### PR DESCRIPTION
This implements support for saving and loading projects as "Folder project", meaning that scenesm external layouts and external events are stored into separate files. This can greatly enhance the collaboration on medium/large projects when more than one person is involved. people can keep working on levels in the external layouts for example, or on different scenes then share their files. :smile:

The implementation is done using a `Splitter` class that "cut" some part of the tree representing the whole serialized projects. The new element are containing a reference to the part that were cut (i.e: the other files). I've also moved the part writing JSON/XML files from gd::Project to a separate class (because it's not the project responsibility to manage files).

@victorlevasseur If you have some time, you can pull the branch and check if you can save a few projects as folder projects, and then load them/modify them again :)

This should be one of the last feature added before releasing version 4 (still need to make sure help is easily accessible for the new AdMob banner and do a find/replace in the wiki to replace automatism by behavior). Let me know if you have something in mind apart from these points that should be addressed/fixed before v4 :smile: 