### PR TITLE
b2TOISolver initialization fix

### DIFF
--- a/Extensions/PhysicsBehavior/Box2D/Box2D/Box2D/Dynamics/Contacts/b2TOISolver.cpp
+++ b/Extensions/PhysicsBehavior/Box2D/Box2D/Box2D/Dynamics/Contacts/b2TOISolver.cpp
@@ -38,7 +38,7 @@ b2TOISolver::b2TOISolver(b2StackAllocator* allocator)
 {
 	m_allocator = allocator;
 	m_constraints = NULL;
-	m_count = NULL;
+	m_count = 0;
 	m_toiBody = NULL;
 }
 


### PR DESCRIPTION
A non-pointer data member (int32 m_count), was incorrectly being initialized to NULL instead of 0 and gcc 4.9.2 was pointing this out:

```
[ 83%] Building CXX object Extensions/PhysicsBehavior/CMakeFiles/PhysicsBehavior.dir/Box2D/Box2D/Box2D/Dynamics/Contacts/b2TOISolver.cpp.o
/home/pstieber/OutsideSource/gdevelop/GD/Extensions/PhysicsBehavior/Box2D/Box2D/Box2D/Dynamics/Contacts/b2TOISolver.cpp: In constructor ‘b2TOISolver::b2TOISolver(b2StackAllocator*)’:
/home/pstieber/OutsideSource/gdevelop/GD/Extensions/PhysicsBehavior/Box2D/Box2D/Box2D/Dynamics/Contacts/b2TOISolver.cpp:41:10: warning: converting to non-pointer type ‘int32 {aka int}’ from NULL [-Wconversion-null]
  m_count = NULL;
          ^
```
This commit removed the warning.