### PR TITLE
Fix crash when ending a scene with Platform objects in it

### DIFF
--- a/Extensions/PlatformBehavior/ScenePlatformObjectsManager.cpp
+++ b/Extensions/PlatformBehavior/ScenePlatformObjectsManager.cpp
@@ -1,15 +1,14 @@
 #include "ScenePlatformObjectsManager.h"
 #include "PlatformBehavior.h"
 
-std::map<RuntimeScene*, ScenePlatformObjectsManager> ScenePlatformObjectsManager::managers; 
+std::map<RuntimeScene*, ScenePlatformObjectsManager> ScenePlatformObjectsManager::managers;
 
 ScenePlatformObjectsManager::~ScenePlatformObjectsManager()
 {
 	for (std::set<PlatformBehavior*>::iterator it = allPlatforms.begin();
-		 it != allPlatforms.end();
-		 ++it)
+		 it != allPlatforms.end();)
 	{
-		(*it)->Activate(false);
+		(*it++)->Activate(false);
 	}
 }
 


### PR DESCRIPTION
The iterator is never invalidated as it is incremented just before its previous iterator is removed from the ```std::set```.