### PR TITLE
Templated objects declarations

### DIFF
--- a/Core/GDCore/DocMainPage.h
+++ b/Core/GDCore/DocMainPage.h
@@ -406,7 +406,7 @@ str += " world";
 str += " " + gd::String::From(2);
 //str now contains "Hello world 2";
 
-gd::string twopointfiveStr = "2.5";
+gd::String twopointfiveStr = "2.5";
 double twopointfive = twopointfive.To<double>();
 //twopointfive == 2.5
  \endcode
@@ -499,30 +499,22 @@ Actions are declared like this :
  * Adding an object is made using gd::PlatformExtension::AddObject method.
  *
  * \code
-        gd::ObjectMetadata & obj = AddObject("Name",
+        gd::ObjectMetadata & obj = AddObject<MyObject>(
+                           "Name",
                            _("Name displayed to users"),
                            _("Description"),
-                           "path-to-a-32-by-32-icon.png",
-                           &FunctionForCreatingTheObject);
- * \endcode
- *
- * *FunctionForCreatingTheObject* is a function that must just create the object. It should look like this:
- *
- * \code
-gd::Object * CreateTextObject(std::string name)
-{
-    return new TextObject(name);
-}
+                           "path-to-a-32-by-32-icon.png");
  * \endcode
  *
  * The *C++ platform* also requires that you call *AddRuntimeObject* to declare the RuntimeObject class associated to the object being declared:<br>
- * You must pass as parameter the name of the class inheriting from RuntimeObject and a function used to create an instance of the
- * RuntimeObject.
+ * It has two template parameters: the first one is the corresponding object class declared with *AddObject* (class inheriting from *gd::Object*) and the
+ * second one is the *RuntimeObject* class.
+ * You must pass as parameter the metadata from the object previously declared and the name of the class inheriting from RuntimeObject.
  *
  * You will also want to specify the .h file associated to the object using gd::ObjectMetadata::SetIncludeFile. For example:
  * \code
 //obj is the gd::ObjectMetadata returned when you called AddObject.
-AddRuntimeObject(obj, "RuntimeTextObject", CreateRuntimeTextObject);
+AddRuntimeObject<TextObject, RuntimeTextObject>(obj, "RuntimeTextObject");
 obj.SetIncludeFile("TextObject/TextObject.h");
  * \endcode
  *
@@ -785,5 +777,3 @@ extern "C" ExtensionBase * GD_EXTENSION_API CreateGDExtension() {
  * \brief Part of the tinyxml library
  * \ingroup TinyXml
  */
-
-

--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -19,11 +19,10 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(gd:
                           "Florian Rival",
                           "Open source (MIT License)");
 
-    gd::ObjectMetadata & obj = extension.AddObject("",
+    gd::ObjectMetadata & obj = extension.AddObject<gd::Object>("",
                _("Base object"),
                _("Base object"),
-               "res/objeticon24.png",
-               &CreateBaseObject);
+               "res/objeticon24.png");
 
     #if defined(GD_IDE_ONLY)
     obj.AddCondition("PosX",

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -20,11 +20,11 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(gd::Pla
                           "Florian Rival",
                           "Open source (MIT License)");
 
-    gd::ObjectMetadata & obj = extension.AddObject("Sprite",
+    gd::ObjectMetadata & obj = extension.AddObject<SpriteObject>(
+               "Sprite",
                _("Sprite"),
                _("Animated object which can be used for most elements of a game"),
-               "CppPlatform/Extensions/spriteicon.png",
-               &CreateSpriteObject);
+               "CppPlatform/Extensions/spriteicon.png");
 
     #if defined(GD_IDE_ONLY)
     obj.AddAction("Opacity",

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.cpp
@@ -292,13 +292,4 @@ void SpriteObject::SwapAnimations(std::size_t firstIndex, std::size_t secondInde
         std::swap(animations[firstIndex], animations[secondIndex]);
 }
 
-/**
- * Function creating an extension Object.
- * GDevelop can not directly create an extension object
- */
-gd::Object * CreateSpriteObject(gd::String name)
-{
-    return new SpriteObject(name);
-}
-
 }

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.h
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.h
@@ -128,7 +128,5 @@ private:
     static Animation badAnimation; //< Bad animation when an out of bound animation is requested.
 };
 
-GD_CORE_API gd::Object * CreateSpriteObject(gd::String name);
-
 }
 #endif // GDCORE_SPRITEOBJECT_H

--- a/Core/GDCore/Extensions/PlatformExtension.cpp
+++ b/Core/GDCore/Extensions/PlatformExtension.cpp
@@ -85,17 +85,6 @@ gd::ExpressionMetadata & PlatformExtension::AddStrExpression(const gd::String & 
 #endif
 }
 
-gd::ObjectMetadata & PlatformExtension::AddObject(const gd::String & name,
-                               const gd::String & fullname,
-                               const gd::String & informations,
-                               const gd::String & icon24x24,
-                               CreateFunPtr createFunPtrP)
-{
-    gd::String nameWithNamespace = GetNameSpace().empty() ? name : GetNameSpace()+name;
-    objectsInfos[nameWithNamespace] = ObjectMetadata(GetNameSpace(), nameWithNamespace, fullname, informations, icon24x24, createFunPtrP);
-    return objectsInfos[nameWithNamespace];
-}
-
 gd::BehaviorMetadata & PlatformExtension::AddBehavior(const gd::String & name,
                                                       const gd::String & fullname,
                                                       const gd::String & defaultName,

--- a/Core/GDCore/Extensions/PlatformExtension.h
+++ b/Core/GDCore/Extensions/PlatformExtension.h
@@ -139,6 +139,7 @@ public:
     /**
      * \brief Declare a new object as being part of the extension.
      * \note This method does nothing when used for GD C++ runtime.
+     * \tparam T the declared class inherited from *gd::Object*
      * \param name The name of the object
      * \param fullname The user friendly name of the object
      * \param description The user friendly description of the object

--- a/Core/GDCore/Extensions/PlatformExtension.h
+++ b/Core/GDCore/Extensions/PlatformExtension.h
@@ -12,6 +12,7 @@
 #include "GDCore/Extensions/Metadata/ObjectMetadata.h"
 #include "GDCore/Extensions/Metadata/BehaviorMetadata.h"
 #include "GDCore/Extensions/Metadata/EventMetadata.h"
+#include "GDCore/CommonTools.h"
 #include "GDCore/String.h"
 namespace gd { class Instruction; }
 namespace gd { class InstructionMetadata; }
@@ -135,6 +136,24 @@ public:
                                            const gd::String & group_,
                                            const gd::String & smallicon_);
 
+   /**
+    * \brief Declare a new object as being part of the extension.
+    * \note This method does nothing when used for GD C++ runtime.
+    * \param name The name of the object
+    * \param fullname The user friendly name of the object
+    * \param description The user friendly description of the object
+    * \param icon The 24x24 icon of the object: res/icons_[SkinName]/[iconName]24.png will be first tried,
+    * and then if it does not exists, the full entered name will be tried.
+    * \deprecated
+    \endcode
+    */
+    gd::ObjectMetadata & AddObject(const gd::String & name_,
+                                   const gd::String & fullname_,
+                                   const gd::String & description_,
+                                   const gd::String & icon24x24_,
+                                   CreateFunPtr createFunPtrP_)
+                                   GD_DEPRECATED;
+
     /**
      * \brief Declare a new object as being part of the extension.
      * \note This method does nothing when used for GD C++ runtime.
@@ -143,21 +162,13 @@ public:
      * \param description The user friendly description of the object
      * \param icon The 24x24 icon of the object: res/icons_[SkinName]/[iconName]24.png will be first tried,
      * and then if it does not exists, the full entered name will be tried.
-     * \param createFunPtr The name of the function that create the object
-     *
-     * Example of the create function:
-     \code
-    gd::Object * CreateMyObject(gd::String name)
-    {
-        return new MyObject(name);
-    }
      \endcode
      */
+    template<class T>
     gd::ObjectMetadata & AddObject(const gd::String & name_,
                                    const gd::String & fullname_,
                                    const gd::String & description_,
-                                   const gd::String & icon24x24_,
-                                   CreateFunPtr createFunPtrP);
+                                   const gd::String & icon24x24_);
 
     /**
      * \brief Declare a new behavior as being part of the extension.
@@ -460,5 +471,7 @@ private:
     compilationInfo.informationCompleted = true;
 
 #endif
+
+#include "GDCore/Extensions/PlatformExtension.inl"
 
 #endif // GDCORE_PLATFORMEXTENSION_H

--- a/Core/GDCore/Extensions/PlatformExtension.h
+++ b/Core/GDCore/Extensions/PlatformExtension.h
@@ -136,24 +136,6 @@ public:
                                            const gd::String & group_,
                                            const gd::String & smallicon_);
 
-   /**
-    * \brief Declare a new object as being part of the extension.
-    * \note This method does nothing when used for GD C++ runtime.
-    * \param name The name of the object
-    * \param fullname The user friendly name of the object
-    * \param description The user friendly description of the object
-    * \param icon The 24x24 icon of the object: res/icons_[SkinName]/[iconName]24.png will be first tried,
-    * and then if it does not exists, the full entered name will be tried.
-    * \deprecated
-    \endcode
-    */
-    gd::ObjectMetadata & AddObject(const gd::String & name_,
-                                   const gd::String & fullname_,
-                                   const gd::String & description_,
-                                   const gd::String & icon24x24_,
-                                   CreateFunPtr createFunPtrP_)
-                                   GD_DEPRECATED;
-
     /**
      * \brief Declare a new object as being part of the extension.
      * \note This method does nothing when used for GD C++ runtime.

--- a/Core/GDCore/Extensions/PlatformExtension.h
+++ b/Core/GDCore/Extensions/PlatformExtension.h
@@ -1,6 +1,7 @@
 /*
  * GDevelop Core
  * Copyright 2008-2016 Florian Rival (Florian.Rival@gmail.com). All rights reserved.
+ * Copyright 2016 Victor Levasseur (victorlevasseur52@gmail.com)
  * This project is released under the MIT License.
  */
 

