### PR TITLE
Improve help

### DIFF
--- a/Core/GDCore/BuiltinExtensions/BaseObjectExtension.cpp
+++ b/Core/GDCore/BuiltinExtensions/BaseObjectExtension.cpp
@@ -38,6 +38,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("relationalOperator", _("Sign of the test"))
         .AddParameter("expression", _("X position"))
         .MarkAsSimple()
+        .SetHelpPage("gdevelop/documentation/manual/base")
         .SetManipulatedType("number");
 
     obj.AddAction("MettreX",
@@ -52,6 +53,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("operator", _("Modification's sign"))
         .AddParameter("expression", _("Value"))
         .MarkAsSimple()
+        .SetHelpPage("gdevelop/documentation/manual/base")
         .SetManipulatedType("number");
 
     obj.AddCondition("PosY",
@@ -66,6 +68,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("relationalOperator", _("Sign of the test"))
         .AddParameter("expression", _("Y position"))
         .MarkAsSimple()
+        .SetHelpPage("gdevelop/documentation/manual/base")
         .SetManipulatedType("number");
 
     obj.AddAction("MettreY",
@@ -80,6 +83,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("operator", _("Modification's sign"))
         .AddParameter("expression", _("Value"))
         .MarkAsSimple()
+        .SetHelpPage("gdevelop/documentation/manual/base")
         .SetManipulatedType("number");
 
     obj.AddAction("MettreXY",
@@ -95,6 +99,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("expression", _("X position"))
         .AddParameter("operator", _("Modification's sign"))
         .AddParameter("expression", _("Y position"))
+        .SetHelpPage("gdevelop/documentation/manual/base")
         .MarkAsSimple();
 
     obj.AddAction("MettreAutourPos",
@@ -110,6 +115,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("expression", _("Y position"))
         .AddParameter("expression", _("Distance"))
         .AddParameter("expression", _("Angle, in degrees"))
+        .SetHelpPage("gdevelop/documentation/manual/base")
         .MarkAsAdvanced();
 
     obj.AddAction("SetAngle",
@@ -123,6 +129,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("object", _("Object"))
         .AddParameter("operator", _("Modification's sign"))
         .AddParameter("expression", _("Value"))
+        .SetHelpPage("gdevelop/documentation/manual/base")
         .SetManipulatedType("number");
 
     obj.AddAction("Rotate",
@@ -136,6 +143,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("object", _("Object"))
         .AddParameter("expression", _("Angular speed (in degrees per second)"))
         .AddCodeOnlyParameter("currentScene", "")
+        .SetHelpPage("gdevelop/documentation/manual/base")
         .MarkAsSimple();
 
     obj.AddAction("RotateTowardAngle",
@@ -149,6 +157,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("object", _("Object"))
         .AddParameter("expression", _("Angle to rotate towards (in degrees)"))
         .AddParameter("expression", _("Angular speed (in degrees per second) (0 for immediate rotation)"))
+        .SetHelpPage("gdevelop/documentation/manual/base")
         .AddCodeOnlyParameter("currentScene", "");
 
     obj.AddAction("RotateTowardPosition",
@@ -164,6 +173,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("expression", _("Y position"))
         .AddParameter("expression", _("Angular speed (in degrees per second) (0 for immediate rotation)"))
         .AddCodeOnlyParameter("currentScene", "")
+        .SetHelpPage("gdevelop/documentation/manual/base")
         .MarkAsAdvanced();
 
     obj.AddAction("AddForceXY",
@@ -177,7 +187,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("object", _("Object"))
         .AddParameter("expression", _("Speed on X axis (in pixels per second)"))
         .AddParameter("expression", _("Speed on Y axis (in pixels per second)"))
-        .AddParameter("expression", _("Damping (Default: 0)"));
+        .AddParameter("expression", _("Damping (Default: 0)"))
+        .SetHelpPage("gdevelop/documentation/manual/base");
 
     obj.AddAction("AddForceAL",
                    _("Add a force (angle)"),
@@ -191,6 +202,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("expression", _("Angle"))
         .AddParameter("expression", _("Speed (in pixels per second)"))
         .AddParameter("expression", _("Damping (Default: 0)"))
+        .SetHelpPage("gdevelop/documentation/manual/base")
         .MarkAsAdvanced();
 
     obj.AddAction("AddForceVersPos",
@@ -206,6 +218,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
         .AddParameter("expression", _("Y position"))
         .AddParameter("expression", _("Speed (in pixels per second)"))
         .AddParameter("expression", _("Damping (Default: 0)"))
+        .SetHelpPage("gdevelop/documentation/manual/base#displacement")
         .MarkAsAdvanced();
 
     obj.AddAction("AddForceTournePos",
@@ -234,6 +247,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
                    "res/actions/arreter.png")
 
         .AddParameter("object", _("Object"))
+        .SetHelpPage("gdevelop/documentation/manual/base#displacement")
         .MarkAsAdvanced();
 
     obj.AddAction("Delete",

--- a/Core/GDCore/BuiltinExtensions/SpriteExtension/Dialogs/SpriteObjectEditor.cpp
+++ b/Core/GDCore/BuiltinExtensions/SpriteExtension/Dialogs/SpriteObjectEditor.cpp
@@ -1813,7 +1813,7 @@ void SpriteObjectEditor::OnAddFromImageBankSelected(wxCommandEvent& event)
 
 void SpriteObjectEditor::OnHelpClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/built_sprite"));
+    gd::HelpFileAccess::Get()->OpenPage("en/game_develop/documentation/manual/built_sprite");
 }
 
 void SpriteObjectEditor::OnyScrollBarScroll(wxScrollEvent& event)

--- a/Core/GDCore/Events/InstructionMetadata.cpp
+++ b/Core/GDCore/Events/InstructionMetadata.cpp
@@ -31,6 +31,7 @@ InstructionMetadata::InstructionMetadata(const gd::String & extensionNamespace_,
                         const gd::String & smallIcon_) :
 fullname(fullname_),
 description(description_),
+helpPage(),
 sentence(sentence_),
 group(group_),
 iconFilename(icon_),

--- a/Core/GDCore/Events/InstructionMetadata.h
+++ b/Core/GDCore/Events/InstructionMetadata.h
@@ -117,6 +117,20 @@ public:
     bool CanHaveSubInstructions() const { return canHaveSubInstructions; }
 
     /**
+     * Get the help page of the instruction.
+     */
+    const gd::String & GetHelpPage() const { return helpPage; }
+
+    /**
+     * Set the help page of the instruction.
+     */
+    InstructionMetadata & SetHelpPage(const gd::String &page)
+    {
+        helpPage = page;
+        return *this;
+    }
+
+    /**
      * Notify that the instruction can have sub instructions.
      */
     InstructionMetadata & SetCanHaveSubInstructions()
@@ -339,6 +353,7 @@ public:
 private:
     gd::String fullname;
     gd::String description;
+    gd::String helpPage;
     gd::String sentence;
     gd::String group;
 #if !defined(GD_NO_WX_GUI)

--- a/Core/GDCore/Events/ObjectMetadata.h
+++ b/Core/GDCore/Events/ObjectMetadata.h
@@ -114,8 +114,7 @@ public:
 
     /**
      * \brief Set the URL pointing to the help page about this object
-     * \note If url starts with a slash, it is considered as an URL relative
-     * the the GDevelop wiki.
+     * \note The path to the page must be relative to the wiki url.
      */
     ObjectMetadata & SetHelpUrl(const gd::String & url);
 

--- a/Core/GDCore/IDE/Dialogs/ChooseBehaviorTypeDialog.cpp
+++ b/Core/GDCore/IDE/Dialogs/ChooseBehaviorTypeDialog.cpp
@@ -275,7 +275,7 @@ void ChooseBehaviorTypeDialog::OnResize(wxSizeEvent& event)
 
 void ChooseBehaviorTypeDialog::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://wiki.compilgames.net/doku.php/game_develop/documentation/manual/edit_object")); //TODO: Behavior help page
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/edit_object"); //TODO: Behavior help page
 }
 
 void ChooseBehaviorTypeDialog::OnplatformChoiceSelect(wxCommandEvent& event)

--- a/Core/GDCore/IDE/Dialogs/ChooseObjectTypeDialog.cpp
+++ b/Core/GDCore/IDE/Dialogs/ChooseObjectTypeDialog.cpp
@@ -283,7 +283,7 @@ void ChooseObjectTypeDialog::OnmoreObjectsBtClick(wxCommandEvent& event)
 
 void ChooseObjectTypeDialog::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/edit_object"));
+    gd::HelpFileAccess::Get()->OpenPage("en/game_develop/documentation/manual/edit_object");
 }
 
 void ChooseObjectTypeDialog::UpdateListColumnsWidth()

--- a/Core/GDCore/IDE/Dialogs/ChooseVariableDialog.cpp
+++ b/Core/GDCore/IDE/Dialogs/ChooseVariableDialog.cpp
@@ -390,7 +390,7 @@ void ChooseVariableDialog::OnRightClick(wxTreeListEvent& event)
  */
 void ChooseVariableDialog::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/global_variables"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/global_variables");
 }
 
 /**

--- a/Core/GDCore/IDE/Dialogs/EditComment.cpp
+++ b/Core/GDCore/IDE/Dialogs/EditComment.cpp
@@ -147,7 +147,7 @@ void EditComment::OnAnnulerBtClick(wxCommandEvent& event)
 
 void EditComment::OnAideBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/comment_events"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/comment_events");
 }
 void EditComment::OntxtColorBtClick(wxCommandEvent& event)
 {

--- a/Core/GDCore/IDE/Dialogs/EditExpressionDialog.cpp
+++ b/Core/GDCore/IDE/Dialogs/EditExpressionDialog.cpp
@@ -971,7 +971,7 @@ void EditExpressionDialog::OnButton17Click(wxCommandEvent& event)
 
 void EditExpressionDialog::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/edit_expr"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/edit_expr");
 }
 
 }

--- a/Core/GDCore/IDE/Dialogs/EditForEachEvent.cpp
+++ b/Core/GDCore/IDE/Dialogs/EditForEachEvent.cpp
@@ -128,7 +128,7 @@ void EditForEachEvent::OnobjectBtClick(wxCommandEvent& event)
 
 void EditForEachEvent::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/foreach_events"));
+    gd::HelpFileAccess::Get()->OpenPage("en/game_develop/documentation/manual/foreach_events");
 }
 
 }

--- a/Core/GDCore/IDE/Dialogs/EditLayerDialog.cpp
+++ b/Core/GDCore/IDE/Dialogs/EditLayerDialog.cpp
@@ -425,7 +425,7 @@ void EditLayerDialog::OndeleteCameraBtClick(wxCommandEvent& event)
 
 void EditLayerDialog::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/editors/scene_editor/edit_layer"));
+    gd::HelpFileAccess::Get()->OpenPage("en/game_develop/documentation/manual/editors/scene_editor/edit_layer");
 }
 
 }

--- a/Core/GDCore/IDE/Dialogs/EditLink.cpp
+++ b/Core/GDCore/IDE/Dialogs/EditLink.cpp
@@ -151,7 +151,7 @@ EditLink::~EditLink()
 
 void EditLink::OnAideBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/link_events"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/link_events");
 }
 
 /**

--- a/Core/GDCore/IDE/Dialogs/EditRepeatEvent.cpp
+++ b/Core/GDCore/IDE/Dialogs/EditRepeatEvent.cpp
@@ -127,7 +127,7 @@ void EditRepeatEvent::OncancelBtClick(wxCommandEvent& event)
 
 void EditRepeatEvent::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/repeat_events"));
+    gd::HelpFileAccess::Get()->OpenPage("en/game_develop/documentation/manual/repeat_events");
 }
 
 }

--- a/Core/GDCore/IDE/Dialogs/EditStrExpressionDialog.cpp
+++ b/Core/GDCore/IDE/Dialogs/EditStrExpressionDialog.cpp
@@ -619,7 +619,7 @@ void EditStrExpressionDialog::OnerrorTxtClick(wxCommandEvent& event)
 
 void EditStrExpressionDialog::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/edit_text"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/edit_text");
 }
 
 }

--- a/Core/GDCore/IDE/Dialogs/GridSetupDialog.cpp
+++ b/Core/GDCore/IDE/Dialogs/GridSetupDialog.cpp
@@ -191,7 +191,7 @@ void GridSetupDialog::OncolorPanelLeftUp(wxMouseEvent& event)
 
 void GridSetupDialog::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/editors/scene_editor/edit_scene_edit"));
+    gd::HelpFileAccess::Get()->OpenPage("en/game_develop/documentation/manual/editors/scene_editor/edit_scene_edit");
 }
 
 

--- a/Core/GDCore/IDE/Dialogs/InstancesAdvancedPasteDialog.cpp
+++ b/Core/GDCore/IDE/Dialogs/InstancesAdvancedPasteDialog.cpp
@@ -227,7 +227,7 @@ float InstancesAdvancedPasteDialog::GetRotationIncrementation() const
 
 void InstancesAdvancedPasteDialog::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/editors/scene_editor/edit_scene_edit"));
+    gd::HelpFileAccess::Get()->OpenPage("en/game_develop/documentation/manual/editors/scene_editor/edit_scene_edit");
 }
 
 

--- a/Core/GDCore/IDE/Dialogs/LayersEditorPanel.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayersEditorPanel.cpp
@@ -319,7 +319,7 @@ void LayersEditorPanel::OnEditLayerClicked(wxCommandEvent& event)
 
 void LayersEditorPanel::OnHelpClicked(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/editors/scene_editor/edit_layer"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/editors/scene_editor/edit_layer");
 }
 
 void LayersEditorPanel::OnLayerDownClicked(wxCommandEvent& event)

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
@@ -758,7 +758,7 @@ void LayoutEditorCanvas::UpdateViewAccordingToZoomFactor()
 
 void LayoutEditorCanvas::OnHelpBtClick( wxCommandEvent & event )
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/edit_layout"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/edit_layout");
 }
 
 

--- a/Core/GDCore/IDE/Dialogs/ObjectsPropgridHelper.cpp
+++ b/Core/GDCore/IDE/Dialogs/ObjectsPropgridHelper.cpp
@@ -174,7 +174,7 @@ bool ObjectsPropgridHelper::OnPropertySelected(gd::Object * object, gd::Layout *
             auto metadata = gd::MetadataProvider::GetObjectMetadata(project.GetCurrentPlatform(),
                 object->GetType());
 
-            gd::HelpFileAccess::Get()->OpenURL(metadata.GetHelpUrl());
+            gd::HelpFileAccess::Get()->OpenURL(metadata.GetHelpUrl()); //TODO: Use OpenPage and store only the page location in metadata
         }
         else if ( event.GetPropertyName() == _("Variables") )
         {

--- a/Core/GDCore/IDE/Dialogs/ObjectsPropgridHelper.cpp
+++ b/Core/GDCore/IDE/Dialogs/ObjectsPropgridHelper.cpp
@@ -174,7 +174,7 @@ bool ObjectsPropgridHelper::OnPropertySelected(gd::Object * object, gd::Layout *
             auto metadata = gd::MetadataProvider::GetObjectMetadata(project.GetCurrentPlatform(),
                 object->GetType());
 
-            gd::HelpFileAccess::Get()->OpenURL(metadata.GetHelpUrl()); //TODO: Use OpenPage and store only the page location in metadata
+            gd::HelpFileAccess::Get()->OpenPage(metadata.GetHelpUrl());
         }
         else if ( event.GetPropertyName() == _("Variables") )
         {

--- a/Core/GDCore/IDE/Dialogs/ProjectExtensionsDialog.cpp
+++ b/Core/GDCore/IDE/Dialogs/ProjectExtensionsDialog.cpp
@@ -396,7 +396,7 @@ void ProjectExtensionsDialog::OnFermerBtClick(wxCommandEvent& event)
 
 void ProjectExtensionsDialog::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/extensions"));
+    gd::HelpFileAccess::Get()->OpenPage("en/game_develop/documentation/manual/extensions");
 }
 
 void ProjectExtensionsDialog::OnResize(wxSizeEvent& event)

--- a/Core/GDCore/IDE/Dialogs/ResourcesEditor.cpp
+++ b/Core/GDCore/IDE/Dialogs/ResourcesEditor.cpp
@@ -986,7 +986,7 @@ void ResourcesEditor::OnShowPropertyGridBtClick( wxCommandEvent& event )
 
 void ResourcesEditor::OnAideBtClick( wxCommandEvent& event )
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/edit_image"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/edit_image");
 }
 
 void ResourcesEditor::OnresourcesTreeItemActivated(wxTreeEvent& event)

--- a/Core/GDCore/Tools/HelpFileAccess.cpp
+++ b/Core/GDCore/Tools/HelpFileAccess.cpp
@@ -6,12 +6,32 @@
 
 #if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
 #include "GDCore/Tools/HelpFileAccess.h"
+#include "GDCore/Tools/Locale/LocaleManager.h"
 #include <wx/mimetype.h> // mimetype support
 
 namespace gd
 {
 
 HelpFileAccess * HelpFileAccess::_singleton = NULL;
+
+wxString HelpFileAccess::GetHelpURL(wxString page) const
+{
+    wxString pageURL = "http://wiki.compilgames.net/doku.php/";
+
+    //Get the language name from the current language of GDevelop
+    wxString languageName = wxLocale::GetLanguageInfo(gd::LocaleManager::Get()->GetLanguage())->CanonicalName.substr(0, 2);
+
+    //Add the language two letter code if the language is supported by the wiki.
+    //Note: for "en", we don't need to add "en" to the URL.
+    if(languageName == "fr" || languageName == "de" || languageName == "es" || languageName == "pt"
+       || languageName == "ru" || languageName == "zh")
+        pageURL += languageName + (!page.StartsWith("/") ? "/" : "" );
+
+    //Add the page location to the URL
+    pageURL += page;
+
+    return pageURL;
+}
 
 }
 #endif

--- a/Core/GDCore/Tools/HelpFileAccess.h
+++ b/Core/GDCore/Tools/HelpFileAccess.h
@@ -7,6 +7,7 @@
 #ifndef HELPFILEACCESS_H
 #define HELPFILEACCESS_H
 #include "GDCore/Tools/Locale/LocaleManager.h"
+#include "GDCore/CommonTools.h"
 #include <wx/string.h>
 
 namespace gd
@@ -58,9 +59,22 @@ public:
     /**
      * Ask the IDE to display the specified URL as help.
      */
-    inline void OpenURL(wxString url)
+    inline void OpenURL(wxString url) GD_DEPRECATED
     {
         helpProvider->OpenURL(url);
+    }
+
+    /**
+     * Ask the IDE to display the specified page as help.
+     * This assumes that the page is hosted on the GDevelop's wiki : http://wiki.compilgames.net/doku.php/language/the_page_name
+     * The "language" from the URL is deduced from the user language. For the languages that are not available on the wiki,
+     * the user is redirected to the english page.
+     *
+     * \param page the address to the page relative to the wiki (http://wiki.compilgames.net/doku.php/language/)
+     */
+    inline void OpenPage(wxString page)
+    {
+        helpProvider->OpenURL(GetHelpURL(page));
     }
 
     static HelpFileAccess *Get()
@@ -83,6 +97,8 @@ public:
 private:
     HelpFileAccess() : helpProvider(NULL) {};
     virtual ~HelpFileAccess() {  };
+
+    wxString GetHelpURL(wxString page) const;
 
     static HelpFileAccess *_singleton;
     HelpProvider * helpProvider;

--- a/Extensions/TextObject/Dialogs/TextObjectEditor.cpp
+++ b/Extensions/TextObject/Dialogs/TextObjectEditor.cpp
@@ -167,5 +167,5 @@ void TextObjectEditor::OnChangeFontButton(wxCommandEvent& event)
 
 void TextObjectEditor::OnHelpBtClicked(wxHyperlinkEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://wiki.compilgames.net/doku.php/gdevelop/documentation/manual/built_text"));
+    gd::HelpFileAccess::Get()->OpenPage("gdevelop/documentation/manual/built_text");
 }

--- a/Extensions/TileMapObject/TileMapConfigurationEditor.cpp
+++ b/Extensions/TileMapObject/TileMapConfigurationEditor.cpp
@@ -53,6 +53,6 @@ void TileMapConfigurationEditor::OnOkPressed(wxCommandEvent& event)
 
 void TileMapConfigurationEditor::OnHelpButtonClicked(wxHyperlinkEvent& event)
 {
-	gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/built_tilemap/tilemapconfig"));
+	gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/built_tilemap/tilemapconfig");
 }
 #endif

--- a/Extensions/TileMapObject/TileMapObjectEditor.cpp
+++ b/Extensions/TileMapObject/TileMapObjectEditor.cpp
@@ -171,7 +171,7 @@ void TileMapObjectEditor::OnChangeMapSizeButtonClicked(wxCommandEvent& event)
 
 void TileMapObjectEditor::OnHelpButtonClicked(wxHyperlinkEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/built_tilemap"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/built_tilemap");
 }
 
 void TileMapObjectEditor::OnCloseButtonClicked(wxCloseEvent& event)

--- a/Extensions/TileMapObject/TileSetConfigurationEditor.cpp
+++ b/Extensions/TileMapObject/TileSetConfigurationEditor.cpp
@@ -130,7 +130,7 @@ void TileSetConfigurationEditor::OnTileSetParameterUpdated(wxSpinEvent& event)
 
 void TileSetConfigurationEditor::OnHelpButtonClicked(wxHyperlinkEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/built_tilemap/tilesetconfig"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/built_tilemap/tilesetconfig");
 }
 
 #endif

--- a/GDCpp/GDCpp/IDE/Dialogs/ProjectExportDialog.cpp
+++ b/GDCpp/GDCpp/IDE/Dialogs/ProjectExportDialog.cpp
@@ -240,7 +240,7 @@ void ProjectExportDialog::OnCompilBtClick( wxCommandEvent& event )
 
 void ProjectExportDialog::OnAideBtClick( wxCommandEvent& event )
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/distribution/compilation"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/distribution/compilation");
 }
 
 void ProjectExportDialog::OnbrowseBtClick(wxCommandEvent& event)

--- a/IDE/ChoiceFile.cpp
+++ b/IDE/ChoiceFile.cpp
@@ -148,5 +148,5 @@ void ChoiceFile::OnbrowseBtClick(wxCommandEvent& event)
 
 void ChoiceFile::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/events_editor/parameters"));
+    gd::HelpFileAccess::Get()->OpenPage("gevelop/documentation/manual/events_editor/parameters");
 }

--- a/IDE/ChoiceJoyAxis.cpp
+++ b/IDE/ChoiceJoyAxis.cpp
@@ -145,5 +145,5 @@ void ChoiceJoyAxis::OnannulerBtClick(wxCommandEvent& event)
 
 void ChoiceJoyAxis::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/events_editor/parameters"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/events_editor/parameters");
 }

--- a/IDE/ChoixBouton.cpp
+++ b/IDE/ChoixBouton.cpp
@@ -145,5 +145,5 @@ void ChoixBouton::OnTestPanelRightDown( wxMouseEvent& event )
 
 void ChoixBouton::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/events_editor/parameters"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/events_editor/parameters");
 }

