### PR TITLE
Updated wxBrush styles.

### DIFF
--- a/Core/GDCore/Events/Builtin/CommentEvent.cpp
+++ b/Core/GDCore/Events/Builtin/CommentEvent.cpp
@@ -87,7 +87,7 @@ void CommentEvent::Render(wxDC & dc, int x, int y, unsigned int width, gd::Event
     unsigned int text2Height = renderingHelper->GetHTMLRenderer().GetTotalHeight();
 
     //Prepare background
-    dc.SetBrush(wxBrush(wxColour(r, v, b), wxTRANSPARENT));
+    dc.SetBrush(wxBrush(wxColour(r, v, b), wxBRUSHSTYLE_TRANSPARENT));
     dc.SetPen(wxPen(wxColour(r/2, v/2, b/2), 1));
 
     //Draw the background

--- a/Extensions/PhysicsBehavior/CustomPolygonDialog.cpp
+++ b/Extensions/PhysicsBehavior/CustomPolygonDialog.cpp
@@ -290,7 +290,7 @@ void CustomPolygonDialog::OnpreviewPnlPaint(wxPaintEvent& event)
     }
 
     //Draw polygon
-    dc.SetBrush(wxBrush(wxColor(50, 57, 122), wxFDIAGONAL_HATCH));
+    dc.SetBrush(wxBrush(wxColor(50, 57, 122), wxBRUSHSTYLE_FDIAGONAL_HATCH));
     dc.SetPen(wxPen(wxColor(50, 57, 122)));
     dc.DrawPolygon(points.size(), &points[0]);
 
@@ -298,7 +298,7 @@ void CustomPolygonDialog::OnpreviewPnlPaint(wxPaintEvent& event)
 
     if(autoResizingCheckBox->GetValue() && !OnOriginRadioBt->GetValue())
     {
-        dc.SetBrush(wxBrush(wxColor(48, 137, 255), wxTRANSPARENT));
+        dc.SetBrush(wxBrush(wxColor(48, 137, 255), wxBRUSHSTYLE_TRANSPARENT));
         dc.SetPen(wxPen(wxColor(48, 137, 255)));
 
         std::vector<wxPoint> polygonSizePoints;

--- a/GDCpp/GDCpp/IDE/Dialogs/ProfileDlg.cpp
+++ b/GDCpp/GDCpp/IDE/Dialogs/ProfileDlg.cpp
@@ -226,7 +226,7 @@ void ProfileDlg::OnratioGraphicsPaint(wxPaintEvent& event)
                                      static_cast<double>(ratioGraphics->GetSize().y)-static_cast<double>(totalTimeData[i])/static_cast<double>(maximumTime)*static_cast<double>(ratioGraphics->GetSize().y)));
         points.push_back(wxPoint(points.back().x, ratioGraphics->GetSize().y));
 
-        dc.SetBrush( wxBrush( wxColour(255, 209, 12), wxSOLID ) );
+        dc.SetBrush( wxBrush( wxColour(255, 209, 12), wxBRUSHSTYLE_SOLID ) );
         dc.SetPen(wxPen(wxColour( 255, 137, 12 )));
         if ( !points.empty() ) dc.DrawPolygon(points.size(), &points[0]);
     }
@@ -243,7 +243,7 @@ void ProfileDlg::OnratioGraphicsPaint(wxPaintEvent& event)
                                      static_cast<double>(ratioGraphics->GetSize().y)-static_cast<double>(eventsData[i])/static_cast<double>(maximumTime)*static_cast<double>(ratioGraphics->GetSize().y)));
         points.push_back(wxPoint(points.back().x, ratioGraphics->GetSize().y));
 
-        dc.SetBrush( wxBrush( wxColour(116, 132, 255), wxSOLID ) );
+        dc.SetBrush( wxBrush( wxColour(116, 132, 255), wxBRUSHSTYLE_SOLID ) );
         dc.SetPen(wxPen(wxColour( 77, 88, 168 )));
         if ( !points.empty() ) dc.DrawPolygon(points.size(), &points[0]);
     }

--- a/IDE/wxstedit/src/stesplit.cpp
+++ b/IDE/wxstedit/src/stesplit.cpp
@@ -504,7 +504,7 @@ void wxSTEditorSplitter::DoPaint(wxDC& dc)
         wxRect rect(left-1, top, clientSize.x-left+1, clientSize.y-top+1);
         if (!rect.IsEmpty())
         {
-            dc.SetBrush(wxBrush(GetBackgroundColour(), wxSOLID));
+            dc.SetBrush(wxBrush(GetBackgroundColour(), wxBRUSHSTYLE_SOLID));
             dc.SetPen(*wxTRANSPARENT_PEN);
             dc.DrawRectangle(rect);
         }


### PR DESCRIPTION
Changed the following in wxBrush constructors:
wxTRANSPARENT -> wxBRUSHSTYLE_TRANSPARENT
wxSOLID -> wxBRUSHSTYLE_SOLID
wxFDIAGONAL_HATCH -> wxBRUSHSTYLE_FDIAGONAL_HATCH
This fixed 6 warnings in the build.