--- a/Core/GDCore/Extensions/PlatformExtension.inl
+++ b/Core/GDCore/Extensions/PlatformExtension.inl
@@ -1,0 +1,27 @@
+#ifndef GDCORE_PLATFORMEXTENSION_INL
+#define GDCORE_PLATFORMEXTENSION_INL
+
+namespace gd
+{
+
+template<class T>
+gd::ObjectMetadata & PlatformExtension::AddObject(const gd::String & name,
+    const gd::String & fullname, const gd::String & description,
+    const gd::String & icon24x24)
+{
+    gd::String nameWithNamespace = GetNameSpace().empty() ? name : GetNameSpace()+name;
+    objectsInfos[nameWithNamespace] = ObjectMetadata(
+        GetNameSpace(),
+        nameWithNamespace,
+        fullname,
+        informations,
+        icon24x24,
+        [](gd::String name) -> gd::Object* { return new T(name); }
+    );
+
+    return objectsInfos[nameWithNamespace];
+}
+
+}
+
+#endif

--- a/Core/GDCore/Extensions/PlatformExtension.inl
+++ b/Core/GDCore/Extensions/PlatformExtension.inl
@@ -1,3 +1,10 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2016 Florian Rival (Florian.Rival@gmail.com). All rights reserved.
+ * Copyright 2016 Victor Levasseur (victorlevasseur52@gmail.com)
+ * This project is released under the MIT License.
+ */
+
 #ifndef GDCORE_PLATFORMEXTENSION_INL
 #define GDCORE_PLATFORMEXTENSION_INL
 

--- a/Core/GDCore/Project/Object.cpp
+++ b/Core/GDCore/Project/Object.cpp
@@ -233,8 +233,3 @@ void Object::SerializeTo(SerializerElement & element) const
 #endif
 
 }
-
-gd::Object * CreateBaseObject(gd::String name)
-{
-    return new gd::Object(name);
-}

--- a/Core/GDCore/Project/Object.h
+++ b/Core/GDCore/Project/Object.h
@@ -345,6 +345,4 @@ typedef std::vector < std::shared_ptr<gd::Object> > ObjList;
  */
 typedef std::shared_ptr<gd::Object> ObjSPtr;
 
-gd::Object * GD_CORE_API CreateBaseObject(gd::String name);
-
 #endif // GDCORE_OBJECT_H

--- a/Extensions/AdMobObject/Extension.cpp
+++ b/Extensions/AdMobObject/Extension.cpp
@@ -18,11 +18,11 @@ void DeclareAdMobObjectExtension(gd::PlatformExtension & extension)
                           "Florian Rival",
                           "Open source (MIT License)");
 
-    gd::ObjectMetadata & obj = extension.AddObject("AdMob",
+    gd::ObjectMetadata & obj = extension.AddObject<AdMobObject>(
+               "AdMob",
                _("AdMob banner"),
                _("Display an ad banner or interstitial screen using AdMob"),
-               "JsPlatform/Extensions/admobicon.png",
-               &CreateAdMobObject);
+               "JsPlatform/Extensions/admobicon.png");
 
     obj.SetHelpUrl("/gdevelop/documentation/manual/built_admob");
 

--- a/Extensions/Box3DObject/Box3DObject.cpp
+++ b/Extensions/Box3DObject/Box3DObject.cpp
@@ -196,14 +196,13 @@ bool RuntimeBox3DObject::Draw( sf::RenderTarget& window )
     return true;
 }
 
-RuntimeBox3DObject::RuntimeBox3DObject(RuntimeScene & scene, const gd::Object & object) :
-    RuntimeObject(scene, object),
+RuntimeBox3DObject::RuntimeBox3DObject(RuntimeScene & scene, const Box3DObject & box3DObject) :
+    RuntimeObject(scene, box3DObject),
     zPosition(0),
     yaw(0),
     pitch(0),
     roll(0)
 {
-    const Box3DObject & box3DObject = static_cast<const Box3DObject&>(object);
 
     SetWidth(box3DObject.GetWidth());
     SetHeight(box3DObject.GetHeight());

--- a/Extensions/Box3DObject/Box3DObject.cpp
+++ b/Extensions/Box3DObject/Box3DObject.cpp
@@ -413,13 +413,3 @@ std::size_t RuntimeBox3DObject::GetNumberOfProperties() const
     return 7;
 }
 #endif
-
-RuntimeObject * CreateRuntimeBox3DObject(RuntimeScene & scene, const gd::Object & object)
-{
-    return new RuntimeBox3DObject(scene, object);
-}
-
-gd::Object * CreateBox3DObject(gd::String name)
-{
-    return new Box3DObject(name);
-}

--- a/Extensions/Box3DObject/Box3DObject.h
+++ b/Extensions/Box3DObject/Box3DObject.h
@@ -85,7 +85,7 @@ class GD_EXTENSION_API RuntimeBox3DObject : public RuntimeObject
 {
 public :
 
-    RuntimeBox3DObject(RuntimeScene & scene, const gd::Object & object);
+    RuntimeBox3DObject(RuntimeScene & scene, const Box3DObject & box3DObject);
     virtual ~RuntimeBox3DObject() {};
     virtual RuntimeObject * Clone() const { return new RuntimeBox3DObject(*this);}
 

--- a/Extensions/Box3DObject/Box3DObject.h
+++ b/Extensions/Box3DObject/Box3DObject.h
@@ -142,8 +142,4 @@ private:
     std::shared_ptr<SFMLTextureWrapper> backTexture;
 };
 
-RuntimeObject * CreateRuntimeBox3DObject(RuntimeScene & scene, const gd::Object & object);
-gd::Object * CreateBox3DObject(gd::String name);
-
 #endif // BOX3DOBJECT_H
-

--- a/Extensions/Box3DObject/Extension.cpp
+++ b/Extensions/Box3DObject/Extension.cpp
@@ -30,13 +30,14 @@ public:
                               "Open source (MIT License)");
 
         {
-            gd::ObjectMetadata & obj = AddObject("Box3D",
+            gd::ObjectMetadata & obj = AddObject<Box3DObject>(
+                       "Box3D",
                        _("3D Box"),
                        _("Displays a 3D Box"),
-                       "CppPlatform/Extensions/Box3Dicon.png",
-                       &CreateBox3DObject);
+                       "CppPlatform/Extensions/Box3Dicon.png");
 
-            AddRuntimeObject(obj, "RuntimeBox3DObject", &CreateRuntimeBox3DObject);
+            AddRuntimeObject<Box3DObject, RuntimeBox3DObject>(
+                obj, "RuntimeBox3DObject");
 
             #if defined(GD_IDE_ONLY)
 

--- a/Extensions/Light/Extension.cpp
+++ b/Extensions/Light/Extension.cpp
@@ -30,13 +30,14 @@ public:
                               "Florian Rival",
                               "Open source (MIT License)");
 
-        gd::ObjectMetadata & obj = AddObject("Light",
+        gd::ObjectMetadata & obj = AddObject<LightObject>(
+                   "Light",
                    _("Light"),
                    _("Emits light that can be stopped by objects"),
-                   "CppPlatform/Extensions/lightIcon32.png",
-                   &CreateLightObject);
+                   "CppPlatform/Extensions/lightIcon32.png");
 
-        AddRuntimeObject(obj, "RuntimeLightObject", CreateRuntimeLightObject);
+        AddRuntimeObject<LightObject, RuntimeLightObject>(
+            obj, "RuntimeLightObject");
 
         #if defined(GD_IDE_ONLY)
         LightObject::LoadEdittimeIcon();