--- a/IDE/ChoixClavier.cpp
+++ b/IDE/ChoixClavier.cpp
@@ -98,7 +98,7 @@ void ChoixClavier::OnButton1Click(wxCommandEvent& event)
 
 void ChoixClavier::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/events_editor/parameters"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/events_editor/parameters");
 }
 
 void ChoixClavier::OnPanel1KeyDown1(wxKeyEvent& event)

--- a/IDE/Dialogs/ObjectsEditor.cpp
+++ b/IDE/Dialogs/ObjectsEditor.cpp
@@ -417,7 +417,7 @@ void ObjectsEditor::CreateRibbonPage(wxRibbonPage * page)
 
 void ObjectsEditor::OnHelpSelected( wxCommandEvent& event )
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/edit_object"));
+    gd::HelpFileAccess::Get()->OpenPage("gdevelop/documentation/manual/edit_object");
 }
 
 void ObjectsEditor::ConnectEvents()

--- a/IDE/EditObjectGroup.cpp
+++ b/IDE/EditObjectGroup.cpp
@@ -232,5 +232,5 @@ void EditObjectGroup::OnDelObjetSelected(wxCommandEvent& event)
 
 void EditObjectGroup::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/edit_group"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/edit_group");
 }

--- a/IDE/EditPropScene.cpp
+++ b/IDE/EditPropScene.cpp
@@ -214,5 +214,5 @@ void EditPropScene::OnPanel1LeftUp(wxMouseEvent& event)
 
 void EditPropScene::OnAideBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/edit_projman"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/edit_projman");
 }

