### PR TITLE
Change sign test text to conventional terms

### DIFF
--- a/IDE/SigneTest.cpp
+++ b/IDE/SigneTest.cpp
@@ -39,9 +39,9 @@ SigneTest::SigneTest(wxWindow* parent)
 	{
 		_("= ( equal to )"),
 		_("> ( greater than )"),
-		_("< ( lesser than )"),
+		_("< ( less than )"),
 		_(">= ( greater than or equal to )"),
-		_("<= ( lesser than or equal to )"),
+		_("<= ( less than or equal to )"),
 		_("!= ( different of )")
 	};
 	SigneRadio = new wxRadioBox(this, ID_RADIOBOX1, _("Choose the comparison operator"), wxDefaultPosition, wxDefaultSize, 6, __wxRadioBoxChoices_1, 1, wxRA_HORIZONTAL, wxDefaultValidator, _T("ID_RADIOBOX1"));

--- a/IDE/SigneTest.cpp
+++ b/IDE/SigneTest.cpp
@@ -42,7 +42,7 @@ SigneTest::SigneTest(wxWindow* parent)
 		_("< ( less than )"),
 		_(">= ( greater than or equal to )"),
 		_("<= ( less than or equal to )"),
-		_("!= ( different of )")
+		_("!= ( not equal to )")
 	};
 	SigneRadio = new wxRadioBox(this, ID_RADIOBOX1, _("Choose the comparison operator"), wxDefaultPosition, wxDefaultSize, 6, __wxRadioBoxChoices_1, 1, wxRA_HORIZONTAL, wxDefaultValidator, _T("ID_RADIOBOX1"));
 	FlexGridSizer1->Add(SigneRadio, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);

--- a/IDE/wxsmith/SigneTest.wxs
+++ b/IDE/wxsmith/SigneTest.wxs
@@ -14,7 +14,7 @@
 						<item>&lt; ( less than )</item>
 						<item>&gt;= ( greater than or equal to )</item>
 						<item>&lt;= ( less than or equal to )</item>
-						<item>!= ( different of )</item>
+						<item>!= ( not equal to )</item>
 					</content>
 					<default>-1</default>
 					<style>wxRA_HORIZONTAL</style>

--- a/IDE/wxsmith/SigneTest.wxs
+++ b/IDE/wxsmith/SigneTest.wxs
@@ -11,9 +11,9 @@
 					<content>
 						<item>= ( equal to )</item>
 						<item>&gt; ( greater than )</item>
-						<item>&lt; ( lesser than )</item>
+						<item>&lt; ( less than )</item>
 						<item>&gt;= ( greater than or equal to )</item>
-						<item>&lt;= ( lesser than or equal to )</item>
+						<item>&lt;= ( less than or equal to )</item>
 						<item>!= ( different of )</item>
 					</content>
 					<default>-1</default>


### PR DESCRIPTION
The terms in the sign test files were slightly peculiar. I have changed them to match more conventional terms, as referenced below. The changes are as such:

* 'lesser than' -> 'less than'
* 'different of' -> 'not equal to'

# References
These references are simply intended to demonstrate common usage and terminology relating to the '>', '<', and '!=' symbols.

* Wikipedia: 
  * [Inequality (mathematics)](https://en.wikipedia.org/wiki/Inequality_%28mathematics%29)
  * [Less-than sign](https://en.wikipedia.org/wiki/Less-than_sign)
  * [Relational operator - standard relational operators](https://en.wikipedia.org/wiki/Relational_operator#Standard_relational_operators)
* Khan Academy [Greater-than and less-than symbols](https://www.khanacademy.org/math/pre-algebra/applying-math-reasoning-topic/greater-than-less-than/v/greater-than-and-less-than-symbols)
* Mozilla Developer Network: [Less than operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Less_than_operator_%28%3C%29)