### PR TITLE
Texture loading optimization

### DIFF
--- a/Core/GDCore/Project/ImageManager.cpp
+++ b/Core/GDCore/Project/ImageManager.cpp
@@ -46,8 +46,10 @@ std::shared_ptr<SFMLTextureWrapper> ImageManager::GetSFMLTexture(const gd::Strin
     {
         ImageResource & image = dynamic_cast<ImageResource&>(resourcesManager->GetResource(name));
 
-        std::shared_ptr<SFMLTextureWrapper> texture(new SFMLTextureWrapper(ResourcesLoader::Get()->LoadSFMLTexture( image.GetFile() )));
+        std::shared_ptr<SFMLTextureWrapper> texture(new SFMLTextureWrapper());
+        ResourcesLoader::Get()->LoadSFMLTexture( image.GetFile(), texture->texture );
         texture->texture.setSmooth(image.smooth);
+        texture->image = texture->texture.copyToImage();
 
         alreadyLoadedImages[name] = texture;
         #if defined(GD_IDE_ONLY)
@@ -102,7 +104,7 @@ void ImageManager::ReloadImage(const gd::String & name) const
 
         std::cout << "ImageManager: Reload " << name << std::endl;
 
-        oldTexture->texture = ResourcesLoader::Get()->LoadSFMLTexture( image.GetFile() );
+        ResourcesLoader::Get()->LoadSFMLTexture( image.GetFile(), oldTexture->texture );
         oldTexture->texture.setSmooth(image.smooth);
         oldTexture->image = oldTexture->texture.copyToImage();
 

--- a/Core/GDCore/Project/ImageManager.cpp
+++ b/Core/GDCore/Project/ImageManager.cpp
@@ -47,9 +47,9 @@ std::shared_ptr<SFMLTextureWrapper> ImageManager::GetSFMLTexture(const gd::Strin
         ImageResource & image = dynamic_cast<ImageResource&>(resourcesManager->GetResource(name));
 
         std::shared_ptr<SFMLTextureWrapper> texture(new SFMLTextureWrapper());
-        ResourcesLoader::Get()->LoadSFMLTexture( image.GetFile(), texture->texture );
+        ResourcesLoader::Get()->LoadSFMLImage( image.GetFile(), texture->image );
+        texture->texture.loadFromImage(texture->image);
         texture->texture.setSmooth(image.smooth);
-        texture->image = texture->texture.copyToImage();
 
         alreadyLoadedImages[name] = texture;
         #if defined(GD_IDE_ONLY)
@@ -104,9 +104,9 @@ void ImageManager::ReloadImage(const gd::String & name) const
 
         std::cout << "ImageManager: Reload " << name << std::endl;
 
-        ResourcesLoader::Get()->LoadSFMLTexture( image.GetFile(), oldTexture->texture );
+        ResourcesLoader::Get()->LoadSFMLImage( image.GetFile(), oldTexture->image );
+        oldTexture->texture.loadFromImage(oldTexture->image);
         oldTexture->texture.setSmooth(image.smooth);
-        oldTexture->image = oldTexture->texture.copyToImage();
 
         return;
     }

--- a/Core/GDCore/Project/ResourcesLoader.cpp
+++ b/Core/GDCore/Project/ResourcesLoader.cpp
@@ -15,6 +15,12 @@ namespace gd
 
 ResourcesLoader * ResourcesLoader::_singleton = NULL;
 
+void ResourcesLoader::LoadSFMLImage( const gd::String & filename, sf::Image & image )
+{
+    if (!image.loadFromFile(filename.ToLocale()))
+        cout << "Failed to load a SFML image: " << filename << endl;
+}
+
 sf::Texture ResourcesLoader::LoadSFMLTexture(const gd::String & filename)
 {
     sf::Texture texture;

--- a/Core/GDCore/Project/ResourcesLoader.cpp
+++ b/Core/GDCore/Project/ResourcesLoader.cpp
@@ -18,10 +18,15 @@ ResourcesLoader * ResourcesLoader::_singleton = NULL;
 sf::Texture ResourcesLoader::LoadSFMLTexture(const gd::String & filename)
 {
     sf::Texture texture;
-    if (!texture.loadFromFile(filename.ToLocale()))
-        cout << "Failed to load a SFML texture: " << filename << endl;
+    LoadSFMLTexture(filename, texture);
 
     return texture;
+}
+
+void ResourcesLoader::LoadSFMLTexture( const gd::String & filename, sf::Texture & texture )
+{
+    if (!texture.loadFromFile(filename.ToLocale()))
+        cout << "Failed to load a SFML texture: " << filename << endl;
 }
 
 std::pair<sf::Font *, char *> ResourcesLoader::LoadFont(const gd::String & filename)

--- a/Core/GDCore/Project/ResourcesLoader.h
+++ b/Core/GDCore/Project/ResourcesLoader.h
@@ -25,6 +25,8 @@ class GD_CORE_API ResourcesLoader
 {
 public:
 
+    void LoadSFMLImage( const gd::String & filename, sf::Image & image );
+
     /**
      * Load a SFML texture.
      */

--- a/Core/GDCore/Project/ResourcesLoader.h
+++ b/Core/GDCore/Project/ResourcesLoader.h
@@ -29,6 +29,7 @@ public:
      * Load a SFML texture.
      */
     sf::Texture LoadSFMLTexture( const gd::String & filename );
+    void LoadSFMLTexture( const gd::String & filename, sf::Texture & texture );
 
     /**
      * Load a SFML Font.

--- a/GDCpp/GDCpp/Runtime/ResourcesLoader.cpp
+++ b/GDCpp/GDCpp/Runtime/ResourcesLoader.cpp
@@ -40,6 +40,13 @@ sf::Texture ResourcesLoader::LoadSFMLTexture(const gd::String & filename)
 {
     sf::Texture texture;
 
+    LoadSFMLTexture(filename, texture);
+
+    return texture;
+}
+
+void ResourcesLoader::LoadSFMLTexture( const gd::String & filename, sf::Texture & texture )
+{
     if (resFile.ContainsFile(filename))
     {
         char* buffer = resFile.GetFile(filename);
@@ -51,8 +58,6 @@ sf::Texture ResourcesLoader::LoadSFMLTexture(const gd::String & filename)
     }
     else if (!texture.loadFromFile(filename.ToLocale()))
         cout << "Failed to load a SFML texture: " << filename << endl;
-
-    return texture;
 }
 
 std::pair<sf::Font *, char *> ResourcesLoader::LoadFont(const gd::String & filename)

--- a/GDCpp/GDCpp/Runtime/ResourcesLoader.cpp
+++ b/GDCpp/GDCpp/Runtime/ResourcesLoader.cpp
@@ -36,6 +36,21 @@ bool ResourcesLoader::SetResourceFile(const gd::String & filename)
     return false;
 }
 
+void ResourcesLoader::LoadSFMLImage( const gd::String & filename, sf::Image & image )
+{
+    if (resFile.ContainsFile(filename))
+    {
+        char* buffer = resFile.GetFile(filename);
+        if (buffer==NULL)
+            cout << "Failed to get the file of a SFML image from resource file: " << filename << endl;
+
+        if (!image.loadFromMemory(buffer, resFile.GetFileSize(filename)))
+            cout << "Failed to load a SFML image from resource file: " << filename << endl;
+    }
+    else if (!image.loadFromFile(filename.ToLocale()))
+        cout << "Failed to load a SFML texture: " << filename << endl;
+}
+
 sf::Texture ResourcesLoader::LoadSFMLTexture(const gd::String & filename)
 {
     sf::Texture texture;

--- a/GDCpp/GDCpp/Runtime/ResourcesLoader.h
+++ b/GDCpp/GDCpp/Runtime/ResourcesLoader.h
@@ -39,6 +39,8 @@ public:
      */
     bool SetResourceFile( const gd::String & filename );
 
+    void LoadSFMLImage( const gd::String & filename, sf::Image & image );
+
     sf::Texture LoadSFMLTexture( const gd::String & filename );
     void LoadSFMLTexture( const gd::String & filename, sf::Texture & texture );
 

--- a/GDCpp/GDCpp/Runtime/ResourcesLoader.h
+++ b/GDCpp/GDCpp/Runtime/ResourcesLoader.h
@@ -40,6 +40,7 @@ public:
     bool SetResourceFile( const gd::String & filename );
 
     sf::Texture LoadSFMLTexture( const gd::String & filename );
+    void LoadSFMLTexture( const gd::String & filename, sf::Texture & texture );
 
     std::pair<sf::Font *, char *> LoadFont( const gd::String & filename );
 


### PR DESCRIPTION
Optimize the textures loading by avoiding a ```sf::Texture``` copy and a ```sf::Image``` copy. As these two classes don't have a move ctor (and not even an implicit one), use references to load the image (and not a return value).