### PR TITLE
Enable depth buffer on SFML windows to fix 3DBox objects

### DIFF
--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
@@ -149,15 +149,15 @@ LayoutEditorCanvas::LayoutEditorCanvas(wxWindow* parent, gd::Project & project_,
 
         //...and pass it to the sf::RenderWindow.
         #if GTK_CHECK_VERSION(3, 0, 0)
-        sf::RenderWindow::create(GDK_WINDOW_XID(win));
+        sf::RenderWindow::create(GDK_WINDOW_XID(win), sf::ContextSettings(24, 8));
         #else
-        sf::RenderWindow::create(GDK_WINDOW_XWINDOW(win));
+        sf::RenderWindow::create(GDK_WINDOW_XWINDOW(win), sf::ContextSettings(24, 8));
         #endif
 
     #else
 
         // Tested under Windows XP only (should work with X11 and other Windows versions - no idea about MacOS)
-        sf::RenderWindow::create(static_cast<sf::WindowHandle>(GetHandle()));
+        sf::RenderWindow::create(static_cast<sf::WindowHandle>(GetHandle()), sf::ContextSettings(24, 8));
 
     #endif
 

--- a/GDCpp/Runtime/main.cpp
+++ b/GDCpp/Runtime/main.cpp
@@ -178,7 +178,7 @@ int main( int argc, char *p_argv[] )
     runtimeGame.LoadFromProject(game);
 
     window.create(sf::VideoMode(game.GetMainWindowDefaultWidth(), game.GetMainWindowDefaultHeight(), 32),
-        "", sf::Style::Close);
+        "", sf::Style::Close, sf::ContextSettings(24, 8));
     window.setActive(true);
 
     //Game main loop


### PR DESCRIPTION
It fixes Box3DObjects on Linux (but not when previewing on Fedora ! :( )