--- a/Extensions/Light/LightObject.cpp
+++ b/Extensions/Light/LightObject.cpp
@@ -89,12 +89,10 @@ void LightObject::DoSerializeTo(gd::SerializerElement & element) const
 }
 #endif
 
-RuntimeLightObject::RuntimeLightObject(RuntimeScene & scene, const gd::Object & object) :
-    RuntimeObject(scene, object),
+RuntimeLightObject::RuntimeLightObject(RuntimeScene & scene, const LightObject & lightObject) :
+    RuntimeObject(scene, lightObject),
     angle(0)
 {
-    const LightObject & lightObject = static_cast<const LightObject&>(object);
-
     globalLight = lightObject.IsGlobalLight();
     globalLightColor = lightObject.GetGlobalColor();
     light = Light(sf::Vector2f(GetX(),GetY()), lightObject.GetIntensity(), lightObject.GetRadius(), lightObject.GetQuality(), lightObject.GetColor());
@@ -296,14 +294,4 @@ void RuntimeLightObject::SetGlobalColor(const gd::String & colorStr)
     if ( colors.size() < 3 ) return; //La couleur est incorrecte
 
     SetGlobalColor(sf::Color( colors[0].To<int>(),colors[1].To<int>(),colors[2].To<int>() ));
-}
-
-RuntimeObject * CreateRuntimeLightObject(RuntimeScene & scene, const gd::Object & object)
-{
-    return new RuntimeLightObject(scene, object);
-}
-
-gd::Object * CreateLightObject(gd::String name)
-{
-    return new LightObject(name);
 }

--- a/Extensions/Light/LightObject.h
+++ b/Extensions/Light/LightObject.h
@@ -92,7 +92,7 @@ class GD_EXTENSION_API RuntimeLightObject : public RuntimeObject
 {
 public :
 
-    RuntimeLightObject(RuntimeScene & scene, const gd::Object & object);
+    RuntimeLightObject(RuntimeScene & scene, const LightObject & lightObject);
     virtual ~RuntimeLightObject() {};
     virtual RuntimeObject * Clone() const { return new RuntimeLightObject(*this);}
 
@@ -154,8 +154,4 @@ private:
     sf::Color globalLightColor;
 };
 
-gd::Object * CreateLightObject(gd::String name);
-RuntimeObject * CreateRuntimeLightObject(RuntimeScene & scene, const gd::Object & object);
-
 #endif // LightObject_H
-

--- a/Extensions/PanelSpriteObject/Extension.cpp
+++ b/Extensions/PanelSpriteObject/Extension.cpp
@@ -22,11 +22,11 @@ void DeclarePanelSpriteObjectExtension(gd::PlatformExtension & extension)
         "Victor Levasseur and Florian Rival",
         "Open source (MIT License)");
 
-    gd::ObjectMetadata & obj = extension.AddObject("PanelSprite",
+    gd::ObjectMetadata & obj = extension.AddObject<PanelSpriteObject>(
+        "PanelSprite",
         _("Panel Sprite (\"9-patch\")"),
         _("An image with edges and corners that are stretched separately from the fill."),
-        "CppPlatform/Extensions/PanelSpriteIcon.png",
-        &CreatePanelSpriteObject);
+        "CppPlatform/Extensions/PanelSpriteIcon.png");
 
     #if defined(GD_IDE_ONLY)
     obj.SetIncludeFile("PanelSpriteObject/PanelSpriteObject.h");
@@ -143,8 +143,9 @@ public:
     Extension()
     {
         DeclarePanelSpriteObjectExtension(*this);
-        AddRuntimeObject(GetObjectMetadata("PanelSpriteObject::PanelSprite"),
-            "RuntimePanelSpriteObject", CreateRuntimePanelSpriteObject);
+        AddRuntimeObject<PanelSpriteObject, RuntimePanelSpriteObject>(
+            GetObjectMetadata("PanelSpriteObject::PanelSprite"),
+            "RuntimePanelSpriteObject");
 
         GD_COMPLETE_EXTENSION_COMPILATION_INFORMATION();
     };

--- a/Extensions/PanelSpriteObject/PanelSpriteObject.cpp
+++ b/Extensions/PanelSpriteObject/PanelSpriteObject.cpp
@@ -79,14 +79,12 @@ void PanelSpriteObject::LoadResources(gd::Project & project, gd::Layout & layout
 }
 #endif
 
-RuntimePanelSpriteObject::RuntimePanelSpriteObject(RuntimeScene & scene, const gd::Object & object) :
-    RuntimeObject(scene, object),
+RuntimePanelSpriteObject::RuntimePanelSpriteObject(RuntimeScene & scene, const PanelSpriteObject & panelSpriteObject) :
+    RuntimeObject(scene, panelSpriteObject),
     width(32),
     height(32),
     angle(0)
 {
-    const PanelSpriteObject & panelSpriteObject = static_cast<const PanelSpriteObject&>(object);
-
     SetRightMargin(panelSpriteObject.GetRightMargin());
     SetLeftMargin(panelSpriteObject.GetLeftMargin());
     SetBottomMargin(panelSpriteObject.GetBottomMargin());

--- a/Extensions/PanelSpriteObject/PanelSpriteObject.cpp
+++ b/Extensions/PanelSpriteObject/PanelSpriteObject.cpp
@@ -329,13 +329,3 @@ void RuntimePanelSpriteObject::ChangeAndReloadImage(const gd::String &txtName, c
     textureName = txtName;
     texture = scene.GetImageManager()->GetSFMLTexture(textureName);
 }
-
-RuntimeObject * CreateRuntimePanelSpriteObject(RuntimeScene & scene, const gd::Object & object)
-{
-    return new RuntimePanelSpriteObject(scene, object);
-}
-
-gd::Object * CreatePanelSpriteObject(gd::String name)
-{
-    return new PanelSpriteObject(name);
-}

--- a/Extensions/PanelSpriteObject/PanelSpriteObject.h
+++ b/Extensions/PanelSpriteObject/PanelSpriteObject.h
@@ -141,8 +141,4 @@ private:
     std::shared_ptr<SFMLTextureWrapper> texture;
 };
 
-RuntimeObject * CreateRuntimePanelSpriteObject(RuntimeScene & scene, const gd::Object & object);
-gd::Object * CreatePanelSpriteObject(gd::String name);
-
 #endif // TILEDSPRITEOBJECT_H
-