--- a/IDE/EventsEditor.cpp
+++ b/IDE/EventsEditor.cpp
@@ -1605,7 +1605,7 @@ void EventsEditor::OnredoMenuSelected(wxCommandEvent& event)
 
 void EventsEditor::OnHelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/edit_event"));
+    gd::HelpFileAccess::Get()->OpenPage("gdevelop/documentation/manual/edit_event");
 }
 
 void EventsEditor::OnEventStoreBtClick( wxCommandEvent& event )

--- a/IDE/GeneratePassword.cpp
+++ b/IDE/GeneratePassword.cpp
@@ -126,7 +126,7 @@ namespace
 void GeneratePassword::OnCreerBtClick(wxCommandEvent& event)
 {
 
-    string carac = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789^$ù*!§";
+    string carac = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789^$ï¿½*!ï¿½";
     long number;
     longEdit->GetValue().ToLong(&number);
     if ( number < 1 ) return;
@@ -154,5 +154,5 @@ void GeneratePassword::OnOkBtClick(wxCommandEvent& event)
 
 void GeneratePassword::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/events_editor/parameters"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/events_editor/parameters");
 }

--- a/IDE/InstructionSelectorDialog.cpp
+++ b/IDE/InstructionSelectorDialog.cpp
@@ -519,9 +519,9 @@ void InstructionSelectorDialog::OnCancelBtClick(wxCommandEvent& event)
 
 void InstructionSelectorDialog::OnHelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(editingAction ?
-        _("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/events_editor/action") :
-        _("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/events_editor/condition"));
+    gd::HelpFileAccess::Get()->OpenPage(editingAction ?
+        "game_develop/documentation/manual/events_editor/action" :
+        "game_develop/documentation/manual/events_editor/condition");
 }
 
 void InstructionSelectorDialog::OnmoreBtClick(wxCommandEvent& event)

