### PR TITLE
Provide compatibility with Windows high contrast themes

### DIFF
--- a/Binaries/Output/Release_Windows/GDIDE.exe.Manifest
+++ b/Binaries/Output/Release_Windows/GDIDE.exe.Manifest
@@ -26,4 +26,18 @@
         />
     </dependentAssembly>
 </dependency>
+<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+  <application>
+    <!-- Windows 10 -->
+    <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    <!-- Windows 8.1 -->
+    <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+    <!-- Windows 8 -->
+    <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+    <!-- Windows 7 -->
+    <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+    <!-- Windows Vista -->
+    <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+  </application>
+</compatibility>
 </assembly>


### PR DESCRIPTION
By providing a manifest specifying the targeted Windows versions (as per https://msdn.microsoft.com/en-us/library/windows/desktop/hh404233(v=vs.85).aspx#_______supporting_high_contrast_themes_in_windows_8_and_later) now scene renders normally under a high contrast theme on Windows, instead of staying unrefreshed.

Fixes #266.