--- a/Extensions/PanelSpriteObject/PanelSpriteObject.h
+++ b/Extensions/PanelSpriteObject/PanelSpriteObject.h
@@ -89,7 +89,7 @@ class GD_EXTENSION_API RuntimePanelSpriteObject : public RuntimeObject
 {
 public :
 
-    RuntimePanelSpriteObject(RuntimeScene & scene, const gd::Object & object);
+    RuntimePanelSpriteObject(RuntimeScene & scene, const PanelSpriteObject & panelSpriteObject);
     virtual ~RuntimePanelSpriteObject() {};
     virtual RuntimeObject * Clone() const { return new RuntimePanelSpriteObject(*this);}
 

--- a/Extensions/ParticleSystem/Extension.cpp
+++ b/Extensions/ParticleSystem/Extension.cpp
@@ -28,13 +28,14 @@ Extension::Extension()
 
     //Declaration of all objects available
     {
-        gd::ObjectMetadata & obj = AddObject("ParticleEmitter",
+        gd::ObjectMetadata & obj = AddObject<ParticleEmitterObject>(
+                   "ParticleEmitter",
                    _("Particles emitter"),
                    _("Displays a large number of small particles to create visual effects"),
-                   "CppPlatform/Extensions/particleSystemicon.png",
-                   &CreateParticleEmitterObject);
+                   "CppPlatform/Extensions/particleSystemicon.png");
 
-        AddRuntimeObject(obj, "RuntimeParticleEmitterObject", CreateRuntimeParticleEmitterObject);
+        AddRuntimeObject<ParticleEmitterObject, RuntimeParticleEmitterObject>(
+            obj, "RuntimeParticleEmitterObject");
 
         #if defined(GD_IDE_ONLY)
         obj.SetIncludeFile("ParticleSystem/ParticleEmitterObject.h");

--- a/Extensions/ParticleSystem/ParticleEmitterObject.cpp
+++ b/Extensions/ParticleSystem/ParticleEmitterObject.cpp
@@ -483,11 +483,10 @@ void ParticleEmitterBase::UpdateLifeTime()
     particleSystem->particleModel->setLifeTime(particleLifeTimeMin,particleLifeTimeMax);
 }
 
-RuntimeParticleEmitterObject::RuntimeParticleEmitterObject(RuntimeScene & scene_, const gd::Object & object):
-    RuntimeObject(scene_, object),
+RuntimeParticleEmitterObject::RuntimeParticleEmitterObject(RuntimeScene & scene_, const ParticleEmitterObject & particleEmitterObject):
+    RuntimeObject(scene_, particleEmitterObject),
     hasSomeParticles(true)
 {
-    const ParticleEmitterObject & particleEmitterObject = static_cast<const ParticleEmitterObject&>(object);
     ParticleEmitterBase::operator=(particleEmitterObject);
 
     //Store a pointer to the scene

--- a/Extensions/ParticleSystem/ParticleEmitterObject.cpp
+++ b/Extensions/ParticleSystem/ParticleEmitterObject.cpp
@@ -831,13 +831,3 @@ void ParticleEmitterBase::Init(const ParticleEmitterBase & other)
     maxParticleNb = other.maxParticleNb;
     destroyWhenNoParticles = other.destroyWhenNoParticles;
 }
-
-gd::Object * CreateParticleEmitterObject(gd::String name)
-{
-    return new ParticleEmitterObject(name);
-}
-
-RuntimeObject * CreateRuntimeParticleEmitterObject(RuntimeScene & scene, const gd::Object & object)
-{
-    return new RuntimeParticleEmitterObject(scene, object);
-}

--- a/Extensions/ParticleSystem/ParticleEmitterObject.h
+++ b/Extensions/ParticleSystem/ParticleEmitterObject.h
@@ -248,7 +248,7 @@ class GD_EXTENSION_API RuntimeParticleEmitterObject : public RuntimeObject, publ
 {
 public :
 
-    RuntimeParticleEmitterObject(RuntimeScene & scene, const gd::Object & object);
+    RuntimeParticleEmitterObject(RuntimeScene & scene, const ParticleEmitterObject & particleEmitterObject);
     virtual ~RuntimeParticleEmitterObject() {};
     virtual RuntimeObject * Clone() const { return new RuntimeParticleEmitterObject(*this);}
 

--- a/Extensions/ParticleSystem/ParticleEmitterObject.h
+++ b/Extensions/ParticleSystem/ParticleEmitterObject.h
@@ -284,7 +284,4 @@ private:
     const RuntimeScene * scene; ///< Pointer to the scene. Initialized during LoadRuntimeResources call.
 };
 
-gd::Object * CreateParticleEmitterObject(gd::String name);
-RuntimeObject * CreateRuntimeParticleEmitterObject(RuntimeScene & scene, const gd::Object & object);
-
 #endif // PARTICLEEMITTEROBJECT_H

--- a/Extensions/PrimitiveDrawing/Extension.cpp
+++ b/Extensions/PrimitiveDrawing/Extension.cpp
@@ -18,11 +18,11 @@ void DeclarePrimitiveDrawingExtension(gd::PlatformExtension & extension)
                   "Florian Rival",
                   "Open source (MIT License)");
 
-    gd::ObjectMetadata & obj = extension.AddObject("Drawer", //"Drawer" is kept for compatibility with GD<=3.6.76
+    gd::ObjectMetadata & obj = extension.AddObject<ShapePainterObject>(
+               "Drawer", //"Drawer" is kept for compatibility with GD<=3.6.76
                _("Shape painter"),
                _("Allows to draw simple shapes on the screen"),
-               "CppPlatform/Extensions/primitivedrawingicon.png",
-               &CreateShapePainterObject);
+               "CppPlatform/Extensions/primitivedrawingicon.png");
 
     #if defined(GD_IDE_ONLY)
     ShapePainterObject::LoadEdittimeIcon();
@@ -202,8 +202,9 @@ public:
     Extension()
     {
         DeclarePrimitiveDrawingExtension(*this);
-        AddRuntimeObject(GetObjectMetadata("PrimitiveDrawing::Drawer"),
-            "RuntimeShapePainterObject", CreateRuntimeShapePainterObject);
+        AddRuntimeObject<ShapePainterObject, RuntimeShapePainterObject>(
+            GetObjectMetadata("PrimitiveDrawing::Drawer"),
+            "RuntimeShapePainterObject");
 
         #if defined(GD_IDE_ONLY)
         AddAction("CopyImageOnAnother",

--- a/Extensions/PrimitiveDrawing/ShapePainterObject.cpp
+++ b/Extensions/PrimitiveDrawing/ShapePainterObject.cpp
@@ -53,11 +53,10 @@ ShapePainterObject::ShapePainterObject(gd::String name_) :
 {
 }
 
-RuntimeShapePainterObject::RuntimeShapePainterObject(RuntimeScene & scene, const gd::Object & object) :
-    RuntimeObject(scene, object)
+RuntimeShapePainterObject::RuntimeShapePainterObject(RuntimeScene & scene, const ShapePainterObject & shapePainterObject) :
+    RuntimeObject(scene, shapePainterObject)
 {
-    const ShapePainterObject & drawerObject = static_cast<const ShapePainterObject&>(object);
-    ShapePainterObjectBase::operator=(drawerObject);
+    ShapePainterObjectBase::operator=(shapePainterObject);
 }
 
 void ShapePainterObjectBase::UnserializeFrom(const gd::SerializerElement & element)

--- a/Extensions/PrimitiveDrawing/ShapePainterObject.cpp
+++ b/Extensions/PrimitiveDrawing/ShapePainterObject.cpp
@@ -311,13 +311,3 @@ void RuntimeShapePainterObject::DrawCircle( float x, float y, float radius )
 
     shapesToDraw.push_back(command);
 }
-
-RuntimeObject * CreateRuntimeShapePainterObject(RuntimeScene & scene, const gd::Object & object)
-{
-    return new RuntimeShapePainterObject(scene, object);
-}
-
-gd::Object * CreateShapePainterObject(gd::String name)
-{
-    return new ShapePainterObject(name);
-}

--- a/Extensions/PrimitiveDrawing/ShapePainterObject.h
+++ b/Extensions/PrimitiveDrawing/ShapePainterObject.h
@@ -137,7 +137,7 @@ private:
 class GD_EXTENSION_API RuntimeShapePainterObject : public RuntimeObject, public ShapePainterObjectBase
 {
 public:
-    RuntimeShapePainterObject(RuntimeScene & scene, const gd::Object & object);
+    RuntimeShapePainterObject(RuntimeScene & scene, const ShapePainterObject & shapePainterObject);
     virtual ~RuntimeShapePainterObject() {};
     virtual RuntimeObject * Clone() const { return new RuntimeShapePainterObject(*this);}
 

--- a/Extensions/PrimitiveDrawing/ShapePainterObject.h
+++ b/Extensions/PrimitiveDrawing/ShapePainterObject.h
@@ -163,7 +163,4 @@ private:
     std::vector < DrawingCommand > shapesToDraw;
 };
 
-RuntimeObject * CreateRuntimeShapePainterObject(RuntimeScene & scene, const gd::Object & object);
-gd::Object * CreateShapePainterObject(gd::String name);
-
 #endif // DRAWEROBJECT_H

--- a/Extensions/SoundObject/Extension.cpp
+++ b/Extensions/SoundObject/Extension.cpp
@@ -36,13 +36,13 @@ public:
 
         //Declaration of all objects available
         {
-            gd::ObjectMetadata & obj = AddObject("Sound",
+            gd::ObjectMetadata & obj = AddObject<SoundObject>("Sound",
                        _("Sound"),
                        _("Invisible object emitting a sound which can be moved in the space."),
-                       "CppPlatform/Extensions/soundicon32.png",
-                       &CreateSoundObject);
+                       "CppPlatform/Extensions/soundicon32.png");
 
-            AddRuntimeObject(obj, "RuntimeSoundObject", CreateRuntimeSoundObject);
+            AddRuntimeObject<SoundObject, RuntimeSoundObject>(
+                obj, "RuntimeSoundObject");
 
             #if defined(GD_IDE_ONLY)
             SoundObject::LoadEdittimeIcon();

--- a/Extensions/SoundObject/SoundObject.cpp
+++ b/Extensions/SoundObject/SoundObject.cpp
@@ -353,13 +353,3 @@ float RuntimeSoundObject::GetPitch() const
 {
     return m_sound->GetPitch();
 }
-
-RuntimeObject * CreateRuntimeSoundObject(RuntimeScene & scene, const gd::Object & object)
-{
-    return new RuntimeSoundObject(scene, object);
-}
-
-gd::Object * CreateSoundObject(gd::String name)
-{
-    return new SoundObject(name);
-}

--- a/Extensions/SoundObject/SoundObject.cpp
+++ b/Extensions/SoundObject/SoundObject.cpp
@@ -46,12 +46,10 @@ SoundObject::SoundObject(gd::String name_) :
 {
 }
 
-RuntimeSoundObject::RuntimeSoundObject(RuntimeScene & scene_, const gd::Object & object) :
-    RuntimeObject(scene_, object),
+RuntimeSoundObject::RuntimeSoundObject(RuntimeScene & scene_, const SoundObject & soundObject) :
+    RuntimeObject(scene_, soundObject),
     m_sound(NULL)
 {
-    const SoundObject & soundObject = static_cast<const SoundObject&>(object);
-
     SetSoundType(soundObject.GetSoundType());
     SetSoundFileName(soundObject.GetSoundFileName());
     SetVolume(soundObject.GetVolume());

--- a/Extensions/SoundObject/SoundObject.h
+++ b/Extensions/SoundObject/SoundObject.h
@@ -104,7 +104,7 @@ class GD_EXTENSION_API RuntimeSoundObject : public RuntimeObject
 {
 public :
 
-    RuntimeSoundObject(RuntimeScene & scene, const gd::Object & object);
+    RuntimeSoundObject(RuntimeScene & scene, const SoundObject & soundObject);
     RuntimeSoundObject(const RuntimeSoundObject & other);
     RuntimeSoundObject & operator=(const RuntimeSoundObject & other);
     virtual ~RuntimeSoundObject();

--- a/Extensions/SoundObject/SoundObject.h
+++ b/Extensions/SoundObject/SoundObject.h
@@ -163,8 +163,4 @@ private:
     void Init(const RuntimeSoundObject &other);
 };
 
-gd::Object * CreateSoundObject(gd::String name);
-RuntimeObject * CreateRuntimeSoundObject(RuntimeScene & scene, const gd::Object & object);
-
 #endif // SoundObject_H
-

--- a/Extensions/TextEntryObject/Extension.cpp
+++ b/Extensions/TextEntryObject/Extension.cpp
@@ -18,11 +18,11 @@ void DeclareTextEntryObjectExtension(gd::PlatformExtension & extension)
         "Florian Rival",
         "Open source (MIT License)");
 
-    gd::ObjectMetadata & obj = extension.AddObject("TextEntry",
+    gd::ObjectMetadata & obj = extension.AddObject<TextEntryObject>(
+               "TextEntry",
                _("Text entry"),
                _("Invisible object used to get the text entered with the keyboard"),
-               "CppPlatform/Extensions/textentry.png",
-               &CreateTextEntryObject);
+               "CppPlatform/Extensions/textentry.png");
 
     #if defined(GD_IDE_ONLY)
     TextEntryObject::LoadEdittimeIcon();
@@ -97,8 +97,9 @@ public:
     Extension()
     {
         DeclareTextEntryObjectExtension(*this);
-        AddRuntimeObject(GetObjectMetadata("TextEntryObject::TextEntry"),
-            "RuntimeTextEntryObject", CreateRuntimeTextEntryObject);
+        AddRuntimeObject<TextEntryObject, RuntimeTextEntryObject>(
+            GetObjectMetadata("TextEntryObject::TextEntry"),
+            "RuntimeTextEntryObject");
 
         GD_COMPLETE_EXTENSION_COMPILATION_INFORMATION();
     };

--- a/Extensions/TextEntryObject/TextEntryObject.cpp
+++ b/Extensions/TextEntryObject/TextEntryObject.cpp
@@ -115,13 +115,3 @@ std::size_t RuntimeTextEntryObject::GetNumberOfProperties() const
     return 2;
 }
 #endif
-
-RuntimeObject * CreateRuntimeTextEntryObject(RuntimeScene & scene, const gd::Object & object)
-{
-    return new RuntimeTextEntryObject(scene, object);
-}
-
-gd::Object * CreateTextEntryObject(gd::String name)
-{
-    return new TextEntryObject(name);
-}

--- a/Extensions/TextEntryObject/TextEntryObject.cpp
+++ b/Extensions/TextEntryObject/TextEntryObject.cpp
@@ -37,8 +37,8 @@ TextEntryObject::TextEntryObject(gd::String name_) :
 {
 }
 
-RuntimeTextEntryObject::RuntimeTextEntryObject(RuntimeScene & scene_, const gd::Object & object) :
-    RuntimeObject(scene_, object),
+RuntimeTextEntryObject::RuntimeTextEntryObject(RuntimeScene & scene_, const TextEntryObject & textEntryObject) :
+    RuntimeObject(scene_, textEntryObject),
     text(),
     scene(&scene_),
     activated(true)

--- a/Extensions/TextEntryObject/TextEntryObject.h
+++ b/Extensions/TextEntryObject/TextEntryObject.h
@@ -77,7 +77,4 @@ private:
     bool activated;
 };
 
