### PR TITLE
Fix code generation when multiple scenes link to the same events

### DIFF
--- a/Core/GDCore/Events/Builtin/LinkEvent.cpp
+++ b/Core/GDCore/Events/Builtin/LinkEvent.cpp
@@ -42,7 +42,7 @@ const EventsList * LinkEvent::GetLinkedEvents(const gd::Project & project) const
     return events;
 }
 
-void LinkEvent::ReplaceLinkByLinkedEvents(gd::Project & project, EventsList & eventList, std::size_t indexOfTheEventInThisList)
+void LinkEvent::ReplaceLinkByLinkedEvents(const gd::Project & project, EventsList & eventList, std::size_t indexOfTheEventInThisList)
 {
     linkWasInvalid = false;
     //Finding what to link to.

--- a/Core/GDCore/Events/Builtin/LinkEvent.h
+++ b/Core/GDCore/Events/Builtin/LinkEvent.h
@@ -75,7 +75,7 @@ public:
      * When implementing a platform with a link event, you should call this function when preprocessing the events
      * (See gd::EventMetadata::codeGeneration).
      */
-    void ReplaceLinkByLinkedEvents(gd::Project & project, EventsList & eventList, std::size_t indexOfTheEventInThisList);
+    void ReplaceLinkByLinkedEvents(const gd::Project & project, EventsList & eventList, std::size_t indexOfTheEventInThisList);
 
     virtual bool IsExecutable() const { return true; };
 

--- a/Core/tests/Events.cpp
+++ b/Core/tests/Events.cpp
@@ -12,6 +12,7 @@
 #include "GDCore/Project/Project.h"
 #include "GDCore/Project/Layout.h"
 #include "GDCore/Project/Variable.h"
+#include "GDCore/Events/InstructionsList.h"
 #include "GDCore/Events/EventsList.h"
 #include "GDCore/Events/Event.h"
 #include "GDCore/Events/Builtin/GroupEvent.h"
@@ -20,6 +21,29 @@
 #include <memory>
 
 TEST_CASE( "Events", "[common][events]" ) {
+    SECTION("InstructionsList") {
+        gd::InstructionsList list;
+        gd::Instruction instr("InstructionType");
+        list.Insert(instr);
+        list.Insert(instr);
+        list.Insert(instr);
+
+        REQUIRE( list.size() == 3 );
+        list[1].SetType("ChangedInstructionType");
+
+        REQUIRE( list[0].GetType() == "InstructionType" );
+        REQUIRE( list[1].GetType() == "ChangedInstructionType" );
+
+        gd::InstructionsList list2 = list;
+        REQUIRE( list2.size() == 3 );
+        list2[0].SetType("YetAnotherInstructionType");
+
+        REQUIRE( list2[0].GetType() == "YetAnotherInstructionType" );
+        REQUIRE( list2[1].GetType() == "ChangedInstructionType" );
+        REQUIRE( list[0].GetType() == "InstructionType" );
+        REQUIRE( list[1].GetType() == "ChangedInstructionType" );
+    }
+
     SECTION("StandardEvent") {
         gd::Instruction instr("InstructionType");
         gd::StandardEvent event;
@@ -29,6 +53,10 @@ TEST_CASE( "Events", "[common][events]" ) {
         std::shared_ptr<gd::StandardEvent> cloned(event.Clone());
         REQUIRE( cloned->GetActions().size() == 1 );
         REQUIRE( cloned->GetActions()[0].GetType() == "InstructionType" );
+
+        cloned->GetActions()[0].SetType("ChangedInstructionType");
+        REQUIRE( cloned->GetActions()[0].GetType() == "ChangedInstructionType" );
+        REQUIRE( event.GetActions()[0].GetType() == "InstructionType" );
     }
 
     SECTION("ForEachEvent") {

--- a/GDCpp/GDCpp/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDCpp/GDCpp/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -409,18 +409,22 @@ gd::String EventsCodeGenerator::GenerateParameterCodes(const gd::String & parame
     return argOutput;
 }
 
-gd::String EventsCodeGenerator::GenerateSceneEventsCompleteCode(gd::Project & project, gd::Layout & scene, gd::EventsList & events, bool compilationForRuntime)
+gd::String EventsCodeGenerator::GenerateSceneEventsCompleteCode(gd::Project & project, gd::Layout & scene, const gd::EventsList & events, bool compilationForRuntime)
 {
+    // Preprocessing then code generation can make changes to the events, so we need to do
+    // the work on a copy of the events.
+    gd::EventsList generatedEvents = events;
+
     gd::String output;
 
     //Prepare the global context ( Used to get needed header files )
     gd::EventsCodeGenerationContext context;
     EventsCodeGenerator codeGenerator(project, scene);
-    codeGenerator.PreprocessEventList(scene.GetEvents());
-    codeGenerator.SetGenerateCodeForRuntime(compilationForRuntime);
 
     //Generate whole events code
-    gd::String wholeEventsCode = codeGenerator.GenerateEventsListCode(events, context);
+    codeGenerator.SetGenerateCodeForRuntime(compilationForRuntime);
+    codeGenerator.PreprocessEventList(generatedEvents);
+    gd::String wholeEventsCode = codeGenerator.GenerateEventsListCode(generatedEvents, context);
 
     //Generate default code around events:
     //Includes

--- a/GDCpp/GDCpp/Events/CodeGeneration/EventsCodeGenerator.h
+++ b/GDCpp/GDCpp/Events/CodeGeneration/EventsCodeGenerator.h
@@ -31,7 +31,7 @@ public:
      * \param compilationForRuntime Set this to true if the code is generated for runtime.
      * \return C++ code
      */
-    static gd::String GenerateSceneEventsCompleteCode(gd::Project & project, gd::Layout & scene, gd::EventsList & events, bool compilationForRuntime = false);
+    static gd::String GenerateSceneEventsCompleteCode(gd::Project & project, gd::Layout & scene, const gd::EventsList & events, bool compilationForRuntime = false);
 
     /**
      * Generate complete C++ file for compiling external events.

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -30,21 +30,25 @@ namespace gdjs
 
 gd::String EventsCodeGenerator::GenerateSceneEventsCompleteCode(gd::Project & project,
                                                                  gd::Layout & scene,
-                                                                 gd::EventsList & events,
+                                                                 const gd::EventsList & events,
                                                                  std::set < gd::String > & includeFiles,
                                                                  bool compilationForRuntime)
 {
+    // Preprocessing then code generation can make changes to the events, so we need to do
+    // the work on a copy of the events.
+    gd::EventsList generatedEvents = events;
+
     gd::String output = "gdjs."+gd::SceneNameMangler::GetMangledSceneName(scene.GetName())+"Code = {};\n";
 
     //Prepare the global context
     unsigned int maxDepthLevelReached = 0;
     gd::EventsCodeGenerationContext context(&maxDepthLevelReached);
     EventsCodeGenerator codeGenerator(project, scene);
-    codeGenerator.SetGenerateCodeForRuntime(compilationForRuntime);
-    codeGenerator.PreprocessEventList(events);
 
     //Generate whole events code
-    gd::String wholeEventsCode = codeGenerator.GenerateEventsListCode(events, context);
+    codeGenerator.SetGenerateCodeForRuntime(compilationForRuntime);
+    codeGenerator.PreprocessEventList(generatedEvents);
+    gd::String wholeEventsCode = codeGenerator.GenerateEventsListCode(generatedEvents, context);
 
     //Extra declarations needed by events
     for ( set<gd::String>::iterator declaration = codeGenerator.GetCustomGlobalDeclaration().begin() ;

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -29,10 +29,8 @@ namespace gdjs
 {
 
 gd::String EventsCodeGenerator::GenerateSceneEventsCompleteCode(gd::Project & project,
-                                                                 gd::Layout & scene,
-                                                                 const gd::EventsList & events,
-                                                                 std::set < gd::String > & includeFiles,
-                                                                 bool compilationForRuntime)
+    const gd::Layout & scene, const gd::EventsList & events, std::set < gd::String > & includeFiles,
+    bool compilationForRuntime)
 {
     // Preprocessing then code generation can make changes to the events, so we need to do
     // the work on a copy of the events.
@@ -56,7 +54,7 @@ gd::String EventsCodeGenerator::GenerateSceneEventsCompleteCode(gd::Project & pr
         output += *declaration+"\n";
 
     //Global objects lists
-    auto generateDeclarations = [&project, &scene, &codeGenerator](gd::Object & object, unsigned int maxDepth,
+    auto generateDeclarations = [&project, &scene, &codeGenerator](const gd::Object & object, unsigned int maxDepth,
         gd::String & globalObjectLists, gd::String & globalObjectListsReset) {
 
         gd::String type = gd::GetTypeOfObject(project, scene, object.GetName());

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.h
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.h
@@ -39,10 +39,8 @@ public:
      * \return JS code
      */
     static gd::String GenerateSceneEventsCompleteCode(gd::Project & project,
-                                                       gd::Layout & scene,
-                                                       const gd::EventsList & events,
-                                                       std::set < gd::String > & includeFiles,
-                                                       bool compilationForRuntime = false);
+        const gd::Layout & scene, const gd::EventsList & events,
+        std::set < gd::String > & includeFiles, bool compilationForRuntime = false);
 
     /**
      * Generate code for executing a condition list

--- a/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.h
+++ b/GDJS/GDJS/Events/CodeGeneration/EventsCodeGenerator.h
@@ -40,7 +40,7 @@ public:
      */
     static gd::String GenerateSceneEventsCompleteCode(gd::Project & project,
                                                        gd::Layout & scene,
-                                                       gd::EventsList & events,
+                                                       const gd::EventsList & events,
                                                        std::set < gd::String > & includeFiles,
                                                        bool compilationForRuntime = false);
 


### PR DESCRIPTION
This fixes a bug when multiple scenes are linking to the scenes events.
During code generation, events can be modified, for example to include links or to erase the type of conditions/actions that are not valid (when using an non existing object for example). 
For the Javascript platform, when generating code for a scene, the same events were used for generating the code of the next scene.
If both scene were using the same events, and that code generation made changes to the events for the first one (for example, to remove an action due to a missing object), the second scene would also be impacted by the change (for example, the action for the object won't be generated).

I stumbled on this bug while using two scenes with the same events, but not the same objects.
With the fix, events are copied so we are sure that code generation is not modifying them, as one could expect when using the code generation functions.

cc @victorlevasseur For your interest :)