--- a/IDE/InstructionSelectorDialog.cpp
+++ b/IDE/InstructionSelectorDialog.cpp
@@ -63,6 +63,7 @@ const long InstructionSelectorDialog::ID_HYPERLINKCTRL1 = wxNewId();
 const long InstructionSelectorDialog::ID_BUTTON1 = wxNewId();
 const long InstructionSelectorDialog::ID_BUTTON2 = wxNewId();
 const long InstructionSelectorDialog::ID_CHECKBOX1 = wxNewId();
+const long InstructionSelectorDialog::ID_INSTRUCTIONHELPLINKCTRL = wxNewId();
 
 InstructionSelectorDialog::InstructionSelectorDialog(wxWindow* parent, gd::Project & game_, gd::Layout & scene_, bool chooseAction) :
     game(game_),
@@ -127,6 +128,8 @@ InstructionSelectorDialog::InstructionSelectorDialog(wxWindow* parent, gd::Proje
     instructionDescriptionTxt = new wxStaticText(this, ID_STATICTEXT2, editingAction ? _("Choose an action in the list") : _("Choose a condition in the list"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT2"));
     BoxSizer3->Add(instructionDescriptionTxt, 1, wxALL|wxEXPAND|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
     rightPartSizer->Add(BoxSizer3, 0, wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
+    instructionHelpLinkCtrl = new wxHyperlinkCtrl(this, ID_INSTRUCTIONHELPLINKCTRL, _("Help on this ") + (editingAction ? _("action") : _("condition")), "");
+    rightPartSizer->Add(instructionHelpLinkCtrl, 0, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 0);
     BoxSizer1 = new wxBoxSizer(wxHORIZONTAL);
     StaticLine1 = new wxStaticLine(this, ID_STATICLINE1, wxDefaultPosition, wxSize(480,-1), wxLI_HORIZONTAL, _T("ID_STATICLINE1"));
     BoxSizer1->Add(StaticLine1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 3);
@@ -191,6 +194,7 @@ InstructionSelectorDialog::InstructionSelectorDialog(wxWindow* parent, gd::Proje
     Connect(ID_HYPERLINKCTRL1,wxEVT_COMMAND_HYPERLINK,(wxObjectEventFunction)&InstructionSelectorDialog::OnHelpBtClick);
     Connect(ID_BUTTON1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&InstructionSelectorDialog::OnOkBtClick);
     Connect(ID_BUTTON2,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&InstructionSelectorDialog::OnCancelBtClick);
+    Connect(ID_INSTRUCTIONHELPLINKCTRL, wxEVT_HYPERLINK, (wxObjectEventFunction)&InstructionSelectorDialog::OnInstructionHelpLinkCtrlClicked);
 
     #if defined(__WXMSW__) //Offer nice look to list
     wxUxThemeEngine* theme =  wxUxThemeEngine::GetIfActive();
@@ -411,7 +415,11 @@ void InstructionSelectorDialog::OninstructionsTreeSelectionChanged(wxTreeEvent& 
 
 void InstructionSelectorDialog::RefreshFromInstruction()
 {
-    if ( instructionType.empty() ) return;
+    if ( instructionType.empty() )
+    {
+        instructionHelpLinkCtrl->Hide();
+        return;
+    }
 
     const gd::InstructionMetadata & instructionMetadata = editingAction ?
         gd::MetadataProvider::GetActionMetadata(game.GetCurrentPlatform(), instructionType) :
@@ -427,6 +435,9 @@ void InstructionSelectorDialog::RefreshFromInstruction()
     instructionDescriptionTxt->Wrap( 450 );
     if ( instructionMetadata.GetBitmapIcon().IsOk() ) ActionImg->SetBitmap( instructionMetadata.GetBitmapIcon() );
     else ActionImg->SetBitmap(gd::CommonBitmapManager::Get()->unknownAction24);
+
+    //Show or hide the instructionHelpLinkCtrl
+    instructionHelpLinkCtrl->Show( instructionMetadata.GetHelpPage() != "" );
 
     //Update parameters controls
     parametersHelper.UpdateControls(instructionMetadata.parameters.size());
@@ -540,4 +551,15 @@ void InstructionSelectorDialog::OnsearchCtrlText(wxCommandEvent& event)
 void InstructionSelectorDialog::OninstructionsTreeItemActivated(wxTreeEvent& event)
 {
     if ( !ParaEdit.empty() ) ParaEdit[0]->SetFocus();
+}
+
+void InstructionSelectorDialog::OnInstructionHelpLinkCtrlClicked(wxHyperlinkEvent& event)
+{
+    if ( instructionType.empty() ) return;
+
+    const gd::InstructionMetadata & instructionMetadata = editingAction ?
+        gd::MetadataProvider::GetActionMetadata(game.GetCurrentPlatform(), instructionType) :
+        gd::MetadataProvider::GetConditionMetadata(game.GetCurrentPlatform(), instructionType);
+
+    gd::HelpFileAccess::Get()->OpenPage( instructionMetadata.GetHelpPage() );
 }

--- a/IDE/InstructionSelectorDialog.h
+++ b/IDE/InstructionSelectorDialog.h
@@ -68,6 +68,7 @@ public:
 	wxNotebook* objectsListsNotebook;
 	wxSearchCtrl* objectsSearchCtrl;
 	wxStaticText* instructionDescriptionTxt;
+	wxHyperlinkCtrl* instructionHelpLinkCtrl;
 	wxCheckBox* objSortCheck;
 	wxTreeCtrl* instructionsTree;
 
@@ -90,6 +91,7 @@ protected:
 	static const long ID_BUTTON1;
 	static const long ID_BUTTON2;
 	static const long ID_CHECKBOX1;
+	static const long ID_INSTRUCTIONHELPLINKCTRL;
 
 private:
 
@@ -109,6 +111,7 @@ private:
 	void OnsearchCtrlText(wxCommandEvent& event);
 	void OninstructionsTreeItemActivated(wxTreeEvent& event);
 	void OnobjectinstructionsTreeItemActivated(wxTreeEvent& event);
+	void OnInstructionHelpLinkCtrlClicked(wxHyperlinkEvent& event);
 	void RefreshObjectsLists();
     bool MatchSearchCriteria(gd::String search, const gd::InstructionMetadata & instrMetadata);
 
@@ -127,4 +130,3 @@ private:
 };
 
 #endif
-

--- a/IDE/MAJ.cpp
+++ b/IDE/MAJ.cpp
@@ -263,7 +263,7 @@ void MAJ::OndownloadAndInstallBtClick(wxCommandEvent& event)
 
 void MAJ::OnHelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/update"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/update");
 }
 
 #endif

--- a/IDE/MainFrame_Help.cpp
+++ b/IDE/MainFrame_Help.cpp
@@ -17,7 +17,7 @@
  */
 void MainFrame::OnMenuAideSelected( wxCommandEvent& event )
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://wiki.compilgames.net/doku.php/en/game_develop/documentation"));
+    gd::HelpFileAccess::Get()->OpenPage("gdevelop/documentation");
 }
 
 /**
@@ -25,7 +25,7 @@ void MainFrame::OnMenuAideSelected( wxCommandEvent& event )
  */
 void MainFrame::OnMenuTutoSelected(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/tutorials/beginnertutorial"));
+    gd::HelpFileAccess::Get()->OpenPage("gdevelop/tutorials/beginnertutorial");
 }
 
 /**

--- a/IDE/Preferences.cpp
+++ b/IDE/Preferences.cpp
@@ -1503,7 +1503,7 @@ void Preferences::OnInactifColor2PnlRightUp( wxMouseEvent& event )
 
 void Preferences::OnAideBtClick( wxCommandEvent& event )
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation")); //TODO
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation"); //TODO
 }
 
 void Preferences::OnBrowseDossierTempBtClick( wxCommandEvent& event )

--- a/IDE/ProjectManager.cpp
+++ b/IDE/ProjectManager.cpp
@@ -1976,7 +1976,7 @@ void ProjectManager::OnCreateNewCppFileSelected(wxCommandEvent& event)
  */
 void ProjectManager::OnRibbonHelpSelected(wxRibbonButtonBarEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://wiki.compilgames.net/doku.php/en/game_develop/documentation"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation");
 }
 
 namespace {

--- a/IDE/SearchEvents.cpp
+++ b/IDE/SearchEvents.cpp
@@ -344,7 +344,7 @@ void SearchEvents::OnpreviousBtClick(wxCommandEvent&)
 
 void SearchEvents::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/edit_event_find"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/edit_event_find");
 }
 
 void SearchEvents::OnKeyDown(wxKeyEvent& event)

--- a/IDE/SigneModification.cpp
+++ b/IDE/SigneModification.cpp
@@ -76,5 +76,5 @@ void SigneModification::OnOkBtClick(wxCommandEvent& event)
 
 void SigneModification::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/events_editor/parameters"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/events_editor/parameters");
 }

--- a/IDE/SigneTest.cpp
+++ b/IDE/SigneTest.cpp
@@ -83,5 +83,5 @@ void SigneTest::OnOkBtClick(wxCommandEvent& event)
 
 void SigneTest::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/events_editor/parameters"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/events_editor/parameters");
 }

--- a/IDE/TrueOrFalse.cpp
+++ b/IDE/TrueOrFalse.cpp
@@ -97,5 +97,5 @@ void TrueOrFalse::OnButton1Click(wxCommandEvent& event)
 
 void TrueOrFalse::OnhelpBtClick(wxCommandEvent& event)
 {
-    gd::HelpFileAccess::Get()->OpenURL(_("http://www.wiki.compilgames.net/doku.php/en/game_develop/documentation/manual/events_editor/parameters"));
+    gd::HelpFileAccess::Get()->OpenPage("game_develop/documentation/manual/events_editor/parameters");
 }


### PR DESCRIPTION
 - add a gd::HelpFileAccess::OpenPage method to launch the help from the wiki using the user language (if supported by the wiki, english otherwise).
 - add a SetHelpPage method in gd::InstructionMetadata to set an help page for instructions. A button is shown under the instruction description to open the related help.