-gd::Object * CreateTextEntryObject(gd::String name);
-RuntimeObject * CreateRuntimeTextEntryObject(RuntimeScene & scene, const gd::Object & object);
-
 #endif // TEXTENTRYOBJECT_H

--- a/Extensions/TextEntryObject/TextEntryObject.h
+++ b/Extensions/TextEntryObject/TextEntryObject.h
@@ -52,7 +52,7 @@ class GD_EXTENSION_API RuntimeTextEntryObject : public RuntimeObject
 {
 public :
 
-    RuntimeTextEntryObject(RuntimeScene & scene, const gd::Object & object);
+    RuntimeTextEntryObject(RuntimeScene & scene, const TextEntryObject & textEntryObject);
     virtual ~RuntimeTextEntryObject() {};
     virtual RuntimeObject * Clone() const { return new RuntimeTextEntryObject(*this);}
 

--- a/Extensions/TextObject/Extension.cpp
+++ b/Extensions/TextObject/Extension.cpp
@@ -23,11 +23,11 @@ void DeclareTextObjectExtension(gd::PlatformExtension & extension)
                           "Florian Rival and Victor Levasseur",
                           "Open source (MIT License)");
 
-    gd::ObjectMetadata & obj = extension.AddObject("Text",
+    gd::ObjectMetadata & obj = extension.AddObject<TextObject>(
+               "Text",
                _("Text"),
                _("Displays a text"),
-               "CppPlatform/Extensions/texticon.png",
-               &CreateTextObject);
+               "CppPlatform/Extensions/texticon.png");
 
     #if defined(GD_IDE_ONLY)
     obj.SetIncludeFile("TextObject/TextObject.h");
@@ -281,8 +281,9 @@ public:
     Extension()
     {
         DeclareTextObjectExtension(*this);
-        AddRuntimeObject(GetObjectMetadata("TextObject::Text"),
-            "RuntimeTextObject", CreateRuntimeTextObject);
+        AddRuntimeObject<TextObject, RuntimeTextObject>(
+            GetObjectMetadata("TextObject::Text"),
+            "RuntimeTextObject");
 
         GD_COMPLETE_EXTENSION_COMPILATION_INFORMATION();
     };

--- a/Extensions/TextObject/TextObject.cpp
+++ b/Extensions/TextObject/TextObject.cpp
@@ -154,13 +154,11 @@ void TextObject::SetFontFilename(const gd::String & fontFilename)
 
 /* RuntimeTextObject : */
 
-RuntimeTextObject::RuntimeTextObject(RuntimeScene & scene, const gd::Object & object) :
-    RuntimeObject(scene, object),
+RuntimeTextObject::RuntimeTextObject(RuntimeScene & scene, const TextObject & textObject) :
+    RuntimeObject(scene, textObject),
     opacity(255),
     angle(0)
 {
-    const TextObject & textObject = static_cast<const TextObject&>(object);
-
     ChangeFont(textObject.GetFontFilename());
     SetSmooth(textObject.IsSmoothed());
     SetColor(textObject.GetColorR(), textObject.GetColorG(), textObject.GetColorB());

--- a/Extensions/TextObject/TextObject.cpp
+++ b/Extensions/TextObject/TextObject.cpp
@@ -394,14 +394,3 @@ std::size_t RuntimeTextObject::GetNumberOfProperties() const
     return 6;
 }
 #endif
-
-
-RuntimeObject * CreateRuntimeTextObject(RuntimeScene & scene, const gd::Object & object)
-{
-    return new RuntimeTextObject(scene, object);
-}
-
-gd::Object * CreateTextObject(gd::String name)
-{
-    return new TextObject(name);
-}

--- a/Extensions/TextObject/TextObject.h
+++ b/Extensions/TextObject/TextObject.h
@@ -108,7 +108,7 @@ class GD_EXTENSION_API RuntimeTextObject : public RuntimeObject
 {
 public :
 
-    RuntimeTextObject(RuntimeScene & scene, const gd::Object & object);
+    RuntimeTextObject(RuntimeScene & scene, const TextObject & textObject);
     virtual ~RuntimeTextObject() {};
     virtual RuntimeObject * Clone() const { return new RuntimeTextObject(*this);}
 

--- a/Extensions/TextObject/TextObject.h
+++ b/Extensions/TextObject/TextObject.h
@@ -178,7 +178,4 @@ private:
     float angle;
 };
 
