### PR TITLE
Fix crash when trying to (de)activate a behavior on an object that doesn't have the behavior + bonus

### DIFF
--- a/Core/GDCore/Extensions/Platform.cpp
+++ b/Core/GDCore/Extensions/Platform.cpp
@@ -95,16 +95,16 @@ std::shared_ptr<gd::Object> Platform::CreateObject(gd::String type, const gd::St
     return std::shared_ptr<gd::Object> (object);
 }
 
-gd::Behavior* Platform::CreateBehavior(const gd::String & behaviorType) const
+std::unique_ptr<gd::Behavior> Platform::CreateBehavior(const gd::String & behaviorType) const
 {
     for (std::size_t i =0;i<extensionsLoaded.size();++i)
     {
-        Behavior* behavior = extensionsLoaded[i]->CreateBehavior(behaviorType);
-        if ( behavior != NULL )
+        std::unique_ptr<gd::Behavior> behavior = extensionsLoaded[i]->CreateBehavior(behaviorType);
+        if ( behavior )
             return behavior;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 std::shared_ptr<gd::BehaviorsSharedData> Platform::CreateBehaviorSharedDatas(const gd::String & behaviorType) const

--- a/Core/GDCore/Extensions/Platform.h
+++ b/Core/GDCore/Extensions/Platform.h
@@ -6,10 +6,10 @@
 
 #ifndef GDCORE_PLATFORM_H
 #define GDCORE_PLATFORM_H
+#include <map>
 #include <memory>
 #include <vector>
 #include "GDCore/String.h"
-#include <map>
 #include "GDCore/Project/ChangesNotifier.h"
 #include "GDCore/Project/LayoutEditorPreviewer.h"
 namespace gd { class InstructionsMetadataHolder; }
@@ -123,7 +123,7 @@ public:
     /**
      * \brief Create a behavior
      */
-    gd::Behavior* CreateBehavior(const gd::String & type) const;
+    std::unique_ptr<gd::Behavior> CreateBehavior(const gd::String & type) const;
 
     /**
      * \brief Create a behavior shared data object.

--- a/Core/GDCore/Extensions/PlatformExtension.cpp
+++ b/Core/GDCore/Extensions/PlatformExtension.cpp
@@ -294,12 +294,12 @@ CreateFunPtr PlatformExtension::GetObjectCreationFunctionPtr(gd::String objectTy
     return NULL;
 }
 
-Behavior* PlatformExtension::CreateBehavior(gd::String type) const
+std::unique_ptr<gd::Behavior> PlatformExtension::CreateBehavior(gd::String type) const
 {
     if ( behaviorsInfo.find(type) != behaviorsInfo.end())
-        return behaviorsInfo.find(type)->second.Get()->Clone();
+        return std::unique_ptr<gd::Behavior>(behaviorsInfo.find(type)->second.Get()->Clone());
 
-    return NULL;
+    return nullptr;
 }
 
 

--- a/Core/GDCore/Extensions/PlatformExtension.h
+++ b/Core/GDCore/Extensions/PlatformExtension.h
@@ -259,7 +259,7 @@ public:
      *
      * Return NULL if \a behaviorType is not provided by the extension.
      */
-    gd::Behavior* CreateBehavior(gd::String behaviorType) const;
+    std::unique_ptr<gd::Behavior> CreateBehavior(gd::String behaviorType) const;
 
     /**
      * \brief Create shared data for a behavior

--- a/Core/GDCore/Project/Object.cpp
+++ b/Core/GDCore/Project/Object.cpp
@@ -104,15 +104,18 @@ std::map<gd::String, gd::PropertyDescriptor> Object::GetProperties(gd::Project &
 
 gd::Behavior * Object::AddNewBehavior(gd::Project & project, const gd::String & type, const gd::String & name)
 {
-    Behavior * behavior = project.GetCurrentPlatform().CreateBehavior(type);
+    std::unique_ptr<gd::Behavior> behavior = project.GetCurrentPlatform().CreateBehavior(type);
 
     if ( behavior )
     {
         behavior->SetName(name);
-        behaviors[behavior->GetName()] = std::unique_ptr<Behavior>(behavior);
+        behaviors[name] = std::move(behavior);
+        return behaviors[name].get();
     }
-
-    return behavior;
+    else
+    {
+        return nullptr;
+    }
 }
 
 sf::Vector2f Object::GetInitialInstanceDefaultSize(gd::InitialInstance & instance, gd::Project & project, gd::Layout & layout) const
@@ -163,12 +166,12 @@ void Object::UnserializeFrom(gd::Project & project, const SerializerElement & el
                 .FindAndReplace("Automatism", "Behavior");
             gd::String autoName = behaviorElement.GetStringAttribute("name", "", "Name");
 
-            Behavior* behavior = project.CreateBehavior(autoType);
-            if ( behavior != NULL )
+            std::unique_ptr<Behavior> behavior = project.CreateBehavior(autoType);
+            if ( behavior )
             {
                 behavior->SetName(autoName);
                 behavior->UnserializeFrom(behaviorElement);
-                behaviors[behavior->GetName()] = std::unique_ptr<Behavior>(behavior);
+                behaviors[autoName] = std::move(behavior);
             }
             else
                 std::cout << "WARNING: Unknown behavior " << autoType << std::endl;
@@ -187,12 +190,12 @@ void Object::UnserializeFrom(gd::Project & project, const SerializerElement & el
                 .FindAndReplace("Automatism", "Behavior"); //Compatibility with GD <= 4
             gd::String autoName = behaviorElement.GetStringAttribute("name");
 
-            Behavior* behavior = project.CreateBehavior(autoType);
-            if ( behavior != NULL )
+            std::unique_ptr<Behavior> behavior = project.CreateBehavior(autoType);
+            if ( behavior )
             {
                 behavior->SetName(autoName);
                 behavior->UnserializeFrom(behaviorElement);
-                behaviors[behavior->GetName()] = std::unique_ptr<Behavior>(behavior);
+                behaviors[autoName] = std::move(behavior);
             }
             else
                 std::cout << "WARNING: Unknown behavior " << autoType << std::endl;

--- a/Core/GDCore/Project/Object.h
+++ b/Core/GDCore/Project/Object.h
@@ -9,10 +9,10 @@
 #include "GDCore/String.h"
 #include <vector>
 #include <map>
+#include "GDCore/Project/Behavior.h"
 #include "GDCore/Project/VariablesContainer.h"
 #include <SFML/System/Vector2.hpp>
 namespace gd { class PropertyDescriptor; }
-namespace gd { class Behavior; }
 namespace gd { class Project; }
 namespace gd { class Layout; }
 namespace gd { class MainFrameWrapper; }
@@ -262,7 +262,7 @@ public:
     /**
      * \brief Get a read-only access to the map containing the behaviors.
      */
-    const std::map<gd::String, gd::Behavior* > & GetAllBehaviors() const {return behaviors;};
+    const std::map<gd::String, std::unique_ptr<gd::Behavior> > & GetAllBehaviors() const {return behaviors;};
     ///@}
 
     /** \name Variable management
@@ -302,7 +302,7 @@ public:
 protected:
     gd::String                             name; ///< The full name of the object
     gd::String                             type; ///< Which type is the object. ( To test if we can do something reserved to some objects with it )
-    std::map<gd::String, gd::Behavior* > behaviors; ///<Contains all behaviors of the object. Behaviors are the ownership of the object
+    std::map<gd::String, std::unique_ptr<gd::Behavior> > behaviors; ///<Contains all behaviors of the object. Behaviors are the ownership of the object
     gd::VariablesContainer                  objectVariables; ///<List of the variables of the object
 
     /**

--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -121,17 +121,17 @@ std::shared_ptr<gd::Object> Project::CreateObject(const gd::String & type, const
     return std::shared_ptr<gd::Object>();
 }
 
-gd::Behavior* Project::CreateBehavior(const gd::String & type, const gd::String & platformName)
+std::unique_ptr<gd::Behavior> Project::CreateBehavior(const gd::String & type, const gd::String & platformName)
 {
     for (std::size_t i = 0;i<platforms.size();++i)
     {
         if ( !platformName.empty() && platforms[i]->GetName() != platformName ) continue;
 
-        gd::Behavior* behavior = platforms[i]->CreateBehavior(type);
+        std::unique_ptr<gd::Behavior> behavior = platforms[i]->CreateBehavior(type);
         if ( behavior ) return behavior;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 std::shared_ptr<gd::BehaviorsSharedData> Project::CreateBehaviorSharedDatas(const gd::String & type, const gd::String & platformName)

--- a/Core/GDCore/Project/Project.h
+++ b/Core/GDCore/Project/Project.h
@@ -6,8 +6,9 @@
 
 #ifndef GDCORE_PROJECT_H
 #define GDCORE_PROJECT_H
-#include "GDCore/String.h"
+#include <memory>
 #include <vector>
+#include "GDCore/String.h"
 class wxPropertyGrid;
 class wxPropertyGridEvent;
 class TiXmlElement;
@@ -243,7 +244,7 @@ public:
      * \param type The type of the behavior
      * \param platformName The name of the platform to be used. If empty, the first platform supporting the object is used.
      */
-    gd::Behavior* CreateBehavior(const gd::String & type, const gd::String & platformName = "");
+    std::unique_ptr<gd::Behavior> CreateBehavior(const gd::String & type, const gd::String & platformName = "");
 
     /**
      * Create behavior shared data of the given type.

--- a/GDCpp/GDCpp/RuntimeObject.cpp
+++ b/GDCpp/GDCpp/RuntimeObject.cpp
@@ -37,7 +37,7 @@ RuntimeObject::RuntimeObject(RuntimeScene & scene, const gd::Object & object) :
     behaviors.clear();
 
     //And insert the new ones.
-    for (std::map<gd::String, Behavior* >::const_iterator it = object.GetAllBehaviors().begin() ; it != object.GetAllBehaviors().end(); ++it )
+    for (auto it = object.GetAllBehaviors().cbegin() ; it != object.GetAllBehaviors().cend(); ++it )
     {
     	behaviors[it->first] = it->second->Clone();
     	behaviors[it->first]->SetOwner(this);

--- a/GDCpp/GDCpp/RuntimeObject.cpp
+++ b/GDCpp/GDCpp/RuntimeObject.cpp
@@ -30,25 +30,18 @@ RuntimeObject::RuntimeObject(RuntimeScene & scene, const gd::Object & object) :
 {
     ClearForce();
 
-    //Do not forget to delete behaviors which are managed using raw pointers.
-    for (std::map<gd::String, Behavior* >::const_iterator it = behaviors.begin() ; it != behaviors.end(); ++it )
-    	delete it->second;
-
     behaviors.clear();
-
-    //And insert the new ones.
+    //Insert the new behaviors.
     for (auto it = object.GetAllBehaviors().cbegin() ; it != object.GetAllBehaviors().cend(); ++it )
     {
-    	behaviors[it->first] = it->second->Clone();
+    	behaviors[it->first] = std::unique_ptr<gd::Behavior>(it->second->Clone());
     	behaviors[it->first]->SetOwner(this);
     }
 }
 
 RuntimeObject::~RuntimeObject()
 {
-    //Do not forget to delete behaviors and forces which are managed using raw pointers.
-    for (std::map<gd::String, Behavior* >::const_iterator it = behaviors.begin() ; it != behaviors.end(); ++it )
-    	delete it->second;
+
 }
 
 void RuntimeObject::Init(const RuntimeObject & object)
@@ -65,14 +58,10 @@ void RuntimeObject::Init(const RuntimeObject & object)
     force5 = object.force5;
     forces = object.forces;
 
-    //Do not forget to delete behaviors which are managed using raw pointers.
-    for (std::map<gd::String, Behavior* >::const_iterator it = behaviors.begin() ; it != behaviors.end(); ++it )
-    	delete it->second;
-
     behaviors.clear();
-    for (std::map<gd::String, Behavior* >::const_iterator it = object.behaviors.begin() ; it != object.behaviors.end(); ++it )
+    for (auto it = object.behaviors.cbegin() ; it != object.behaviors.cend(); ++it )
     {
-    	behaviors[it->first] = it->second->Clone();
+    	behaviors[it->first] = std::unique_ptr<gd::Behavior>(it->second->Clone());
     	behaviors[it->first]->SetOwner(this);
     }
 }
@@ -555,12 +544,12 @@ bool RuntimeObject::CursorOnObject(RuntimeScene & scene, bool)
 
 Behavior* RuntimeObject::GetBehaviorRawPointer(const gd::String & name)
 {
-    return behaviors.find(name)->second;
+    return behaviors.find(name)->second.get();
 }
 
 Behavior* RuntimeObject::GetBehaviorRawPointer(const gd::String & name) const
 {
-    return behaviors.find(name)->second;
+    return behaviors.find(name)->second.get();
 }
 
 bool RuntimeObject::ClearForce()
@@ -631,13 +620,13 @@ float RuntimeObject::TotalForceLength() const
 
 void RuntimeObject::DoBehaviorsPreEvents(RuntimeScene & scene)
 {
-    for (std::map<gd::String, Behavior* >::const_iterator it = behaviors.begin() ; it != behaviors.end(); ++it )
+    for (auto it = behaviors.cbegin() ; it != behaviors.cend(); ++it )
         it->second->StepPreEvents(scene);
 }
 
 void RuntimeObject::DoBehaviorsPostEvents(RuntimeScene & scene)
 {
-    for (std::map<gd::String, Behavior* >::const_iterator it = behaviors.begin() ; it != behaviors.end(); ++it )
+    for (auto it = behaviors.cbegin() ; it != behaviors.cend(); ++it )
         it->second->StepPostEvents(scene);
 }
 

--- a/GDCpp/GDCpp/RuntimeObject.cpp
+++ b/GDCpp/GDCpp/RuntimeObject.cpp
@@ -221,12 +221,16 @@ bool RuntimeObject::TestAngleOfDisplacement(float angle, float tolerance)
 
 void RuntimeObject::ActivateBehavior( const gd::String & behaviorName, bool activate )
 {
-    GetBehaviorRawPointer(behaviorName)->Activate(activate);
+    if(GetBehaviorRawPointer(behaviorName))
+        GetBehaviorRawPointer(behaviorName)->Activate(activate);
 }
 
 bool RuntimeObject::BehaviorActivated( const gd::String & behaviorName )
 {
-    return GetBehaviorRawPointer(behaviorName)->Activated();
+    if(GetBehaviorRawPointer(behaviorName))
+        return GetBehaviorRawPointer(behaviorName)->Activated();
+    else
+        return false;
 }
 
 double RuntimeObject::GetSqDistanceTo(double pointX, double pointY)

--- a/GDCpp/GDCpp/RuntimeObject.h
+++ b/GDCpp/GDCpp/RuntimeObject.h
@@ -9,10 +9,10 @@
 #include <string>
 #include <vector>
 #include <map>
-#include "GDCpp/RuntimeVariablesContainer.h"
+#include "GDCpp/Project/Behavior.h"
 #include "GDCpp/Force.h"
+#include "GDCpp/RuntimeVariablesContainer.h"
 #include "GDCpp/String.h"
-namespace gd { class Behavior; }
 namespace gd { class InitialInstance; }
 namespace gd { class Object; }
 namespace sf { class RenderTarget; }
@@ -438,14 +438,14 @@ protected:
 
     gd::String                                             name; ///< The full name of the object
     gd::String                                             type; ///< Which type is the object. ( To test if we can do something reserved to some objects with it )
-    float                                                   X; ///<X position on the scene
-    float                                                   Y; ///<Y position on the scene
-    int                                                     zOrder; ///<Z order on the scene, to choose if an object is displayed before another object.
-    bool                                                    hidden; ///<True to prevent the object from being rendered.
+    float                                                  X; ///<X position on the scene
+    float                                                  Y; ///<Y position on the scene
+    int                                                    zOrder; ///<Z order on the scene, to choose if an object is displayed before another object.
+    bool                                                   hidden; ///<True to prevent the object from being rendered.
     gd::String                                             layer; ///<Name of the layer on which the object is.
-    std::map<gd::String, gd::Behavior* >                 behaviors; ///<Contains all behaviors of the object. Behaviors are the ownership of the object
-    RuntimeVariablesContainer                               objectVariables; ///<List of the variables of the object
-    std::vector < Force >                                   forces; ///< Forces applied to the object
+    std::map<gd::String, std::unique_ptr<gd::Behavior>>    behaviors; ///<Contains all behaviors of the object. Behaviors are the ownership of the object
+    RuntimeVariablesContainer                              objectVariables; ///<List of the variables of the object
+    std::vector < Force >                                  forces; ///< Forces applied to the object
 
     /**
      * \brief Initialize object using another object. Used by copy-ctor and assign-op.

--- a/GDCpp/GDCpp/RuntimeObject.h
+++ b/GDCpp/GDCpp/RuntimeObject.h
@@ -6,9 +6,10 @@
 #ifndef RUNTIMEOBJECT_H
 #define RUNTIMEOBJECT_H
 
+#include <map>
+#include <memory>
 #include <string>
 #include <vector>
-#include <map>
 #include "GDCpp/Project/Behavior.h"
 #include "GDCpp/Force.h"
 #include "GDCpp/RuntimeVariablesContainer.h"


### PR DESCRIPTION
Fix #243 by testing if the behavior exists.
Also replaces ```std::map<gd::String, Behavior*>``` with ```std::map<gd::String, std::unique_ptr<Behavior>>``` so there is no need to manually delete the behaviors. ```GetBehaviorRawPointer``` still returns a raw pointer which is non-owning.

I may add another commit to add a templated function to do a deep copy of ```std::map<K, std::unique_ptr<T>>``` and ```std::vector<std::unique_ptr<T>>``` (good idea ?).