### PR TITLE
wxTextCtrl and and wxMenuItem updates

### DIFF
--- a/IDE/BugReport.cpp
+++ b/IDE/BugReport.cpp
@@ -115,7 +115,7 @@ BugReport::BugReport( wxWindow* parent, const std::vector<gd::String> & openedFi
     FlexGridSizer4->AddGrowableRow(3);
     StaticText3 = new wxStaticText(Panel3, ID_STATICTEXT3, _("To help us solve the problem, try to describe the error as precisely as\nyou can. Indicate if possible:\n-How did the error happened (Click on a button ...)\n-In which part of program (Scene editor, events editor...)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT3"));
     FlexGridSizer4->Add(StaticText3, 1, wxALL|wxEXPAND|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
-    UserReportEdit = new wxTextCtrl(Panel3, ID_TEXTCTRL1, wxEmptyString, wxDefaultPosition, wxSize(408,100), wxTE_AUTO_SCROLL|wxTE_MULTILINE, wxDefaultValidator, _T("ID_TEXTCTRL1"));
+    UserReportEdit = new wxTextCtrl(Panel3, ID_TEXTCTRL1, wxEmptyString, wxDefaultPosition, wxSize(408,100), wxTE_MULTILINE, wxDefaultValidator, _T("ID_TEXTCTRL1"));
     FlexGridSizer4->Add(UserReportEdit, 1, wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
     FlexGridSizer2 = new wxFlexGridSizer(0, 1, 0, 0);
     StaticText1 = new wxStaticText(Panel3, ID_STATICTEXT1, _("You can enter your email: (optional, so as to contact you if we need more information)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT1"));
@@ -145,7 +145,7 @@ BugReport::BugReport( wxWindow* parent, const std::vector<gd::String> & openedFi
     FlexGridSizer10->AddGrowableRow(1);
     StaticText7 = new wxStaticText(Panel4, ID_STATICTEXT7, _("Here is a list of the projects opened during the last session:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT7"));
     FlexGridSizer10->Add(StaticText7, 1, wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-    openedFilesEdit = new wxTextCtrl(Panel4, ID_TEXTCTRL2, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_AUTO_SCROLL|wxTE_MULTILINE|wxTE_READONLY, wxDefaultValidator, _T("ID_TEXTCTRL2"));
+    openedFilesEdit = new wxTextCtrl(Panel4, ID_TEXTCTRL2, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxTE_READONLY, wxDefaultValidator, _T("ID_TEXTCTRL2"));
     FlexGridSizer10->Add(openedFilesEdit, 1, wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
     FlexGridSizer5->Add(FlexGridSizer10, 1, wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
     StaticText4 = new wxStaticText(Panel4, ID_STATICTEXT4, _("GDevelop may have made automatic backups of these projects. When you\'ll\nclose this window, the backups will be opened. If these backup are not corrupted,\nyou can save them over the original project files."), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT4"));

--- a/IDE/EventsEditor.cpp
+++ b/IDE/EventsEditor.cpp
@@ -159,7 +159,7 @@ void EventsEditor::Init(wxWindow* parent)
 	FlexGridSizer2 = new wxFlexGridSizer(0, 3, 0, 0);
 	FlexGridSizer2->AddGrowableCol(0);
 	FlexGridSizer2->AddGrowableRow(0);
-	liveEdit = new wxTextCtrl(liveEditingPanel, ID_TEXTCTRL1, wxEmptyString, wxDefaultPosition, wxSize(280,21), wxTE_AUTO_SCROLL|wxTE_PROCESS_ENTER, wxDefaultValidator, _T("ID_TEXTCTRL1"));
+	liveEdit = new wxTextCtrl(liveEditingPanel, ID_TEXTCTRL1, wxEmptyString, wxDefaultPosition, wxSize(280,21), wxTE_PROCESS_ENTER, wxDefaultValidator, _T("ID_TEXTCTRL1"));
 	FlexGridSizer2->Add(liveEdit, 1, wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	parameterEditBt = new wxBitmapButton(liveEditingPanel, ID_BITMAPBUTTON1, gd::SkinHelper::GetIcon("edit", 16), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW, wxDefaultValidator, _T("ID_BITMAPBUTTON1"));
 	FlexGridSizer2->Add(parameterEditBt, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);

--- a/IDE/MAJ.cpp
+++ b/IDE/MAJ.cpp
@@ -86,7 +86,7 @@ parent(parent_)
 	StaticText1->SetFont(StaticText1Font);
 	FlexGridSizer6->Add(StaticText1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer1->Add(FlexGridSizer6, 1, wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
-	infoEdit = new wxTextCtrl(this, ID_TEXTCTRL1, _("No informations about the new version"), wxDefaultPosition, wxSize(400,227), wxTE_AUTO_SCROLL|wxTE_MULTILINE|wxTE_READONLY, wxDefaultValidator, _T("ID_TEXTCTRL1"));
+	infoEdit = new wxTextCtrl(this, ID_TEXTCTRL1, _("No informations about the new version"), wxDefaultPosition, wxSize(400,227), wxTE_MULTILINE|wxTE_READONLY, wxDefaultValidator, _T("ID_TEXTCTRL1"));
 	FlexGridSizer1->Add(infoEdit, 1, wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer1->Add(0,0,1, wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	FlexGridSizer4 = new wxFlexGridSizer(0, 2, 0, 0);

--- a/IDE/wxsmith/BugReport.wxs
+++ b/IDE/wxsmith/BugReport.wxs
@@ -120,7 +120,7 @@
 								<object class="sizeritem">
 									<object class="wxTextCtrl" name="ID_TEXTCTRL1" variable="UserReportEdit" member="yes">
 										<size>408,100</size>
-										<style>wxTE_AUTO_SCROLL|wxTE_MULTILINE</style>
+										<style>wxTE_MULTILINE</style>
 										<handler function="OnUserReportEditText" entry="EVT_TEXT" />
 									</object>
 									<flag>wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
@@ -208,7 +208,7 @@
 										</object>
 										<object class="sizeritem">
 											<object class="wxTextCtrl" name="ID_TEXTCTRL2" variable="openedFilesEdit" member="yes">
-												<style>wxTE_AUTO_SCROLL|wxTE_MULTILINE|wxTE_READONLY</style>
+												<style>wxTE_MULTILINE|wxTE_READONLY</style>
 											</object>
 											<flag>wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 											<border>5</border>

--- a/IDE/wxsmith/ConsoleFrame.wxs
+++ b/IDE/wxsmith/ConsoleFrame.wxs
@@ -41,7 +41,7 @@
 						<object class="sizeritem">
 							<object class="wxTextCtrl" name="ID_TEXTCTRL1" variable="consoleTextCtrl" member="yes">
 								<size>239,140</size>
-								<style>wxTE_AUTO_SCROLL|wxTE_MULTILINE|wxTE_RICH</style>
+								<style>wxTE_MULTILINE|wxTE_RICH</style>
 							</object>
 							<flag>wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 							<border>5</border>

--- a/IDE/wxsmith/EventsEditor.wxs
+++ b/IDE/wxsmith/EventsEditor.wxs
@@ -33,7 +33,7 @@
 							<object class="sizeritem">
 								<object class="wxTextCtrl" name="ID_TEXTCTRL1" variable="liveEdit" member="yes">
 									<size>280,21</size>
-									<style>wxTE_AUTO_SCROLL|wxTE_PROCESS_ENTER</style>
+									<style>wxTE_PROCESS_ENTER</style>
 									<handler function="OnliveEditText" entry="EVT_TEXT" />
 									<handler function="OnliveEditTextEnter" entry="EVT_TEXT_ENTER" />
 								</object>

--- a/IDE/wxsmith/MAJ.wxs
+++ b/IDE/wxsmith/MAJ.wxs
@@ -70,7 +70,7 @@
 				<object class="wxTextCtrl" name="ID_TEXTCTRL1" variable="infoEdit" member="yes">
 					<value>No informations about the new version</value>
 					<size>400,227</size>
-					<style>wxTE_AUTO_SCROLL|wxTE_MULTILINE|wxTE_READONLY</style>
+					<style>wxTE_MULTILINE|wxTE_READONLY</style>
 				</object>
 				<flag>wxALL|wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 				<border>5</border>

--- a/IDE/wxstedit/src/stemenum.cpp
+++ b/IDE/wxstedit/src/stemenum.cpp
@@ -1079,7 +1079,7 @@ bool wxSTEditorMenuManager::DoSetTextItem(wxMenu *menu, wxMenuBar *menuBar,
         wxMenuItem *menuItem = menu->FindItem(menu_id);
         if (menuItem)
         {
-            menuItem->SetText(val);
+            menuItem->SetItemLabel(val);
             ret = true;
         }
     }
@@ -1088,7 +1088,7 @@ bool wxSTEditorMenuManager::DoSetTextItem(wxMenu *menu, wxMenuBar *menuBar,
         wxMenuItem *menuItem = menuBar->FindItem(menu_id);
         if (menuItem)
         {
-            menuItem->SetText(val);
+            menuItem->SetItemLabel(val);
             ret = true;
         }
     }


### PR DESCRIPTION
While attempting to build gdevelop on Fedora 21 using GCC 4.9.2 against a current wxWidgets master built with 2.8 compatibility turned off, I ran into a few compilation errors that were fixed with these changes.