-gd::Object * CreateTextObject(gd::String name);
-RuntimeObject * CreateRuntimeTextObject(RuntimeScene & scene, const gd::Object & object);
-
 #endif // TEXTOBJECT_H

--- a/Extensions/TileMapObject/Extension.cpp
+++ b/Extensions/TileMapObject/Extension.cpp
@@ -24,11 +24,11 @@ void DeclareTileMapObjectExtension(gd::PlatformExtension & extension)
                               "Victor Levasseur and Florian Rival",
                               "Open source (MIT License)");
 
-    gd::ObjectMetadata & obj = extension.AddObject("TileMap",
+    gd::ObjectMetadata & obj = extension.AddObject<TileMapObject>(
+               "TileMap",
                _("Tile Map"),
                _("Displays a tile map"),
-               "CppPlatform/Extensions/TileMapIcon.png",
-               &CreateTileMapObject);
+               "CppPlatform/Extensions/TileMapIcon.png");
 
     #if defined(GD_IDE_ONLY)
     obj.SetIncludeFile("TileMapObject/RuntimeTileMapObject.h");
@@ -191,8 +191,9 @@ public:
     Extension()
     {
         DeclareTileMapObjectExtension(*this);
-        AddRuntimeObject(GetObjectMetadata("TileMapObject::TileMap"),
-            "RuntimeTileMapObject", CreateRuntimeTileMapObject);
+        AddRuntimeObject<TileMapObject, RuntimeTileMapObject>(
+            GetObjectMetadata("TileMapObject::TileMap"),
+            "RuntimeTileMapObject");
 
         GD_COMPLETE_EXTENSION_COMPILATION_INFORMATION();
     };

--- a/Extensions/TileMapObject/RuntimeTileMapObject.cpp
+++ b/Extensions/TileMapObject/RuntimeTileMapObject.cpp
@@ -27,8 +27,8 @@ This project is released under the MIT License.
 #include "TileSet.h"
 #include "TileMapTools.h"
 
-RuntimeTileMapObject::RuntimeTileMapObject(RuntimeScene & scene, const gd::Object & object) :
-    RuntimeObject(scene, object),
+RuntimeTileMapObject::RuntimeTileMapObject(RuntimeScene & scene, const TileMapObject & tileMapObject) :
+    RuntimeObject(scene, tileMapObject),
     tileSet(),
     tileMap(),
     vertexArray(sf::Quads),
@@ -36,8 +36,6 @@ RuntimeTileMapObject::RuntimeTileMapObject(RuntimeScene & scene, const gd::Objec
     oldY(0),
     needGeneration(false)
 {
-    const TileMapObject & tileMapObject = static_cast<const TileMapObject&>(object);
-
     tileSet = tileMapObject.tileSet;
     tileMap = tileMapObject.tileMap;
 

--- a/Extensions/TileMapObject/RuntimeTileMapObject.cpp
+++ b/Extensions/TileMapObject/RuntimeTileMapObject.cpp
@@ -251,8 +251,3 @@ bool GD_EXTENSION_API SingleTileCollision(std::map<gd::String, std::vector<Runti
         return false;
     });
 }
-
-RuntimeObject * CreateRuntimeTileMapObject(RuntimeScene & scene, const gd::Object & object)
-{
-    return new RuntimeTileMapObject(scene, object);
-}

--- a/Extensions/TileMapObject/RuntimeTileMapObject.h
+++ b/Extensions/TileMapObject/RuntimeTileMapObject.h
@@ -20,6 +20,7 @@ This project is released under the MIT License.
 
 class SFMLTextureWrapper;
 class RuntimeScene;
+class TileMapObject;
 namespace gd { class ImageManager; }
 namespace gd { class InitialInstance; }
 #if defined(GD_IDE_ONLY)
@@ -34,7 +35,7 @@ class GD_EXTENSION_API RuntimeTileMapObject : public RuntimeObject
 
 public :
 
-    RuntimeTileMapObject(RuntimeScene & scene, const gd::Object & object);
+    RuntimeTileMapObject(RuntimeScene & scene, const TileMapObject & tileMapObject);
     virtual ~RuntimeTileMapObject() {};
     virtual RuntimeObject * Clone() const { return new RuntimeTileMapObject(*this);}
 

--- a/Extensions/TileMapObject/RuntimeTileMapObject.h
+++ b/Extensions/TileMapObject/RuntimeTileMapObject.h
@@ -101,6 +101,4 @@ bool GD_EXTENSION_API SingleTileCollision(std::map<gd::String, std::vector<Runti
                          std::map<gd::String, std::vector<RuntimeObject*>*> objectLists,
                          bool conditionInverted);
 
-RuntimeObject * CreateRuntimeTileMapObject(RuntimeScene & scene, const gd::Object & object);
-
 #endif

--- a/Extensions/TileMapObject/TileMapObject.cpp
+++ b/Extensions/TileMapObject/TileMapObject.cpp
@@ -151,8 +151,3 @@ void TileMapObject::EditObject( wxWindow* parent, gd::Project & game, gd::MainFr
 #endif
 }
 #endif
-
-gd::Object * CreateTileMapObject(gd::String name)
-{
-    return new TileMapObject(name);
-}

--- a/Extensions/TileMapObject/TileMapObject.h
+++ b/Extensions/TileMapObject/TileMapObject.h
@@ -67,6 +67,4 @@ private:
     sf::VertexArray vertexArray;
 };
 
-gd::Object * CreateTileMapObject(gd::String name);
-
 #endif // TILEDSPRITEOBJECT_H

--- a/Extensions/TiledSpriteObject/Extension.cpp
+++ b/Extensions/TiledSpriteObject/Extension.cpp
@@ -20,11 +20,11 @@ void DeclareTiledSpriteObjectExtension(gd::PlatformExtension & extension)
                               "Victor Levasseur and Florian Rival",
                               "Open source (MIT License)");
 
-    gd::ObjectMetadata & obj = extension.AddObject("TiledSprite",
+    gd::ObjectMetadata & obj = extension.AddObject<TiledSpriteObject>(
+               "TiledSprite",
                _("Tiled Sprite"),
                _("Displays an image repeated over an area"),
-               "CppPlatform/Extensions/TiledSpriteIcon.png",
-               &CreateTiledSpriteObject);
+               "CppPlatform/Extensions/TiledSpriteIcon.png");
 
     #if defined(GD_IDE_ONLY)
     obj.SetIncludeFile("TiledSpriteObject/TiledSpriteObject.h");
@@ -182,8 +182,9 @@ public:
     Extension()
     {
         DeclareTiledSpriteObjectExtension(*this);
-        AddRuntimeObject(GetObjectMetadata("TiledSpriteObject::TiledSprite"),
-            "RuntimeTiledSpriteObject", CreateRuntimeTiledSpriteObject);
+        AddRuntimeObject<TiledSpriteObject, RuntimeTiledSpriteObject>(
+            GetObjectMetadata("TiledSpriteObject::TiledSprite"),
+            "RuntimeTiledSpriteObject");
 
         GD_COMPLETE_EXTENSION_COMPILATION_INFORMATION();
     };

--- a/Extensions/TiledSpriteObject/TiledSpriteObject.cpp
+++ b/Extensions/TiledSpriteObject/TiledSpriteObject.cpp
@@ -77,20 +77,18 @@ namespace
     }
 }
 
-RuntimeTiledSpriteObject::RuntimeTiledSpriteObject(RuntimeScene & scene, const gd::Object & object) :
-    RuntimeObject(scene, object),
+RuntimeTiledSpriteObject::RuntimeTiledSpriteObject(RuntimeScene & scene, const TiledSpriteObject & tiledSpriteObject) :
+    RuntimeObject(scene, tiledSpriteObject),
     width(32),
     height(32),
     xOffset(0),
     yOffset(),
     angle(0)
 {
-    const TiledSpriteObject & panelSpriteObject = static_cast<const TiledSpriteObject&>(object);
+    SetWidth(tiledSpriteObject.GetWidth());
+    SetHeight(tiledSpriteObject.GetHeight());
 
-    SetWidth(panelSpriteObject.GetWidth());
-    SetHeight(panelSpriteObject.GetHeight());
-
-    textureName = panelSpriteObject.textureName;
+    textureName = tiledSpriteObject.textureName;
     ChangeAndReloadImage(textureName, scene);
 }
 

--- a/Extensions/TiledSpriteObject/TiledSpriteObject.cpp
+++ b/Extensions/TiledSpriteObject/TiledSpriteObject.cpp
@@ -196,13 +196,3 @@ std::size_t RuntimeTiledSpriteObject::GetNumberOfProperties() const
     return 3;
 }
 #endif
