### PR TITLE
Remove debug warnings when opening the TileMapObject editor

### DIFF
--- a/Extensions/TileMapObject/TileMapObject.cpp
+++ b/Extensions/TileMapObject/TileMapObject.cpp
@@ -10,6 +10,7 @@ This project is released under the MIT License.
 
 #if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
 #include <wx/bitmap.h> //Must be placed first, otherwise we get errors relative to "cannot convert 'const TCHAR*'..." in wx/msw/winundef.h
+#include <wx/log.h>
 #include <wx/panel.h>
 #endif
 #include "TileMapObject.h"
@@ -145,6 +146,7 @@ bool TileMapObject::GenerateThumbnail(const gd::Project & project, wxBitmap & th
 void TileMapObject::EditObject( wxWindow* parent, gd::Project & game, gd::MainFrameWrapper & mainFrameWrapper )
 {
 #if !defined(GD_NO_WX_GUI)
+    wxLogNull logNo;
     TileMapObjectEditor dialog(parent, game, *this, mainFrameWrapper);
     dialog.ShowModal();
 #endif


### PR DESCRIPTION
Remove debug warnings when opening the TileMapObject editor.