-
-RuntimeObject * CreateRuntimeTiledSpriteObject(RuntimeScene & scene, const gd::Object & object)
-{
-    return new RuntimeTiledSpriteObject(scene, object);
-}
-
-gd::Object * CreateTiledSpriteObject(gd::String name)
-{
-    return new TiledSpriteObject(name);
-}

--- a/Extensions/TiledSpriteObject/TiledSpriteObject.h
+++ b/Extensions/TiledSpriteObject/TiledSpriteObject.h
@@ -72,7 +72,7 @@ class GD_EXTENSION_API RuntimeTiledSpriteObject : public RuntimeObject
 {
 public :
 
-    RuntimeTiledSpriteObject(RuntimeScene & scene, const gd::Object & object);
+    RuntimeTiledSpriteObject(RuntimeScene & scene, const TiledSpriteObject & tiledSpriteObject);
     virtual ~RuntimeTiledSpriteObject() {};
     virtual RuntimeObject * Clone() const { return new RuntimeTiledSpriteObject(*this);}
 

--- a/Extensions/TiledSpriteObject/TiledSpriteObject.h
+++ b/Extensions/TiledSpriteObject/TiledSpriteObject.h
@@ -114,7 +114,4 @@ private:
     std::shared_ptr<SFMLTextureWrapper> texture;
 };
 
-gd::Object * CreateTiledSpriteObject(gd::String name);
-RuntimeObject * CreateRuntimeTiledSpriteObject(RuntimeScene & scene, const gd::Object & object);
-
 #endif // TILEDSPRITEOBJECT_H

--- a/GDCpp/GDCpp/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/GDCpp/GDCpp/Extensions/Builtin/BaseObjectExtension.cpp
@@ -12,7 +12,7 @@ BaseObjectExtension::BaseObjectExtension()
     gd::BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(*this);
 
     gd::ObjectMetadata & obj = GetObjectMetadata("");
-    AddRuntimeObject(obj, "", &CreateBaseRuntimeObject);
+    AddRuntimeObject<gd::Object, RuntimeObject>(obj, "");
 
     #if defined(GD_IDE_ONLY)
     std::map<gd::String, gd::InstructionMetadata > & objectActions = GetAllActionsForObject("");
@@ -107,4 +107,3 @@ BaseObjectExtension::BaseObjectExtension()
     GetAllExpressions()["Count"].SetFunctionName("PickedObjectsCount").SetIncludeFile("GDCpp/Extensions/Builtin/ObjectTools.h");
     #endif
 }
-

--- a/GDCpp/GDCpp/Extensions/Builtin/SpriteExtension.cpp
+++ b/GDCpp/GDCpp/Extensions/Builtin/SpriteExtension.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "GDCore/Extensions/Builtin/AllBuiltinExtensions.h"
+#include "GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.h"
 #include "GDCpp/Extensions/Builtin/SpriteExtension.h"
 #include "GDCpp/RuntimeSpriteObject.h"
 #if !defined(GD_IDE_ONLY)
@@ -16,7 +17,7 @@ SpriteExtension::SpriteExtension()
     gd::BuiltinExtensionsImplementer::ImplementsSpriteExtension(*this);
 
     gd::ObjectMetadata & obj = GetObjectMetadata("Sprite");
-    AddRuntimeObject(obj, "RuntimeSpriteObject", &CreateRuntimeSpriteObject);
+    AddRuntimeObject<gd::SpriteObject, RuntimeSpriteObject>(obj, "RuntimeSpriteObject");
 
     #if defined(GD_IDE_ONLY)
     obj.SetIncludeFile("GDCpp/RuntimeSpriteObject.h");

--- a/GDCpp/GDCpp/Extensions/ExtensionBase.cpp
+++ b/GDCpp/GDCpp/Extensions/ExtensionBase.cpp
@@ -29,14 +29,6 @@ CreateRuntimeObjectFunPtr ExtensionBase::GetRuntimeObjectCreationFunctionPtr(gd:
     return NULL;
 }
 
-void ExtensionBase::AddRuntimeObject(gd::ObjectMetadata & object, gd::String className, CreateRuntimeObjectFunPtr createFun)
-{
-#if defined(GD_IDE_ONLY)
-    object.className = className;
-#endif
-    runtimeObjectCreationFunctionTable[object.GetName()] = createFun;
-}
-
 #if !defined(GD_IDE_ONLY)
 //Implementations of some dependencies of ExtensionBase are compiled in this compilation unit
 //when compiling for runtime:

--- a/GDCpp/GDCpp/Extensions/ExtensionBase.h
+++ b/GDCpp/GDCpp/Extensions/ExtensionBase.h
@@ -1,6 +1,7 @@
 /*
  * GDevelop C++ Platform
  * Copyright 2008-2016 Florian Rival (Florian.Rival@gmail.com). All rights reserved.
+ * Copyright 2016 Victor Levasseur (victorlevasseur52@gmail.com)
  * This project is released under the MIT License.
  */
 

--- a/GDCpp/GDCpp/Extensions/ExtensionBase.h
+++ b/GDCpp/GDCpp/Extensions/ExtensionBase.h
@@ -7,16 +7,18 @@
 #ifndef EXTENSIONBASE_H
 #define EXTENSIONBASE_H
 
-#include <string>
-#include <vector>
+#include <iostream>
 #include <map>
 #include <memory>
+#include <vector>
+#include <string>
 #include "GDCore/Extensions/Metadata/InstructionMetadata.h"
 #include "GDCore/Extensions/Metadata/ExpressionMetadata.h"
 #include "GDCore/Extensions/Metadata/ObjectMetadata.h"
 #include "GDCore/Extensions/Metadata/BehaviorMetadata.h"
 #include "GDCore/Extensions/PlatformExtension.h"
 #include "GDCore/Tools/Localization.h"
+#include "GDCore/CommonTools.h"
 namespace gd { class Instruction; }
 namespace gd { class Layout; }
 namespace gd { class Object; }
@@ -59,7 +61,15 @@ public :
      * \param createFun A function taking a reference to a RuntimeScene and to a const reference to a gd::Object and returning a pointer
      * to the RuntimeObject created.
      */
-    void AddRuntimeObject(gd::ObjectMetadata & object, gd::String className, CreateRuntimeObjectFunPtr createFun);
+    void AddRuntimeObject(gd::ObjectMetadata & object, gd::String className, CreateRuntimeObjectFunPtr createFun) GD_DEPRECATED;
+
+    /**
+     * \brief To be called so as to declare the creation and destruction function of a RuntimeObject associated to a gd::Object.
+     * \param object The object associated to the RuntimeObject being declared.
+     * \param className The C++ class name associated to the RuntimeObject.
+     */
+    template<class T, class U>
+    void AddRuntimeObject(gd::ObjectMetadata & object, gd::String className);
 
     /**
      * \brief Return a function to create the runtime object if the type is handled by the extension
@@ -130,5 +140,7 @@ protected :
 private:
     std::map < gd::String, CreateRuntimeObjectFunPtr > runtimeObjectCreationFunctionTable;
 };
+
+#include "GDCpp/Extensions/ExtensionBase.inl"
 
 #endif // EXTENSIONBASE_H

--- a/GDCpp/GDCpp/Extensions/ExtensionBase.h
+++ b/GDCpp/GDCpp/Extensions/ExtensionBase.h
@@ -56,6 +56,8 @@ public :
 
     /**
      * \brief To be called so as to declare the creation and destruction function of a RuntimeObject associated to a gd::Object.
+     * \tparam T the object class (inheriting *gd::Object*) declared with *AddObject*
+     * \tparam U the runtime object class (inheriting *RuntimeObject*)
      * \param object The object associated to the RuntimeObject being declared.
      * \param className The C++ class name associated to the RuntimeObject.
      */

--- a/GDCpp/GDCpp/Extensions/ExtensionBase.h
+++ b/GDCpp/GDCpp/Extensions/ExtensionBase.h
@@ -58,15 +58,6 @@ public :
      * \brief To be called so as to declare the creation and destruction function of a RuntimeObject associated to a gd::Object.
      * \param object The object associated to the RuntimeObject being declared.
      * \param className The C++ class name associated to the RuntimeObject.
-     * \param createFun A function taking a reference to a RuntimeScene and to a const reference to a gd::Object and returning a pointer
-     * to the RuntimeObject created.
-     */
-    void AddRuntimeObject(gd::ObjectMetadata & object, gd::String className, CreateRuntimeObjectFunPtr createFun) GD_DEPRECATED;
-
-    /**
-     * \brief To be called so as to declare the creation and destruction function of a RuntimeObject associated to a gd::Object.
-     * \param object The object associated to the RuntimeObject being declared.
-     * \param className The C++ class name associated to the RuntimeObject.
      */
     template<class T, class U>
     void AddRuntimeObject(gd::ObjectMetadata & object, gd::String className);

--- a/GDCpp/GDCpp/Extensions/ExtensionBase.inl
+++ b/GDCpp/GDCpp/Extensions/ExtensionBase.inl
@@ -1,0 +1,27 @@
+#ifndef EXTENSIONBASE_INL
+#define EXTENSIONBASE_INL
+
+template<class T, class U>
+void ExtensionBase::AddRuntimeObject(gd::ObjectMetadata & object, gd::String className)
+{
+#if defined(GD_IDE_ONLY)
+    object.className = className;
+#endif
+    runtimeObjectCreationFunctionTable[object.GetName()] =
+        [](RuntimeScene & scene, const gd::Object & object) -> RuntimeObject* {
+            try
+            {
+                const T& derivedObject = dynamic_cast<const T&>(object);
+                return new U(scene, derivedObject);
+            }
+            catch(const std::bad_cast &e)
+            {
+                std::cout << "Tried to create a RuntimeObject from an invalid gd::Object: " << std::endl;
+                std::cout << e.what() << std::endl;
+            }
+
+            return nullptr;
+        };
+}
+
+#endif

--- a/GDCpp/GDCpp/Extensions/ExtensionBase.inl
+++ b/GDCpp/GDCpp/Extensions/ExtensionBase.inl
@@ -1,3 +1,9 @@
+/*
+ * GDevelop C++ Platform
+ * Copyright 2008-2016 Florian Rival (Florian.Rival@gmail.com). All rights reserved.
+ * Copyright 2016 Victor Levasseur (victorlevasseur52@gmail.com)
+ * This project is released under the MIT License.
+ */
 #ifndef EXTENSIONBASE_INL
 #define EXTENSIONBASE_INL
 

--- a/GDCpp/GDCpp/RuntimeObject.cpp
+++ b/GDCpp/GDCpp/RuntimeObject.cpp
@@ -655,8 +655,3 @@ void RuntimeObject::VariableRemoveChild(gd::Variable & variable, const gd::Strin
 {
     variable.RemoveChild(childName);
 }
-
-RuntimeObject * CreateBaseRuntimeObject(RuntimeScene & scene, const gd::Object & object)
-{
-    return new RuntimeObject(scene, object);
-}

--- a/GDCpp/GDCpp/RuntimeObject.h
+++ b/GDCpp/GDCpp/RuntimeObject.h
@@ -454,9 +454,4 @@ protected:
     void Init(const RuntimeObject & object);
 };
 
-/**
- * As extensions, a function used to create an object ("return new RuntimeObject(name);").
- */
-RuntimeObject * CreateBaseRuntimeObject(RuntimeScene & scene, const gd::Object & object);
-
 #endif // RUNTIMEOBJECT_H

--- a/GDCpp/GDCpp/RuntimeObject.h
+++ b/GDCpp/GDCpp/RuntimeObject.h
@@ -23,6 +23,7 @@ class RuntimeScene;
  * \brief A RuntimeObject is something displayed on the scene.
  *
  * Games don't directly use this class: Extensions can provide object by deriving from this class, and redefining functions:
+ * - The constructor must have this signature : MyRuntimeObject(RuntimeScene & scene, const MyObject & object) with MyObject the class inheriting from gd::Object.
  * - An important function is RuntimeObject::Draw. It is called to render the object on the scene. This function take in parameter a reference to the target where render the object.
  * - RuntimeObject must be able to return their size, by redefining RuntimeObject::GetWidth and RuntimeObject::GetHeight
  * - RuntimeObject must be able to return the position where they have precisely drawn ( for example, Sprite can draw its image not exactly at the position of the object, if the origin point was moved ). It must also be able to return the position of their center. See RuntimeObject::GetDrawableX, RuntimeObject::GetDrawableY and RuntimeObject::GetCenterX, RuntimeObject::GetCenterY.
@@ -45,12 +46,14 @@ public:
      * The default implementation already takes care of setting common properties
      * ( name, type, behaviors... ). Be sure to call the original constructor if you redefine it:
      * \code
-     * MyRuntimeObject(RuntimeScene & scene, const gd::Object & object) :
+     * MyRuntimeObject(RuntimeScene & scene, const MyObject & object) :
      *     RuntimeObject(scene, object)
      * {
      *     //...
      * }
      * \endcode
+     * \note The constructor can take a specialized gd::Object as its second parameter which is the gd::Object sub-class
+     * declared in ExtensionBase::AddRuntimeObject (the first template parameter)
      */
     RuntimeObject(RuntimeScene & scene, const gd::Object & object);
 

--- a/GDCpp/GDCpp/RuntimeSpriteObject.cpp
+++ b/GDCpp/GDCpp/RuntimeSpriteObject.cpp
@@ -37,8 +37,8 @@
 gd::Animation RuntimeSpriteObject::badAnimation;
 gd::Sprite * RuntimeSpriteObject::badSpriteDatas = NULL;
 
-RuntimeSpriteObject::RuntimeSpriteObject(RuntimeScene & scene, const gd::Object & object) :
-    RuntimeObject(scene, object),
+RuntimeSpriteObject::RuntimeSpriteObject(RuntimeScene & scene, const gd::SpriteObject & spriteObject) :
+    RuntimeObject(scene, spriteObject),
     currentAnimation( 0 ),
     currentDirection( 0 ),
     currentAngle( 0 ),
@@ -59,9 +59,6 @@ RuntimeSpriteObject::RuntimeSpriteObject(RuntimeScene & scene, const gd::Object 
     colorB( 255 )
 {
     if (!badSpriteDatas) badSpriteDatas = new gd::Sprite();
-
-    //Initialize the runtime object using the object
-    const gd::SpriteObject & spriteObject = static_cast<const gd::SpriteObject&>(object);
 
     animations.clear();
     for (std::size_t i = 0; i < spriteObject.GetAllAnimations().size(); ++i)

--- a/GDCpp/GDCpp/RuntimeSpriteObject.cpp
+++ b/GDCpp/GDCpp/RuntimeSpriteObject.cpp
@@ -625,8 +625,3 @@ AnimationProxy & AnimationProxy::operator=(const AnimationProxy & rhs)
 
     return *this;
 }
-
-RuntimeObject * CreateRuntimeSpriteObject(RuntimeScene & scene, const gd::Object & object)
-{
-    return new RuntimeSpriteObject(scene, object);
-}

--- a/GDCpp/GDCpp/RuntimeSpriteObject.h
+++ b/GDCpp/GDCpp/RuntimeSpriteObject.h
@@ -315,6 +315,4 @@ private:
     static gd::Animation    badAnimation;
 };
 
-GD_API RuntimeObject * CreateRuntimeSpriteObject(RuntimeScene & scene, const gd::Object & object);
-
 #endif // SPRITEOBJECT_H

--- a/GDCpp/GDCpp/RuntimeSpriteObject.h
+++ b/GDCpp/GDCpp/RuntimeSpriteObject.h
@@ -13,6 +13,7 @@ namespace gd { class Object; }
 namespace gd { class Layout; }
 namespace sf { class Sprite; }
 namespace gd { class Sprite; }
+namespace gd { class SpriteObject; }
 namespace gd { class Animation; }
 namespace gd { class MainFrameWrapper; }
 namespace gd { class PropertyDescriptor; }
@@ -50,7 +51,7 @@ class GD_API RuntimeSpriteObject : public RuntimeObject
 {
 public:
 
-    RuntimeSpriteObject(RuntimeScene & scene, const gd::Object & object);
+    RuntimeSpriteObject(RuntimeScene & scene, const gd::SpriteObject & spriteObject);
     virtual ~RuntimeSpriteObject();
     virtual RuntimeObject * Clone() const { return new RuntimeSpriteObject(*this);}
 


### PR DESCRIPTION
PR content : 
 - ```gd::PlatformExtension::AddObject``` is now a template method (of argument ```T```, the object's class we want to declare). It does not take a function pointer as last argument anymore. The template argument is used to create a lambda that replaces the old ```CreateXXXObject(gd::String name)``` function pointer
 - ```ExtensionBase::AddRuntimeObject``` is now a templace method (of arguments ```T```, the gd::Object derivative, and ```U```, the runtime object's class we want to declare). The function pointer argument was removed too as the function pointer is generated by the method itself with a lambda. The lambda is a bit more complicated than the old ```CreateXXXRuntimeObject(RuntimeScene&, const gd::Object&)``` as, thanks to ```T```, it does a ```dynamic_cast``` on the ```gd::Object``` before passing it to the runtime object's constructor. This allows the runtime objects constructors to get directly the correctly typed ```gd::Object``` inherited class (and it handles the ```bad_cast``` exception).

If you agree with the current implementation, I'll add another commit to update the doc.