### PR TITLE
No shared_ptr for RuntimeObjects and SceneStack

### DIFF
--- a/Core/GDCore/DocMainPage.h
+++ b/Core/GDCore/DocMainPage.h
@@ -531,7 +531,7 @@ AddEvent("Name",
          "Description",
          "Group",
          "path-to-a-16-by-16-icon.png",
-         std::shared_ptr<gd::BaseEvent>(new EventClassName))
+         std::make_shared<EventClassName>())
  * \endcode
  *
  * The event must be able to generate its code when events are being translated to C++ or Javascript:<br>
@@ -543,7 +543,7 @@ AddEvent("Standard",
          _("Standard event: Actions are run if conditions are fulfilled."),
          "",
          "res/eventaddicon.png",
-         std::shared_ptr<gd::BaseEvent>(new gd::StandardEvent))
+         std::make_shared<gd::StandardEvent>())
 	.SetCodeGenerator(std::shared_ptr<gd::EventMetadata::CodeGenerator>(codeGen));
  * \endcode
 
@@ -560,8 +560,8 @@ gd::BehaviorMetadata & aut = AddBehavior("Name",
 	"Group",
 	"path-to-a-32-by-32-icon.png",
 	"BehaviorClassName",
-	std::shared_ptr<gd::Behavior>(new BehaviorClassName),
-	std::shared_ptr<gd::BehaviorsSharedData>(new BehaviorSharedDataClassName));
+	std::make_shared<BehaviorClassName>(),
+	std::make_shared<BehaviorSharedDataClassName>());
  * \endcode
  * The last line can be replaced by <code>std::shared_ptr<gd::BehaviorsSharedData>()</code> if no shared data are being used.
  *
@@ -619,8 +619,8 @@ public:
                        "",
                        "CppPlatform/Extensions/myicon.png",
                        "PhysicsBehavior",
-                       std::shared_ptr<gd::Behavior>(new BehaviorClassName),
-                       std::shared_ptr<gd::BehaviorsSharedData>(new BehaviorSharedDataClassName));
+                       std::make_shared<BehaviorClassName>(),
+                       std::make_shared<BehaviorSharedDataClassName>());
 
             #if defined(GD_IDE_ONLY)
             behaviorInfo.SetIncludeFile("MyExtension/MyIncludeFile.h");

--- a/Core/GDCore/Events/EventsList.cpp
+++ b/Core/GDCore/Events/EventsList.cpp
@@ -58,7 +58,7 @@ gd::BaseEvent & EventsList::InsertNewEvent(gd::Project & project, const gd::Stri
     if ( event == std::shared_ptr<gd::BaseEvent>())
     {
         std::cout << "Unknown event of type " << eventType;
-        event = std::shared_ptr<gd::BaseEvent>(new EmptyEvent);
+        event = std::make_shared<EmptyEvent>();
     }
 
     InsertEvent(event, position);

--- a/Core/GDCore/Events/Serialization.cpp
+++ b/Core/GDCore/Events/Serialization.cpp
@@ -172,7 +172,7 @@ void EventsListSerialization::UnserializeEventsFrom(gd::Project & project, Event
         else
         {
             std::cout << "WARNING: Unknown event of type " << type << std::endl;
-            event = std::shared_ptr<gd::BaseEvent>(new EmptyEvent);
+            event = std::make_shared<EmptyEvent>();
         }
 
         event->SetDisabled(eventElem.GetBoolAttribute("disabled"));

--- a/Core/GDCore/Extensions/Builtin/CommonInstructionsExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CommonInstructionsExtension.cpp
@@ -70,37 +70,37 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCommonInstructionsExten
     extension.AddEvent("Standard", _("Standard event"),
               _("Standard event: Actions are run if conditions are fulfilled."),
               "", "res/eventaddicon.png",
-              std::shared_ptr<gd::BaseEvent>(new gd::StandardEvent));
+              std::make_shared<gd::StandardEvent>());
 
     extension.AddEvent("Link", _("Link"),
               _("Link to some external events"),
               "", "res/lienaddicon.png",
-              std::shared_ptr<gd::BaseEvent>(new gd::LinkEvent));
+              std::make_shared<gd::LinkEvent>());
 
     extension.AddEvent("Comment", _("Comment"),
               _("Event displaying a text in the events editor"),
               "", "res/comment.png",
-              std::shared_ptr<gd::BaseEvent>(new gd::CommentEvent));
+              std::make_shared<gd::CommentEvent>());
 
     extension.AddEvent("While", _("While"),
               _("The event is repeated while the conditions are true"),
               "", "res/while.png",
-              std::shared_ptr<gd::BaseEvent>(new gd::WhileEvent));
+              std::make_shared<gd::WhileEvent>());
 
     extension.AddEvent("Repeat", _("Repeat"),
               _("Event repeated a number of times"),
               "", "res/repeat.png",
-              std::shared_ptr<gd::BaseEvent>(new gd::RepeatEvent));
+              std::make_shared<gd::RepeatEvent>());
 
     extension.AddEvent("ForEach", _("For each object"),
               _("Repeat the event for each specified object."),
               "", "res/foreach.png",
-              std::shared_ptr<gd::BaseEvent>(new gd::ForEachEvent));
+              std::make_shared<gd::ForEachEvent>());
 
     extension.AddEvent("Group", _("Group"),
               _("Group containing events"),
               "", "res/foreach.png",
-              std::shared_ptr<gd::BaseEvent>(new gd::GroupEvent));
+              std::make_shared<gd::GroupEvent>());
 #endif
 }
 

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/Sprite.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/Sprite.cpp
@@ -142,7 +142,7 @@ void Sprite::MakeSpriteOwnsItsImage()
 {
     if ( !hasItsOwnImage || sfmlImage == std::shared_ptr<SFMLTextureWrapper>() )
     {
-        sfmlImage = std::shared_ptr<SFMLTextureWrapper>(new SFMLTextureWrapper(sfmlImage->texture)); //Copy the texture.
+        sfmlImage = std::make_shared<SFMLTextureWrapper>(sfmlImage->texture); //Copy the texture.
         sfmlSprite.setTexture(sfmlImage->texture);
         hasItsOwnImage = true;
     }

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.h
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteObject.h
@@ -44,7 +44,7 @@ public :
 
     SpriteObject(gd::String name_);
     virtual ~SpriteObject();
-    virtual gd::Object * Clone() const { return new SpriteObject(*this);}
+    virtual std::unique_ptr<gd::Object> Clone() const { return gd::make_unique<SpriteObject>(*this); }
 
     #if defined(GD_IDE_ONLY)
     virtual bool GenerateThumbnail(const gd::Project & project, wxBitmap & thumbnail) const;

--- a/Core/GDCore/Extensions/Metadata/ObjectMetadata.h
+++ b/Core/GDCore/Extensions/Metadata/ObjectMetadata.h
@@ -7,6 +7,7 @@
 #define OBJECTMETADATA_H
 #include "GDCore/String.h"
 #include <map>
+#include <memory>
 #include "GDCore/Extensions/Metadata/InstructionMetadata.h"
 #include "GDCore/Extensions/Metadata/ExpressionMetadata.h"
 #include "GDCore/String.h"
@@ -18,7 +19,7 @@ namespace gd { class InstructionMetadata; }
 namespace gd { class ExpressionMetadata; }
 class wxBitmap;
 
-typedef gd::Object * (*CreateFunPtr)(gd::String name);
+typedef std::unique_ptr<gd::Object> (*CreateFunPtr)(gd::String name);
 
 namespace gd
 {

--- a/Core/GDCore/Extensions/Platform.cpp
+++ b/Core/GDCore/Extensions/Platform.cpp
@@ -76,7 +76,7 @@ std::shared_ptr<gd::PlatformExtension> Platform::GetExtension(const gd::String &
     return std::shared_ptr<gd::PlatformExtension> ();
 }
 
-std::shared_ptr<gd::Object> Platform::CreateObject(gd::String type, const gd::String & name) const
+std::unique_ptr<gd::Object> Platform::CreateObject(gd::String type, const gd::String & name) const
 {
     if ( creationFunctionTable.find(type) == creationFunctionTable.end() )
     {
@@ -84,7 +84,7 @@ std::shared_ptr<gd::Object> Platform::CreateObject(gd::String type, const gd::St
         type = "";
         if ( creationFunctionTable.find("") == creationFunctionTable.end() ) {
             std::cout << "Unable to create a Base object!" << std::endl;
-            return std::shared_ptr<gd::Object>();
+            return nullptr;
         }
     }
 
@@ -92,7 +92,7 @@ std::shared_ptr<gd::Object> Platform::CreateObject(gd::String type, const gd::St
     gd::Object * object = (creationFunctionTable.find(type)->second)(name);
     object->SetType(type);
 
-    return std::shared_ptr<gd::Object> (object);
+    return std::unique_ptr<gd::Object> (object);
 }
 
 std::unique_ptr<gd::Behavior> Platform::CreateBehavior(const gd::String & behaviorType) const

--- a/Core/GDCore/Extensions/Platform.cpp
+++ b/Core/GDCore/Extensions/Platform.cpp
@@ -89,10 +89,10 @@ std::unique_ptr<gd::Object> Platform::CreateObject(gd::String type, const gd::St
     }
 
     //Create a new object with the type we want.
-    gd::Object * object = (creationFunctionTable.find(type)->second)(name);
+    std::unique_ptr<gd::Object> object = (creationFunctionTable.find(type)->second)(name);
     object->SetType(type);
 
-    return std::unique_ptr<gd::Object> (object);
+    return std::unique_ptr<gd::Object>(std::move(object));
 }
 
 std::unique_ptr<gd::Behavior> Platform::CreateBehavior(const gd::String & behaviorType) const
@@ -135,12 +135,12 @@ std::shared_ptr<gd::BaseEvent> Platform::CreateEvent(const gd::String & eventTyp
 #if !defined(GD_NO_WX_GUI)
 std::shared_ptr<gd::LayoutEditorPreviewer> Platform::GetLayoutPreviewer(gd::LayoutEditorCanvas & editor) const
 {
-    return std::shared_ptr<gd::LayoutEditorPreviewer>(new gd::LayoutEditorPreviewer);
+    return std::make_shared<gd::LayoutEditorPreviewer>();
 }
 
 std::vector<std::shared_ptr<gd::ProjectExporter>> Platform::GetProjectExporters() const
 {
-    return std::vector<std::shared_ptr<gd::ProjectExporter>>{std::shared_ptr<gd::ProjectExporter>(new gd::ProjectExporter)};
+    return std::vector<std::shared_ptr<gd::ProjectExporter>>{std::make_shared<gd::ProjectExporter>()};
 }
 #endif
 

--- a/Core/GDCore/Extensions/Platform.h
+++ b/Core/GDCore/Extensions/Platform.h
@@ -118,7 +118,7 @@ public:
     /**
      * \brief Create an object of given type with the specified name.
      */
-    std::shared_ptr<gd::Object> CreateObject(gd::String type, const gd::String & name) const;
+    std::unique_ptr<gd::Object> CreateObject(gd::String type, const gd::String & name) const;
 
     /**
      * \brief Create a behavior

--- a/Core/GDCore/Extensions/Platform.h
+++ b/Core/GDCore/Extensions/Platform.h
@@ -12,6 +12,7 @@
 #include "GDCore/String.h"
 #include "GDCore/Project/ChangesNotifier.h"
 #include "GDCore/Project/LayoutEditorPreviewer.h"
+
 namespace gd { class InstructionsMetadataHolder; }
 namespace gd { class Project; }
 namespace gd { class Object; }
@@ -24,8 +25,7 @@ namespace gd { class PlatformExtension; }
 namespace gd { class LayoutEditorCanvas; }
 namespace gd { class ProjectExporter; }
 
-typedef void (*DestroyFunPtr)(gd::Object*);
-typedef gd::Object * (*CreateFunPtr)(gd::String name);
+typedef std::unique_ptr<gd::Object> (*CreateFunPtr)(gd::String name);
 
 #undef CreateEvent
 

--- a/Core/GDCore/Extensions/PlatformExtension.h
+++ b/Core/GDCore/Extensions/PlatformExtension.h
@@ -16,6 +16,7 @@
 #include "GDCore/CommonTools.h"
 #include "GDCore/String.h"
 #include "GDCore/Tools/VersionPriv.h"
+
 namespace gd { class Instruction; }
 namespace gd { class InstructionMetadata; }
 namespace gd { class ExpressionMetadata; }
@@ -29,8 +30,7 @@ namespace gd { class BehaviorsSharedData; }
 namespace gd { class Behavior; }
 namespace gd { class Object; }
 
-typedef void (*DestroyFunPtr)(gd::Object*);
-typedef gd::Object * (*CreateFunPtr)(gd::String name);
+typedef std::unique_ptr<gd::Object> (*CreateFunPtr)(gd::String name);
 
 namespace gd
 {

--- a/Core/GDCore/Extensions/PlatformExtension.inl
+++ b/Core/GDCore/Extensions/PlatformExtension.inl
@@ -8,6 +8,8 @@
 #ifndef GDCORE_PLATFORMEXTENSION_INL
 #define GDCORE_PLATFORMEXTENSION_INL
 
+#include "GDCore/Tools/MakeUnique.h"
+
 namespace gd
 {
 
@@ -23,7 +25,7 @@ gd::ObjectMetadata & PlatformExtension::AddObject(const gd::String & name,
         fullname,
         informations,
         icon24x24,
-        [](gd::String name) -> gd::Object* { return new T(name); }
+        [](gd::String name) -> std::unique_ptr<gd::Object> { return gd::make_unique<T>(name); }
     );
 
     return objectsInfos[nameWithNamespace];

--- a/Core/GDCore/IDE/Clipboard.cpp
+++ b/Core/GDCore/IDE/Clipboard.cpp
@@ -21,16 +21,16 @@ namespace gd
 {
 
 Clipboard::Clipboard() :
-objectCopied(NULL),
+objectCopied(nullptr),
 hasObject(false),
 hasEvents(false),
 hasInstructions(false),
 instructionsAreConditions(true),
-externalEventsCopied(NULL),
+externalEventsCopied(nullptr),
 hasExternalEvents(false),
-externalLayoutCopied(NULL),
+externalLayoutCopied(nullptr),
 hasExternalLayout(false),
-layoutCopied(NULL),
+layoutCopied(nullptr),
 hasLayout(false),
 hasObjectGroup(false),
 hasInstances(false)
@@ -60,14 +60,14 @@ void Clipboard::DestroySingleton()
     }
 }
 
-void Clipboard::SetObject( const gd::Object * object )
+void Clipboard::SetObject( const gd::Object& object )
 {
-    objectCopied = object->Clone();
+    objectCopied = object.Clone();
 
     hasObject = true;
 }
 
-gd::Object * Clipboard::GetObject()
+std::unique_ptr<gd::Object> Clipboard::GetObject()
 {
     return objectCopied->Clone();
 }

--- a/Core/GDCore/IDE/Clipboard.h
+++ b/Core/GDCore/IDE/Clipboard.h
@@ -41,8 +41,8 @@ public:
      */
     static void DestroySingleton();
 
-    void SetObject( const gd::Object * object );
-    gd::Object * GetObject();
+    void SetObject( const gd::Object& object );
+    std::unique_ptr<gd::Object> GetObject();
     bool HasObject() { return hasObject; };
     void ForgetObject() { hasObject = false; };
 
@@ -82,7 +82,7 @@ private:
     Clipboard();
     virtual ~Clipboard();
 
-    gd::Object * objectCopied;
+    std::unique_ptr<gd::Object> objectCopied;
     bool hasObject;
 
     gd::EventsList eventsCopied;

--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas2.cpp
@@ -84,7 +84,7 @@ void LayoutEditorCanvas::OnUpdate()
 void LayoutEditorCanvas::DrawSelectionRectangleGuiElement(std::vector < std::shared_ptr<sf::Shape> > & target, const sf::FloatRect & rectangle )
 {
     //Create the shapes
-    std::shared_ptr<sf::Shape> selection = std::shared_ptr<sf::Shape>(new sf::RectangleShape(sf::Vector2f(rectangle.width, rectangle.height)));
+    std::shared_ptr<sf::Shape> selection = std::make_shared<sf::RectangleShape>(sf::Vector2f(rectangle.width, rectangle.height));
     selection->setPosition(rectangle.left, rectangle.top);
     selection->setFillColor(sf::Color( 0, 0, 200, 40 ));
     selection->setOutlineColor(sf::Color( 0, 0, 255, 128 ));
@@ -97,20 +97,20 @@ void LayoutEditorCanvas::DrawSelectionRectangleGuiElement(std::vector < std::sha
 void LayoutEditorCanvas::DrawAngleButtonGuiElement(std::vector < std::shared_ptr<sf::Shape> > & target, const sf::Vector2f & position, float angle )
 {
     //Create the shapes
-    std::shared_ptr<sf::Shape> centerShape = std::shared_ptr<sf::Shape>(new sf::CircleShape(3));
+    std::shared_ptr<sf::Shape> centerShape = std::make_shared<sf::CircleShape>(3);
     centerShape->setPosition(position);
     centerShape->setOutlineColor(sf::Color( 0, 0, 255, 128 ));
     centerShape->setOutlineThickness(1);
     centerShape->setFillColor(sf::Color( 0, 0, 200, 40 ));
     centerShape->setOrigin(sf::Vector2f(3,3));
 
-    std::shared_ptr<sf::Shape> angleButton = std::shared_ptr<sf::Shape>(new sf::RectangleShape(sf::Vector2f(smallButtonSize, smallButtonSize)));
+    std::shared_ptr<sf::Shape> angleButton = std::make_shared<sf::RectangleShape>(sf::Vector2f(smallButtonSize, smallButtonSize));
     angleButton->setPosition(position+sf::Vector2f(25.0*cos(angle/180.0*3.14159), 25.0*sin(angle/180.0*3.14159)));
     angleButton->setOutlineColor(sf::Color( 0, 0, 0, 255 ));
     angleButton->setOutlineThickness(1);
     angleButton->setOrigin(sf::Vector2f(smallButtonSize/2.0, smallButtonSize/2.0));
 
-    std::shared_ptr<sf::Shape> line = std::shared_ptr<sf::Shape>(new sf::RectangleShape(sf::Vector2f(26, 1)));
+    std::shared_ptr<sf::Shape> line = std::make_shared<sf::RectangleShape>(sf::Vector2f(26, 1));
     line->setPosition(position+sf::Vector2f(3.0*cos(angle/180.0*3.14159), 3.0*sin(angle/180.0*3.14159)));
     line->setRotation(angle);
     line->setFillColor(sf::Color( 0, 0, 200, 128 ));
@@ -136,7 +136,7 @@ void LayoutEditorCanvas::DrawAngleButtonGuiElement(std::vector < std::shared_ptr
 
 void LayoutEditorCanvas::DrawHighlightRectangleGuiElement(std::vector < std::shared_ptr<sf::Shape> > & target, const sf::FloatRect & rectangle )
 {
-    std::shared_ptr<sf::Shape> highlight = std::shared_ptr<sf::Shape>(new sf::RectangleShape(sf::Vector2f(rectangle.width, rectangle.height)));
+    std::shared_ptr<sf::Shape> highlight = std::make_shared<sf::RectangleShape>(sf::Vector2f(rectangle.width, rectangle.height));
     highlight->setPosition(rectangle.left, rectangle.top);
     highlight->setFillColor(sf::Color( 230, 230, 230, 20 ));
     highlight->setOutlineColor(sf::Color( 200, 200, 200, 70 ));
@@ -154,7 +154,7 @@ void LayoutEditorCanvas::AddSmallButtonGuiElement(std::vector < std::shared_ptr<
     guiElements.push_back(guiElement);
 
     //Draw button
-    std::shared_ptr<sf::Shape> button = std::shared_ptr<sf::Shape>(new sf::RectangleShape(sf::Vector2f(smallButtonSize, smallButtonSize)));
+    std::shared_ptr<sf::Shape> button = std::make_shared<sf::RectangleShape>(sf::Vector2f(smallButtonSize, smallButtonSize));
     button->setPosition(position);
     button->setOutlineColor(sf::Color( 0, 0, 0, 255 ));
     button->setOutlineThickness(1);

--- a/Core/GDCore/Project/ClassWithObjects.h
+++ b/Core/GDCore/Project/ClassWithObjects.h
@@ -35,7 +35,7 @@ public:
      * \brief Default constructor creating a container without any objects.
      */
     ClassWithObjects();
-    virtual ~ClassWithObjects() {};
+    virtual ~ClassWithObjects();
 
     /** \name Objects management
      * Members functions related to objects management.
@@ -113,12 +113,12 @@ public:
     /**
      * Provide a raw access to the vector containing the objects
      */
-    std::vector < std::shared_ptr<gd::Object> > & GetObjects() { return initialObjects; }
+    std::vector < std::unique_ptr<gd::Object> > & GetObjects() { return initialObjects; }
 
     /**
      * Provide a raw access to the vector containing the objects
      */
-    const std::vector < std::shared_ptr<gd::Object> > & GetObjects() const  { return initialObjects; }
+    const std::vector < std::unique_ptr<gd::Object> > & GetObjects() const  { return initialObjects; }
     ///@}
 
     /** \name Saving and loading
@@ -137,7 +137,7 @@ public:
     ///@}
 
 protected:
-    std::vector < std::shared_ptr<gd::Object> > initialObjects; ///< Objects contained.
+    std::vector < std::unique_ptr<gd::Object> > initialObjects; ///< Objects contained.
 };
 
 }

--- a/Core/GDCore/Project/ImageManager.cpp
+++ b/Core/GDCore/Project/ImageManager.cpp
@@ -21,7 +21,7 @@ ImageManager::ImageManager() :
     resourcesManager(NULL)
 {
     #if !defined(EMSCRIPTEN)
-    badTexture = std::shared_ptr<SFMLTextureWrapper>(new SFMLTextureWrapper);
+    badTexture = std::make_shared<SFMLTextureWrapper>();
     badTexture->texture.loadFromMemory(gd::InvalidImageData, sizeof(gd::InvalidImageData));
     badTexture->texture.setSmooth(false);
     badTexture->image = badTexture->texture.copyToImage();
@@ -124,7 +124,7 @@ std::shared_ptr<OpenGLTextureWrapper> ImageManager::GetOpenGLTexture(const gd::S
 
     std::cout << "Load OpenGL Texture" << name << std::endl;
 
-    std::shared_ptr<OpenGLTextureWrapper> texture = std::shared_ptr<OpenGLTextureWrapper>(new OpenGLTextureWrapper(GetSFMLTexture(name)));
+    std::shared_ptr<OpenGLTextureWrapper> texture = std::make_shared<OpenGLTextureWrapper>(GetSFMLTexture(name));
     alreadyLoadedOpenGLTextures[name] = texture;
     return texture;
 }

--- a/Core/GDCore/Project/Layer.cpp
+++ b/Core/GDCore/Project/Layer.cpp
@@ -121,7 +121,7 @@ void Layer::UnserializeFrom(const SerializerElement & element)
     {
         const SerializerElement & effectElement = effectsElement.GetChild(i);
 
-        auto effect = std::shared_ptr<gd::Effect>(new Effect);
+        auto effect = std::make_shared<Effect>();
         effect->UnserializeFrom(effectElement);
         effects.push_back(effect);
     }
@@ -180,7 +180,7 @@ std::size_t Layer::GetEffectPosition(const gd::String & name) const
 
 gd::Effect & Layer::InsertNewEffect(const gd::String & name, std::size_t position)
 {
-    auto newEffect = std::shared_ptr<gd::Effect>(new Effect);
+    auto newEffect = std::make_shared<Effect>();
     newEffect->SetName(name);
     newEffect->SetEffectName(name);
     if (position<effects.size())
@@ -193,7 +193,7 @@ gd::Effect & Layer::InsertNewEffect(const gd::String & name, std::size_t positio
 
 void Layer::InsertEffect(const gd::Effect & effect, std::size_t position)
 {
-    auto newEffect = std::shared_ptr<gd::Effect>(new Effect(effect));
+    auto newEffect = std::make_shared<gd::Effect>(effect);
     if (position<effects.size())
         effects.insert(effects.begin()+position, newEffect);
     else

--- a/Core/GDCore/Project/Layout.cpp
+++ b/Core/GDCore/Project/Layout.cpp
@@ -20,6 +20,7 @@
 #include "GDCore/Events/Serialization.h"
 #include "GDCore/Serialization/SerializerElement.h"
 #include "GDCore/CommonTools.h"
+#include "GDCore/Tools/PolymorphicClone.h"
 
 using namespace std;
 
@@ -338,9 +339,7 @@ void Layout::Init(const Layout & other)
     initialLayers = other.initialLayers;
     variables = other.GetVariables();
 
-    initialObjects.clear();
-    for (std::size_t i =0;i<other.initialObjects.size();++i)
-    	initialObjects.push_back( std::shared_ptr<gd::Object>(other.initialObjects[i]->Clone()) );
+    initialObjects = gd::Clone(other.initialObjects);
 
     behaviorsInitialSharedDatas.clear();
     for (std::map< gd::String, std::shared_ptr<gd::BehaviorsSharedData> >::const_iterator it = other.behaviorsInitialSharedDatas.begin();

--- a/Core/GDCore/Project/Object.h
+++ b/Core/GDCore/Project/Object.h
@@ -329,8 +329,8 @@ protected:
  *
  * \see gd::Object
  */
-struct ObjectHasName : public std::binary_function<std::shared_ptr<gd::Object>, gd::String, bool> {
-    bool operator()(const std::shared_ptr<gd::Object> & object, const gd::String & name) const { return object->GetName() == name; }
+struct ObjectHasName : public std::binary_function<std::unique_ptr<gd::Object>, gd::String, bool> {
+    bool operator()(const std::unique_ptr<gd::Object> & object, const gd::String & name) const { return object->GetName() == name; }
 };
 
 }
@@ -338,11 +338,11 @@ struct ObjectHasName : public std::binary_function<std::shared_ptr<gd::Object>, 
 /**
  * An object list is a vector containing (smart) pointers to objects.
  */
-typedef std::vector < std::shared_ptr<gd::Object> > ObjList;
+using ObjList = std::vector<std::unique_ptr<gd::Object>>;
 
 /**
  * Objects are usually managed thanks to (smart) pointers.
  */
-typedef std::shared_ptr<gd::Object> ObjSPtr;
+using ObjSPtr = std::unique_ptr<gd::Object>;
 
 #endif // GDCORE_OBJECT_H

--- a/Core/GDCore/Project/Object.h
+++ b/Core/GDCore/Project/Object.h
@@ -11,7 +11,9 @@
 #include <map>
 #include "GDCore/Project/Behavior.h"
 #include "GDCore/Project/VariablesContainer.h"
+#include "GDCore/Tools/MakeUnique.h"
 #include <SFML/System/Vector2.hpp>
+
 namespace gd { class PropertyDescriptor; }
 namespace gd { class Project; }
 namespace gd { class Layout; }
@@ -62,7 +64,7 @@ public:
      * return new MyObject(*this);
      * \endcode
      */
-    virtual gd::Object * Clone() const { return new gd::Object(*this); }
+    virtual std::unique_ptr<gd::Object> Clone() const { return gd::make_unique<gd::Object>(*this); }
 
     /** \name Common properties
      * Members functions related to common properties

--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -67,7 +67,7 @@ Project::Project() :
     maxFPS(60),
     minFPS(10),
     verticalSync(false),
-    imageManager(std::shared_ptr<gd::ImageManager>(new ImageManager))
+    imageManager(std::make_shared<ImageManager>())
     #if defined(GD_IDE_ONLY)
     ,useExternalSourceFiles(false),
     currentPlatform(NULL),
@@ -1026,7 +1026,7 @@ void Project::Init(const gd::Project & game)
 
     //Resources
     resourcesManager = game.resourcesManager;
-    imageManager = std::shared_ptr<ImageManager>(new ImageManager(*game.imageManager));
+    imageManager = std::make_shared<ImageManager>(*game.imageManager);
     imageManager->SetResourcesManager(&resourcesManager);
 
     initialObjects = gd::Clone(game.initialObjects);

--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -109,17 +109,17 @@ Project::~Project()
 {
 }
 
-std::shared_ptr<gd::Object> Project::CreateObject(const gd::String & type, const gd::String & name, const gd::String & platformName)
+std::unique_ptr<gd::Object> Project::CreateObject(const gd::String & type, const gd::String & name, const gd::String & platformName)
 {
     for (std::size_t i = 0;i<platforms.size();++i)
     {
         if ( !platformName.empty() && platforms[i]->GetName() != platformName ) continue;
 
-        std::shared_ptr<gd::Object> object = platforms[i]->CreateObject(type, name); //Create a base object if the type can't be found in the platform
+        std::unique_ptr<gd::Object> object = platforms[i]->CreateObject(type, name); //Create a base object if the type can't be found in the platform
         if ( object && object->GetType() == type ) return object; //If the object is valid and has the good type (not a base object), return it
     }
 
-    return std::shared_ptr<gd::Object>();
+    return nullptr;
 }
 
 std::unique_ptr<gd::Behavior> Project::CreateBehavior(const gd::String & type, const gd::String & platformName)
@@ -1029,9 +1029,7 @@ void Project::Init(const gd::Project & game)
     imageManager = std::shared_ptr<ImageManager>(new ImageManager(*game.imageManager));
     imageManager->SetResourcesManager(&resourcesManager);
 
-    GetObjects().clear();
-    for (std::size_t i =0;i<game.GetObjects().size();++i)
-    	GetObjects().push_back( std::shared_ptr<gd::Object>(game.GetObjects()[i]->Clone()) );
+    initialObjects = gd::Clone(game.initialObjects);
 
     scenes = gd::Clone(game.scenes);
 

--- a/Core/GDCore/Project/Project.h
+++ b/Core/GDCore/Project/Project.h
@@ -231,7 +231,7 @@ public:
      * \param name The name of the object
      * \param platformName The name of the platform to be used. If empty, the first platform supporting the object is used.
      */
-    std::shared_ptr<gd::Object> CreateObject(const gd::String & type, const gd::String & name, const gd::String & platformName = "");
+    std::unique_ptr<gd::Object> CreateObject(const gd::String & type, const gd::String & name, const gd::String & platformName = "");
 
     /**
      * Create a behavior of the given type.

--- a/Core/GDCore/Project/ResourcesManager.cpp
+++ b/Core/GDCore/Project/ResourcesManager.cpp
@@ -86,12 +86,12 @@ const Resource & ResourcesManager::GetResource(const gd::String & name) const
 std::shared_ptr<Resource> ResourcesManager::CreateResource(const gd::String & kind)
 {
     if (kind == "image")
-        return std::shared_ptr<Resource>(new ImageResource);
+        return std::make_shared<ImageResource>();
     else if (kind == "audio")
-        return std::shared_ptr<Resource>(new AudioResource);
+        return std::make_shared<AudioResource>();
 
     std::cout << "Bad resource created (type: " << kind << ")" << std::endl;
-    return std::shared_ptr<Resource>(new Resource);
+    return std::make_shared<Resource>();
 }
 
 bool ResourcesManager::HasResource(const gd::String & name) const

--- a/Core/GDCore/Tools/MakeUnique.h
+++ b/Core/GDCore/Tools/MakeUnique.h
@@ -1,0 +1,49 @@
+/*
+ * GDevelop Core
+ * This project is released under the MIT License.
+ *
+ * This file is from https://isocpp.org/files/papers/N3656.txt
+ */
+#ifndef GDCORE_MAKEUNIQUE_H
+#define GDCORE_MAKEUNIQUE_H
+
+#include <memory>
+
+/**
+ * Temporary implementation of make_unique as it's not available in C++11.
+ */
+namespace gd
+{
+
+template<class T> struct _Unique_if {
+    typedef std::unique_ptr<T> _Single_object;
+};
+
+template<class T> struct _Unique_if<T[]> {
+    typedef std::unique_ptr<T[]> _Unknown_bound;
+};
+
+template<class T, size_t N> struct _Unique_if<T[N]> {
+    typedef void _Known_bound;
+};
+
+template<class T, class... Args>
+    typename _Unique_if<T>::_Single_object
+    make_unique(Args&&... args) {
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    }
+
+template<class T>
+    typename _Unique_if<T>::_Unknown_bound
+    make_unique(size_t n) {
+        typedef typename std::remove_extent<T>::type U;
+        return std::unique_ptr<T>(new U[n]());
+    }
+
+template<class T, class... Args>
+    typename _Unique_if<T>::_Known_bound
+    make_unique(Args&&...) = delete;
+
+}
+
+#endif

--- a/Extensions/AdMobObject/AdMobObject.h
+++ b/Extensions/AdMobObject/AdMobObject.h
@@ -21,7 +21,7 @@ class GD_EXTENSION_API AdMobObject : public gd::Object
 public:
     AdMobObject(gd::String name_);
     virtual ~AdMobObject() {};
-    virtual gd::Object * Clone() const { return new AdMobObject(*this); }
+    virtual std::unique_ptr<gd::Object> Clone() const { return gd::make_unique<AdMobObject>(*this); }
 
     #if !defined(GD_NO_WX_GUI)
     void DrawInitialInstance(gd::InitialInstance & instance, sf::RenderTarget & renderTarget, gd::Project & project, gd::Layout & layout) override;

--- a/Extensions/AnchorBehavior/Extension.cpp
+++ b/Extensions/AnchorBehavior/Extension.cpp
@@ -25,8 +25,8 @@ void DeclareAnchorBehaviorExtension(gd::PlatformExtension & extension)
           "",
           "CppPlatform/Extensions/AnchorIcon.png",
           "AnchorBehavior",
-          std::shared_ptr<gd::Behavior>(new AnchorBehavior),
-          std::shared_ptr<gd::BehaviorsSharedData>(new gd::BehaviorsSharedData));
+          std::make_shared<AnchorBehavior>(),
+          std::make_shared<gd::BehaviorsSharedData>());
 
     #if defined(GD_IDE_ONLY)
 

--- a/Extensions/Box3DObject/Box3DObject.h
+++ b/Extensions/Box3DObject/Box3DObject.h
@@ -33,7 +33,7 @@ public :
 
     Box3DObject(gd::String name_);
     virtual ~Box3DObject();
-    virtual gd::Object * Clone() const { return new Box3DObject(*this);}
+    virtual std::unique_ptr<gd::Object> Clone() const { return std::unique_ptr<gd::Object>(new Box3DObject(*this)) ;}
 
     #if defined(GD_IDE_ONLY)
     virtual void LoadResources(gd::Project & project, gd::Layout & layout);
@@ -87,7 +87,7 @@ public :
 
     RuntimeBox3DObject(RuntimeScene & scene, const Box3DObject & box3DObject);
     virtual ~RuntimeBox3DObject() {};
-    virtual RuntimeObject * Clone() const { return new RuntimeBox3DObject(*this);}
+    virtual std::unique_ptr<RuntimeObject> Clone() const { return gd::make_unique<RuntimeBox3DObject>(*this);}
 
     virtual bool ExtraInitializationFromInitialInstance(const gd::InitialInstance & position);
     virtual bool Draw(sf::RenderTarget & renderTarget);

--- a/Extensions/DestroyOutsideBehavior/Extension.cpp
+++ b/Extensions/DestroyOutsideBehavior/Extension.cpp
@@ -25,7 +25,7 @@ void DeclareDestroyOutsideBehaviorExtension(gd::PlatformExtension & extension)
           "",
           "CppPlatform/Extensions/destroyoutsideicon.png",
           "DestroyOutsideBehavior",
-          std::shared_ptr<gd::Behavior>(new DestroyOutsideBehavior),
+          std::make_shared<DestroyOutsideBehavior>(),
           std::shared_ptr<gd::BehaviorsSharedData>());
 
     #if defined(GD_IDE_ONLY)

--- a/Extensions/DraggableBehavior/Extension.cpp
+++ b/Extensions/DraggableBehavior/Extension.cpp
@@ -25,7 +25,7 @@ void DeclareDraggableBehaviorExtension(gd::PlatformExtension & extension)
           "",
           "CppPlatform/Extensions/draggableicon.png",
           "DraggableBehavior",
-          std::shared_ptr<gd::Behavior>(new DraggableBehavior),
+          std::make_shared<DraggableBehavior>(),
           std::shared_ptr<gd::BehaviorsSharedData>());
 
     #if defined(GD_IDE_ONLY)

--- a/Extensions/Function/Extension.cpp
+++ b/Extensions/Function/Extension.cpp
@@ -107,7 +107,7 @@ public:
             _("Function event : An event which is launched only thanks to action \"Launch a function\""),
             "",
             "res/function.png",
-            std::shared_ptr<gd::BaseEvent>(new FunctionEvent))
+            std::make_shared<FunctionEvent>())
             .SetCodeGenerator([](gd::BaseEvent & event_, gd::EventsCodeGenerator & codeGenerator,
                 gd::EventsCodeGenerationContext & /* The function has nothing to do with the current context */){
                 FunctionEvent & event = dynamic_cast<FunctionEvent&>(event_);

--- a/Extensions/Light/Extension.cpp
+++ b/Extensions/Light/Extension.cpp
@@ -197,8 +197,8 @@ public:
               "",
               "CppPlatform/Extensions/lightObstacleIcon32.png",
               "LightObstacleBehavior",
-              std::shared_ptr<gd::Behavior>(new LightObstacleBehavior),
-              std::shared_ptr<gd::BehaviorsSharedData>(new SceneLightObstacleDatas));
+              std::make_shared<LightObstacleBehavior>(),
+              std::make_shared<SceneLightObstacleDatas>());
 
         GD_COMPLETE_EXTENSION_COMPILATION_INFORMATION();
     };

--- a/Extensions/Light/LightObject.cpp
+++ b/Extensions/Light/LightObject.cpp
@@ -100,7 +100,7 @@ RuntimeLightObject::RuntimeLightObject(RuntimeScene & scene, const LightObject &
     //Get a manager for the scene
     if ( lightManagersList[&scene].expired() )
     {
-        manager = std::shared_ptr<Light_Manager>(new Light_Manager);
+        manager = std::make_shared<Light_Manager>();
         lightManagersList[&scene] = manager;
     }
     else
@@ -124,7 +124,7 @@ void RuntimeLightObject::UpdateGlobalLightMembers()
     if ( globalLight )
     {
         //Create supplementary members for the global light
-        if ( !globalLightImage ) globalLightImage = std::shared_ptr<sf::RenderTexture>(new sf::RenderTexture);
+        if ( !globalLightImage ) globalLightImage = std::make_shared<sf::RenderTexture>();
     }
     else
     {

--- a/Extensions/Light/LightObject.h
+++ b/Extensions/Light/LightObject.h
@@ -46,7 +46,7 @@ public :
 
     LightObject(gd::String name_);
     virtual ~LightObject() {};
-    virtual gd::Object * Clone() const { return new LightObject(*this);}
+    virtual std::unique_ptr<gd::Object> Clone() const { return gd::make_unique<LightObject>(*this); }
 
     #if defined(GD_IDE_ONLY)
     virtual void DrawInitialInstance(gd::InitialInstance & instance, sf::RenderTarget & renderTarget, gd::Project & project, gd::Layout & layout);
@@ -94,7 +94,7 @@ public :
 
     RuntimeLightObject(RuntimeScene & scene, const LightObject & lightObject);
     virtual ~RuntimeLightObject() {};
-    virtual RuntimeObject * Clone() const { return new RuntimeLightObject(*this);}
+    virtual std::unique_ptr<RuntimeObject> Clone() const { return gd::make_unique<RuntimeLightObject>(*this);}
 
     virtual bool Draw(sf::RenderTarget & renderTarget);
 

--- a/Extensions/Light/LightObstacleBehavior.cpp
+++ b/Extensions/Light/LightObstacleBehavior.cpp
@@ -58,7 +58,7 @@ void LightObstacleBehavior::DoStepPostEvents(RuntimeScene & scene)
     //Get a manager for the scene
     if ( RuntimeLightObject::lightManagersList[&scene].expired() )
     {
-        manager = std::shared_ptr<Light_Manager>(new Light_Manager);
+        manager = std::make_shared<Light_Manager>();
         RuntimeLightObject::lightManagersList[&scene] = manager;
     }
     else

--- a/Extensions/Network/Extension.cpp
+++ b/Extensions/Network/Extension.cpp
@@ -176,8 +176,8 @@ public:
                   "",
                   "CppPlatform/Extensions/networkicon32.png",
                   "NetworkBehavior",
-                  std::shared_ptr<gd::Behavior>(new NetworkBehavior),
-                  std::shared_ptr<gd::BehaviorsSharedData>(new SceneNetworkDatas));
+                  std::make_shared<NetworkBehavior>(),
+                  std::make_shared<SceneNetworkDatas>());
 
             #if defined(GD_IDE_ONLY)
             aut.SetIncludeFile("Network/NetworkBehavior.h");

--- a/Extensions/PanelSpriteObject/PanelSpriteObject.h
+++ b/Extensions/PanelSpriteObject/PanelSpriteObject.h
@@ -32,7 +32,7 @@ public :
 
     PanelSpriteObject(gd::String name_);
     virtual ~PanelSpriteObject();
-    virtual gd::Object * Clone() const { return new PanelSpriteObject(*this);}
+    virtual std::unique_ptr<gd::Object> Clone() const { return std::unique_ptr<gd::Object>(new PanelSpriteObject(*this)) ;}
 
     #if defined(GD_IDE_ONLY)
     virtual void LoadResources(gd::Project & project, gd::Layout & layout);
@@ -91,7 +91,7 @@ public :
 
     RuntimePanelSpriteObject(RuntimeScene & scene, const PanelSpriteObject & panelSpriteObject);
     virtual ~RuntimePanelSpriteObject() {};
-    virtual RuntimeObject * Clone() const { return new RuntimePanelSpriteObject(*this);}
+    virtual std::unique_ptr<RuntimeObject> Clone() const { return gd::make_unique<RuntimePanelSpriteObject>(*this);}
 
     virtual bool Draw(sf::RenderTarget & renderTarget);
 

--- a/Extensions/ParticleSystem/ParticleEmitterObject.h
+++ b/Extensions/ParticleSystem/ParticleEmitterObject.h
@@ -219,7 +219,7 @@ public :
 
     ParticleEmitterObject(gd::String name_);
     virtual ~ParticleEmitterObject() {};
-    virtual gd::Object * Clone() const { return new ParticleEmitterObject(*this);}
+    virtual std::unique_ptr<gd::Object> Clone() const { return gd::make_unique<ParticleEmitterObject>(*this); }
 
     #if defined(GD_IDE_ONLY)
     virtual void DrawInitialInstance(gd::InitialInstance & instance, sf::RenderTarget & renderTarget, gd::Project & project, gd::Layout & layout);
@@ -250,7 +250,7 @@ public :
 
     RuntimeParticleEmitterObject(RuntimeScene & scene, const ParticleEmitterObject & particleEmitterObject);
     virtual ~RuntimeParticleEmitterObject() {};
-    virtual RuntimeObject * Clone() const { return new RuntimeParticleEmitterObject(*this);}
+    virtual std::unique_ptr<RuntimeObject> Clone() const { return gd::make_unique<RuntimeParticleEmitterObject>(*this);}
 
     virtual bool Draw(sf::RenderTarget & renderTarget);
 

--- a/Extensions/PathBehavior/Extension.cpp
+++ b/Extensions/PathBehavior/Extension.cpp
@@ -41,8 +41,8 @@ public:
                       "",
                       "CppPlatform/Extensions/pathicon.png",
                       "PathBehavior",
-                      std::shared_ptr<gd::Behavior>(new PathBehavior),
-                      std::shared_ptr<gd::BehaviorsSharedData>(new ScenePathDatas));
+                      std::make_shared<PathBehavior>(),
+                      std::make_shared<ScenePathDatas>());
 
                 #if defined(GD_IDE_ONLY)
 

--- a/Extensions/PathfindingBehavior/Extension.cpp
+++ b/Extensions/PathfindingBehavior/Extension.cpp
@@ -38,8 +38,8 @@ public:
                   "",
                   "CppPlatform/Extensions/AStaricon.png",
                   "PathfindingBehavior",
-                  std::shared_ptr<gd::Behavior>(new PathfindingBehavior),
-                  std::shared_ptr<gd::BehaviorsSharedData>(new gd::BehaviorsSharedData));
+                  std::make_shared<PathfindingBehavior>(),
+                  std::make_shared<gd::BehaviorsSharedData>());
 
             #if defined(GD_IDE_ONLY)
 
@@ -483,8 +483,8 @@ public:
                   "",
                   "CppPlatform/Extensions/pathfindingobstacleicon.png",
                   "PathfindingObstacleBehavior",
-                  std::shared_ptr<gd::Behavior>(new PathfindingObstacleBehavior),
-                  std::shared_ptr<gd::BehaviorsSharedData>(new gd::BehaviorsSharedData));
+                  std::make_shared<PathfindingObstacleBehavior>(),
+                  std::make_shared<gd::BehaviorsSharedData>());
 
             #if defined(GD_IDE_ONLY)
             aut.SetIncludeFile("PathfindingBehavior/PathfindingObstacleBehavior.h");

--- a/Extensions/PathfindingBehavior/tests/PathfindingBehavior.cpp
+++ b/Extensions/PathfindingBehavior/tests/PathfindingBehavior.cpp
@@ -62,14 +62,14 @@ TEST_CASE( "PathfindingBehavior", "[game-engine][pathfinding]" ) {
 		//Add an obstacle
 		gd::Object obstacleObj("obstacle");
 		obstacleObj.AddBehavior(new PathfindingObstacleBehavior());
-		std::shared_ptr<ResizableRuntimeObject> obstacle(new ResizableRuntimeObject(scene, obstacleObj));
-
-		scene.objectsInstances.AddObject(obstacle);
-
-		obstacle->SetX(1100);
+		std::unique_ptr<ResizableRuntimeObject> obstacle(new ResizableRuntimeObject(scene, obstacleObj));
+        obstacle->SetX(1100);
 		obstacle->SetY(1200);
 		obstacle->SetWidth(200);
 		obstacle->SetHeight(200);
+
+		scene.objectsInstances.AddObject(std::move(obstacle));
+
 		scene.RenderAndStep();
 
 		runtimeBehavior->MoveTo(scene, 1200, 1300);
@@ -89,10 +89,8 @@ TEST_CASE( "PathfindingBehavior", "[game-engine][pathfinding]" ) {
 		obstacleObj.AddBehavior(new PathfindingObstacleBehavior());
 
 		RuntimeScene scene(NULL, &game);
-		std::shared_ptr<RuntimeObject> player(new RuntimeObject(scene, playerObj));
-		std::shared_ptr<ResizableRuntimeObject> obstacle(new ResizableRuntimeObject(scene, obstacleObj));
-		scene.objectsInstances.AddObject(player);
-		scene.objectsInstances.AddObject(obstacle);
+		auto * player = scene.objectsInstances.AddObject(std::unique_ptr<RuntimeObject>(new RuntimeObject(scene, playerObj)));
+		auto * obstacle = scene.objectsInstances.AddObject(std::unique_ptr<RuntimeObject>(new ResizableRuntimeObject(scene, obstacleObj)));
 
 		obstacle->SetX(300);
 		obstacle->SetY(600);
@@ -140,12 +138,10 @@ TEST_CASE( "PathfindingBehavior", "[game-engine][pathfinding]" ) {
 		obstacleObj.AddBehavior(new PathfindingObstacleBehavior());
 
 		RuntimeScene scene(NULL, &game);
-		std::shared_ptr<RuntimeObject> player(new RuntimeObject(scene, playerObj));
-		std::shared_ptr<ResizableRuntimeObject> obstacle1(new ResizableRuntimeObject(scene, obstacleObj));
-		std::shared_ptr<ResizableRuntimeObject> obstacle2(new ResizableRuntimeObject(scene, obstacleObj));
-		scene.objectsInstances.AddObject(player);
-		scene.objectsInstances.AddObject(obstacle1);
-		scene.objectsInstances.AddObject(obstacle2);
+
+		auto * player = scene.objectsInstances.AddObject(std::unique_ptr<RuntimeObject>(new RuntimeObject(scene, playerObj)));
+		auto * obstacle1 = scene.objectsInstances.AddObject(std::unique_ptr<RuntimeObject>(new ResizableRuntimeObject(scene, obstacleObj)));
+		auto * obstacle2 = scene.objectsInstances.AddObject(std::unique_ptr<RuntimeObject>(new ResizableRuntimeObject(scene, obstacleObj)));
 
 		obstacle1->SetX(-20);
 		obstacle2->SetX(20);
@@ -175,8 +171,7 @@ TEST_CASE( "PathfindingBehavior", "[game-engine][pathfinding]" ) {
 		playerObj.AddBehavior(behavior);
 
 		RuntimeScene scene(NULL, &game);
-		std::shared_ptr<RuntimeObject> player(new RuntimeObject(scene, playerObj));
-		scene.objectsInstances.AddObject(player);
+		auto * player = scene.objectsInstances.AddObject(std::unique_ptr<RuntimeObject>(new RuntimeObject(scene, playerObj)));
 
 		PathfindingBehavior * runtimeBehavior =
 			static_cast<PathfindingBehavior *>(player->GetBehaviorRawPointer("Pathfinding"));

--- a/Extensions/PhysicsBehavior/Extension.cpp
+++ b/Extensions/PhysicsBehavior/Extension.cpp
@@ -41,8 +41,8 @@ public:
                   "",
                   "res/physics32.png",
                   "PhysicsBehavior",
-                  std::shared_ptr<gd::Behavior>(new PhysicsBehavior),
-                  std::shared_ptr<gd::BehaviorsSharedData>(new ScenePhysicsDatas));
+                  std::make_shared<PhysicsBehavior>(),
+                  std::make_shared<ScenePhysicsDatas>());
 
             #if defined(GD_IDE_ONLY)
             aut.SetIncludeFile("PhysicsBehavior/PhysicsBehavior.h");

--- a/Extensions/PlatformBehavior/Extension.cpp
+++ b/Extensions/PlatformBehavior/Extension.cpp
@@ -28,8 +28,8 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension & extension)
               "",
               "CppPlatform/Extensions/platformerobjecticon.png",
               "PlatformerObjectBehavior",
-              std::shared_ptr<gd::Behavior>(new PlatformerObjectBehavior),
-              std::shared_ptr<gd::BehaviorsSharedData>(new gd::BehaviorsSharedData));
+              std::make_shared<PlatformerObjectBehavior>(),
+              std::make_shared<gd::BehaviorsSharedData>());
 
         #if defined(GD_IDE_ONLY)
         aut.SetIncludeFile("PlatformBehavior/PlatformerObjectBehavior.h");
@@ -429,8 +429,8 @@ void DeclarePlatformBehaviorExtension(gd::PlatformExtension & extension)
               "",
               "CppPlatform/Extensions/platformicon.png",
               "PlatformBehavior",
-              std::shared_ptr<gd::Behavior>(new PlatformBehavior),
-              std::shared_ptr<gd::BehaviorsSharedData>(new gd::BehaviorsSharedData));
+              std::make_shared<PlatformBehavior>(),
+              std::make_shared<gd::BehaviorsSharedData>());
 
         #if defined(GD_IDE_ONLY)
         aut.SetIncludeFile("PlatformBehavior/PlatformBehavior.h");

--- a/Extensions/PrimitiveDrawing/PrimitiveDrawingTools.cpp
+++ b/Extensions/PrimitiveDrawing/PrimitiveDrawingTools.cpp
@@ -56,7 +56,7 @@ void GD_EXTENSION_API CreateSFMLTexture( RuntimeScene & scene, const gd::String 
     //Get or create the texture in memory
     std::shared_ptr<SFMLTextureWrapper> newTexture;
     if ( !scene.GetImageManager()->HasLoadedSFMLTexture(imageName) )
-        newTexture = std::shared_ptr<SFMLTextureWrapper>(new SFMLTextureWrapper);
+        newTexture = std::make_shared<SFMLTextureWrapper>();
     else
         newTexture = scene.GetImageManager()->GetSFMLTexture(imageName);
 
@@ -84,7 +84,7 @@ void GD_EXTENSION_API OpenSFMLTextureFromFile( RuntimeScene & scene, const gd::S
     //Get or create the texture in memory
     std::shared_ptr<SFMLTextureWrapper> newTexture;
     if ( !scene.GetImageManager()->HasLoadedSFMLTexture(imageName) )
-        newTexture = std::shared_ptr<SFMLTextureWrapper>(new SFMLTextureWrapper);
+        newTexture = std::make_shared<SFMLTextureWrapper>();
     else
         newTexture = scene.GetImageManager()->GetSFMLTexture(imageName);
 

--- a/Extensions/PrimitiveDrawing/ShapePainterObject.h
+++ b/Extensions/PrimitiveDrawing/ShapePainterObject.h
@@ -113,7 +113,7 @@ class GD_EXTENSION_API ShapePainterObject : public gd::Object, public ShapePaint
 public:
     ShapePainterObject(gd::String name_);
     virtual ~ShapePainterObject() {};
-    virtual gd::Object * Clone() const { return new ShapePainterObject(*this); }
+    virtual std::unique_ptr<gd::Object> Clone() const { return gd::make_unique<ShapePainterObject>(*this); }
 
     #if defined(GD_IDE_ONLY)
     virtual void DrawInitialInstance(gd::InitialInstance & instance, sf::RenderTarget & renderTarget, gd::Project & project, gd::Layout & layout);
@@ -139,7 +139,7 @@ class GD_EXTENSION_API RuntimeShapePainterObject : public RuntimeObject, public 
 public:
     RuntimeShapePainterObject(RuntimeScene & scene, const ShapePainterObject & shapePainterObject);
     virtual ~RuntimeShapePainterObject() {};
-    virtual RuntimeObject * Clone() const { return new RuntimeShapePainterObject(*this);}
+    virtual std::unique_ptr<RuntimeObject> Clone() const { return gd::make_unique<RuntimeShapePainterObject>(*this);}
 
     virtual bool Draw(sf::RenderTarget & renderTarget);
 

--- a/Extensions/SoundObject/SoundObject.h
+++ b/Extensions/SoundObject/SoundObject.h
@@ -42,7 +42,7 @@ public :
 
     SoundObject(gd::String name_);
     virtual ~SoundObject() {};
-    virtual gd::Object * Clone() const { return new SoundObject(*this);}
+    virtual std::unique_ptr<gd::Object> Clone() const { return gd::make_unique<SoundObject>(*this); }
 
     #if defined(GD_IDE_ONLY)
     virtual void DrawInitialInstance(gd::InitialInstance & instance, sf::RenderTarget & renderTarget, gd::Project & project, gd::Layout & layout);
@@ -108,7 +108,7 @@ public :
     RuntimeSoundObject(const RuntimeSoundObject & other);
     RuntimeSoundObject & operator=(const RuntimeSoundObject & other);
     virtual ~RuntimeSoundObject();
-    virtual RuntimeSoundObject * Clone() const { return new RuntimeSoundObject(*this);}
+    virtual std::unique_ptr<RuntimeObject> Clone() const { return gd::make_unique<RuntimeSoundObject>(*this);}
 
     virtual bool ExtraInitializationFromInitialInstance(const gd::InitialInstance & position);
 

--- a/Extensions/TextEntryObject/TextEntryObject.h
+++ b/Extensions/TextEntryObject/TextEntryObject.h
@@ -32,7 +32,7 @@ class GD_EXTENSION_API TextEntryObject : public gd::Object
 public :
     TextEntryObject(gd::String name_);
     virtual ~TextEntryObject() {};
-    virtual gd::Object * Clone() const { return new TextEntryObject(*this); }
+    virtual std::unique_ptr<gd::Object> Clone() const { return gd::make_unique<TextEntryObject>(*this); }
 
     #if defined(GD_IDE_ONLY)
     virtual void DrawInitialInstance(gd::InitialInstance & instance, sf::RenderTarget & renderTarget, gd::Project & project, gd::Layout & layout);
@@ -54,7 +54,7 @@ public :
 
     RuntimeTextEntryObject(RuntimeScene & scene, const TextEntryObject & textEntryObject);
     virtual ~RuntimeTextEntryObject() {};
-    virtual RuntimeObject * Clone() const { return new RuntimeTextEntryObject(*this);}
+    virtual std::unique_ptr<RuntimeObject> Clone() const { return gd::make_unique<RuntimeTextEntryObject>(*this);}
 
     #if defined(GD_IDE_ONLY)
     virtual void GetPropertyForDebugger (std::size_t propertyNb, gd::String & name, gd::String & value) const;

--- a/Extensions/TextObject/TextObject.h
+++ b/Extensions/TextObject/TextObject.h
@@ -34,7 +34,7 @@ public :
 
     TextObject(gd::String name_);
     virtual ~TextObject();
-    virtual gd::Object * Clone() const { return new TextObject(*this); }
+    virtual std::unique_ptr<gd::Object> Clone() const { return gd::make_unique<TextObject>(*this); }
 
     #if defined(GD_IDE_ONLY)
     virtual void DrawInitialInstance(gd::InitialInstance & instance, sf::RenderTarget & renderTarget, gd::Project & project, gd::Layout & layout);
@@ -110,7 +110,7 @@ public :
 
     RuntimeTextObject(RuntimeScene & scene, const TextObject & textObject);
     virtual ~RuntimeTextObject() {};
-    virtual RuntimeObject * Clone() const { return new RuntimeTextObject(*this);}
+    virtual std::unique_ptr<RuntimeObject> Clone() const { return gd::make_unique<RuntimeTextObject>(*this);}
 
     virtual bool Draw(sf::RenderTarget & renderTarget);
 

--- a/Extensions/TileMapObject/RuntimeTileMapObject.h
+++ b/Extensions/TileMapObject/RuntimeTileMapObject.h
@@ -37,7 +37,7 @@ public :
 
     RuntimeTileMapObject(RuntimeScene & scene, const TileMapObject & tileMapObject);
     virtual ~RuntimeTileMapObject() {};
-    virtual RuntimeObject * Clone() const { return new RuntimeTileMapObject(*this);}
+    virtual std::unique_ptr<RuntimeObject> Clone() const { return gd::make_unique<RuntimeTileMapObject>(*this);}
 
     virtual bool Draw(sf::RenderTarget & renderTarget);
 

--- a/Extensions/TileMapObject/TileMapObject.h
+++ b/Extensions/TileMapObject/TileMapObject.h
@@ -35,7 +35,7 @@ public :
 
     TileMapObject(gd::String name_);
     virtual ~TileMapObject() {};
-    virtual gd::Object * Clone() const { return new TileMapObject(*this);}
+    virtual std::unique_ptr<gd::Object> Clone() const { return gd::make_unique<TileMapObject>(*this); }
 
     #if defined(GD_IDE_ONLY)
     virtual bool GenerateThumbnail(const gd::Project & project, wxBitmap & thumbnail) const;

--- a/Extensions/TiledSpriteObject/TiledSpriteObject.h
+++ b/Extensions/TiledSpriteObject/TiledSpriteObject.h
@@ -31,7 +31,7 @@ public :
 
     TiledSpriteObject(gd::String name_);
     virtual ~TiledSpriteObject() {};
-    virtual gd::Object * Clone() const { return new TiledSpriteObject(*this);}
+    virtual std::unique_ptr<gd::Object> Clone() const { return gd::make_unique<TiledSpriteObject>(*this); }
 
     #if defined(GD_IDE_ONLY)
     virtual bool GenerateThumbnail(const gd::Project & project, wxBitmap & thumbnail) const;
@@ -74,7 +74,7 @@ public :
 
     RuntimeTiledSpriteObject(RuntimeScene & scene, const TiledSpriteObject & tiledSpriteObject);
     virtual ~RuntimeTiledSpriteObject() {};
-    virtual RuntimeObject * Clone() const { return new RuntimeTiledSpriteObject(*this);}
+    virtual std::unique_ptr<RuntimeObject> Clone() const { return gd::make_unique<RuntimeTiledSpriteObject>(*this);}
 
     virtual bool Draw(sf::RenderTarget & renderTarget);
 

--- a/Extensions/TimedEvent/Extension.cpp
+++ b/Extensions/TimedEvent/Extension.cpp
@@ -44,7 +44,7 @@ public:
                       _("Event which launch its conditions and actions only after a amount of time is reached."),
                       "",
                       "CppPlatform/Extensions/timedevent16.png",
-                      std::shared_ptr<gd::BaseEvent>(new TimedEvent))
+                      std::make_shared<TimedEvent>())
             .SetCodeGenerator([](gd::BaseEvent & event_, gd::EventsCodeGenerator & codeGenerator, gd::EventsCodeGenerationContext & context) {
                 TimedEvent & event = dynamic_cast<TimedEvent&>(event_);
 

--- a/Extensions/TopDownMovementBehavior/Extension.cpp
+++ b/Extensions/TopDownMovementBehavior/Extension.cpp
@@ -26,8 +26,8 @@ void DeclareTopDownMovementBehaviorExtension(gd::PlatformExtension & extension)
           "",
           "CppPlatform/Extensions/topdownmovementicon.png",
           "TopDownMovementBehavior",
-          std::shared_ptr<gd::Behavior>(new TopDownMovementBehavior),
-          std::shared_ptr<gd::BehaviorsSharedData>(new gd::BehaviorsSharedData));
+          std::make_shared<TopDownMovementBehavior>(),
+          std::make_shared<gd::BehaviorsSharedData>());
 
     #if defined(GD_IDE_ONLY)
 

--- a/GDCpp/GDCpp/Events/CodeGeneration/EventsCodeGenerator.cpp
+++ b/GDCpp/GDCpp/Events/CodeGeneration/EventsCodeGenerator.cpp
@@ -521,7 +521,7 @@ void EventsCodeGenerator::PreprocessEventList( gd::EventsList & eventsList )
             if ( scene.GetProfiler() && scene.GetProfiler()->profilingActivated && eventsList[i].IsExecutable() )
             {
                 //Define a new profile event
-                std::shared_ptr<ProfileEvent> profileEvent = std::shared_ptr<ProfileEvent>(new ProfileEvent);
+                std::shared_ptr<ProfileEvent> profileEvent = std::make_shared<ProfileEvent>();
                 profileEvent->originalEvent = eventsList[i].originalEvent;
                 profileEvent->SetPreviousProfileEvent(previousProfileEvent);
 
@@ -539,7 +539,7 @@ void EventsCodeGenerator::PreprocessEventList( gd::EventsList & eventsList )
     if ( !eventsList.IsEmpty() && scene.GetProfiler() && scene.GetProfiler()->profilingActivated )
     {
         //Define a new profile events
-        std::shared_ptr<ProfileEvent> profileEvent = std::shared_ptr<ProfileEvent>(new ProfileEvent);
+        std::shared_ptr<ProfileEvent> profileEvent = std::make_shared<ProfileEvent>();
         profileEvent->SetPreviousProfileEvent(previousProfileEvent);
 
         //Add it at the end of the events list

--- a/GDCpp/GDCpp/Extensions/CppPlatform.cpp
+++ b/GDCpp/GDCpp/Extensions/CppPlatform.cpp
@@ -131,19 +131,19 @@ bool CppPlatform::AddExtension(std::shared_ptr<gd::PlatformExtension> platformEx
     return true;
 }
 
-std::shared_ptr<RuntimeObject> CppPlatform::CreateRuntimeObject(RuntimeScene & scene, gd::Object & object)
+std::unique_ptr<RuntimeObject> CppPlatform::CreateRuntimeObject(RuntimeScene & scene, gd::Object & object)
 {
     const gd::String & type = object.GetType();
 
     if ( runtimeObjCreationFunctionTable.find(type) == runtimeObjCreationFunctionTable.end() )
     {
         std::cout << "Tried to create an object with an unknown type: " << type << std::endl;
-        return std::shared_ptr<RuntimeObject>();
+        return std::unique_ptr<RuntimeObject>();
     }
 
     //Create a new object with the type we want.
     RuntimeObject * newObject = runtimeObjCreationFunctionTable[type](scene, object);
-    return std::shared_ptr<RuntimeObject>(newObject);
+    return std::unique_ptr<RuntimeObject>(newObject);
 }
 
 #if defined(GD_IDE_ONLY)

--- a/GDCpp/GDCpp/Extensions/CppPlatform.cpp
+++ b/GDCpp/GDCpp/Extensions/CppPlatform.cpp
@@ -82,25 +82,25 @@ CppPlatform::CppPlatform() :
 #endif
 
     std::cout << "* Loading builtin extensions... "; std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new BaseObjectExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new SpriteExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new CommonInstructionsExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new CommonConversionsExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new VariablesExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new MouseExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new KeyboardExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new JoystickExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new SceneExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new TimeExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new MathematicalToolsExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new CameraExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new AudioExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new FileExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new NetworkExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new WindowExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new StringInstructionsExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new AdvancedExtension())); std::cout.flush();
-    AddExtension(std::shared_ptr<ExtensionBase>(new ExternalLayoutsExtension())); std::cout.flush();
+    AddExtension(std::make_shared<BaseObjectExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<SpriteExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<CommonInstructionsExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<CommonConversionsExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<VariablesExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<MouseExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<KeyboardExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<JoystickExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<SceneExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<TimeExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<MathematicalToolsExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<CameraExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<AudioExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<FileExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<NetworkExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<WindowExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<StringInstructionsExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<AdvancedExtension>()); std::cout.flush();
+    AddExtension(std::make_shared<ExternalLayoutsExtension>()); std::cout.flush();
     std::cout << "done." << std::endl;
 }
 
@@ -142,8 +142,7 @@ std::unique_ptr<RuntimeObject> CppPlatform::CreateRuntimeObject(RuntimeScene & s
     }
 
     //Create a new object with the type we want.
-    RuntimeObject * newObject = runtimeObjCreationFunctionTable[type](scene, object);
-    return std::unique_ptr<RuntimeObject>(newObject);
+    return runtimeObjCreationFunctionTable[type](scene, object);
 }
 
 #if defined(GD_IDE_ONLY)
@@ -155,14 +154,14 @@ gd::String CppPlatform::GetDescription() const
 #if !defined(GD_NO_WX_GUI)
 std::shared_ptr<gd::LayoutEditorPreviewer> CppPlatform::GetLayoutPreviewer(gd::LayoutEditorCanvas & editor) const
 {
-    return std::shared_ptr<gd::LayoutEditorPreviewer>(new CppLayoutPreviewer(editor));
+    return std::make_shared<CppLayoutPreviewer>(editor);
 }
 
 std::vector<std::shared_ptr<gd::ProjectExporter>> CppPlatform::GetProjectExporters() const
 {
     return std::vector<std::shared_ptr<gd::ProjectExporter>>{
-        std::shared_ptr<gd::ProjectExporter>(new Exporter),
-        std::shared_ptr<gd::ProjectExporter>(new AndroidExporter(gd::NativeFileSystem::Get()))
+        std::make_shared<Exporter>(),
+        std::make_shared<AndroidExporter>(gd::NativeFileSystem::Get())
     };
 }
 #endif

--- a/GDCpp/GDCpp/Extensions/CppPlatform.h
+++ b/GDCpp/GDCpp/Extensions/CppPlatform.h
@@ -42,7 +42,7 @@ public:
      * \param scene The scene the object is going to be used on.
      * \param scene The gd::Object the RuntimeObject must be based on.
      */
-    std::shared_ptr<RuntimeObject> CreateRuntimeObject(RuntimeScene & scene, gd::Object & object);
+    std::unique_ptr<RuntimeObject> CreateRuntimeObject(RuntimeScene & scene, gd::Object & object);
 
     /**
      * \brief Our platform need to do a bit of extra work when adding an extension

--- a/GDCpp/GDCpp/Extensions/CppPlatform.h
+++ b/GDCpp/GDCpp/Extensions/CppPlatform.h
@@ -16,8 +16,7 @@ namespace gd { class Object; }
 class RuntimeObject;
 class RuntimeScene;
 
-typedef void (*DestroyRuntimeObjectFunPtr)(RuntimeObject*);
-typedef RuntimeObject * (*CreateRuntimeObjectFunPtr)(RuntimeScene & scene, const gd::Object & object);
+typedef std::unique_ptr<RuntimeObject> (*CreateRuntimeObjectFunPtr)(RuntimeScene & scene, const gd::Object & object);
 
 /**
  * \brief GDevelop C++ Platform

--- a/GDCpp/GDCpp/Extensions/ExtensionBase.h
+++ b/GDCpp/GDCpp/Extensions/ExtensionBase.h
@@ -20,6 +20,7 @@
 #include "GDCore/Extensions/PlatformExtension.h"
 #include "GDCore/Tools/Localization.h"
 #include "GDCore/CommonTools.h"
+
 namespace gd { class Instruction; }
 namespace gd { class Layout; }
 namespace gd { class Object; }
@@ -35,7 +36,7 @@ class EventsCodeGenerator;
 #undef CreateEvent
 
 //Declare typedefs for objects creations/destructions functions
-typedef RuntimeObject * (*CreateRuntimeObjectFunPtr)(RuntimeScene & scene, const gd::Object & object);
+typedef std::unique_ptr<RuntimeObject> (*CreateRuntimeObjectFunPtr)(RuntimeScene & scene, const gd::Object & object);
 
 
 /**

--- a/GDCpp/GDCpp/Extensions/ExtensionBase.inl
+++ b/GDCpp/GDCpp/Extensions/ExtensionBase.inl
@@ -7,6 +7,8 @@
 #ifndef EXTENSIONBASE_INL
 #define EXTENSIONBASE_INL
 
+#include "GDCore/Tools/MakeUnique.h"
+
 template<class T, class U>
 void ExtensionBase::AddRuntimeObject(gd::ObjectMetadata & object, gd::String className)
 {
@@ -14,11 +16,11 @@ void ExtensionBase::AddRuntimeObject(gd::ObjectMetadata & object, gd::String cla
     object.className = className;
 #endif
     runtimeObjectCreationFunctionTable[object.GetName()] =
-        [](RuntimeScene & scene, const gd::Object & object) -> RuntimeObject* {
+        [](RuntimeScene & scene, const gd::Object & object) -> std::unique_ptr<RuntimeObject> {
             try
             {
                 const T& derivedObject = dynamic_cast<const T&>(object);
-                return new U(scene, derivedObject);
+                return gd::make_unique<U>(scene, derivedObject);
             }
             catch(const std::bad_cast &e)
             {
@@ -26,7 +28,7 @@ void ExtensionBase::AddRuntimeObject(gd::ObjectMetadata & object, gd::String cla
                 std::cout << e.what() << std::endl;
             }
 
-            return nullptr;
+            return std::unique_ptr<U>();
         };
 }
 

--- a/GDCpp/GDCpp/IDE/BaseDebugger.h
+++ b/GDCpp/GDCpp/IDE/BaseDebugger.h
@@ -9,6 +9,8 @@
 #define BASEDEBUGGER_H
 #include <SFML/System.hpp>
 
+class RuntimeObject;
+
 /**
  * \brief Internal base class to implement a debugger.
  * Derive from this class and implement
@@ -25,6 +27,11 @@ class GD_API BaseDebugger
          * Called at each frame by RuntimeScene
          */
         void Update();
+
+        virtual void OnRuntimeObjectAdded(RuntimeObject * object) {};
+        virtual void OnRuntimeObjectAboutToBeRemoved(RuntimeObject * object) {};
+
+        virtual void OnRuntimeObjectListFullRefresh() {};
 
     protected:
     private:

--- a/GDCpp/GDCpp/IDE/CodeCompilationHelpers.cpp
+++ b/GDCpp/GDCpp/IDE/CodeCompilationHelpers.cpp
@@ -134,7 +134,7 @@ namespace
             task.compilerCall.outputFile = gd::String(CodeCompiler::Get()->GetOutputDirectory()+"GD"+gd::String::From(&sourceFile)+"RuntimeObjectFile.o");
             task.compilerCall.extraHeaderDirectories.push_back(wxFileName::FileName(game.GetProjectFile()).GetPath());
             task.scene = NULL;
-            task.postWork = std::shared_ptr<CodeCompilerExtraWork>(new SourceFileCodeCompilerPostWork(optionalScene));
+            task.postWork = std::make_shared<SourceFileCodeCompilerPostWork>(optionalScene);
             task.userFriendlyName = "Compilation of file "+task.compilerCall.inputFile;
 
             CodeCompiler::Get()->AddTask(task);
@@ -155,7 +155,7 @@ namespace
 
                     task.compilerCall.inputFile = CodeCompiler::Get()->GetOutputDirectory()+"GD"+gd::String::From(&events)+"RuntimeEventsSource.cpp";
                     task.compilerCall.outputFile = CodeCompiler::Get()->GetOutputDirectory()+"GD"+gd::String::From(&events)+"RuntimeObjectFile.o";
-                    task.preWork = std::shared_ptr<CodeCompilerExtraWork>(new ExternalEventsCodeCompilerRuntimePreWork(&game, &events, resourceWorker));
+                    task.preWork = std::make_shared<ExternalEventsCodeCompilerRuntimePreWork>(&game, &events, resourceWorker);
                     task.userFriendlyName = "Compilation of external events "+events.GetName();
 
                     CodeCompiler::Get()->AddTask(task);
@@ -183,7 +183,7 @@ namespace
         task.compilerCall.eventsGeneratedCode = true;
         task.compilerCall.inputFile = CodeCompiler::Get()->GetOutputDirectory()+"GD"+gd::String::From(&scene)+"ObjectFile.o";
         task.compilerCall.outputFile = CodeCompiler::Get()->GetOutputDirectory()+"GD"+gd::String::From(&scene)+"Code.dll";
-        task.postWork = std::shared_ptr<CodeCompilerExtraWork>(new EventsCodeCompilerLinkingPostWork(&game, &scene));
+        task.postWork = std::make_shared<EventsCodeCompilerLinkingPostWork>(&game, &scene);
         task.scene = &scene;
         task.userFriendlyName = "Linking code for scene "+scene.GetName();
 
@@ -506,8 +506,8 @@ void GD_API CodeCompilationHelpers::CreateSceneEventsCompilationTask(gd::Project
     task.compilerCall.inputFile = gd::String(CodeCompiler::Get()->GetOutputDirectory()+"GD"+gd::String::From(&scene)+"EventsSource.cpp");
     task.compilerCall.outputFile = gd::String(CodeCompiler::Get()->GetOutputDirectory()+"GD"+gd::String::From(&scene)+"ObjectFile.o");
     task.scene = &scene;
-    task.preWork = std::shared_ptr<CodeCompilerExtraWork>(new EventsCodeCompilerPreWork(&game, &scene));
-    task.postWork = std::shared_ptr<CodeCompilerExtraWork>(new EventsCodeCompilerPostWork(&game, &scene));
+    task.preWork = std::make_shared<EventsCodeCompilerPreWork>(&game, &scene);
+    task.postWork = std::make_shared<EventsCodeCompilerPostWork>(&game, &scene);
     task.userFriendlyName = "Compilation of events of scene "+scene.GetName();
 
     CodeCompiler::Get()->AddTask(task);
@@ -527,7 +527,7 @@ void GD_API CodeCompilationHelpers::CreateExternalSourceFileCompilationTask(gd::
     task.compilerCall.extraHeaderDirectories.push_back(wxFileName::FileName(game.GetProjectFile()).GetPath());
 
     task.scene = scene;
-    if ( scene ) task.postWork = std::shared_ptr<CodeCompilerExtraWork>(new SourceFileCodeCompilerPostWork(scene));
+    if ( scene ) task.postWork = std::make_shared<SourceFileCodeCompilerPostWork>(scene);
 
     task.userFriendlyName = "Compilation of file "+file.GetFileName();
 
@@ -543,8 +543,8 @@ void  GD_API CodeCompilationHelpers::CreateExternalEventsCompilationTask(gd::Pro
     task.compilerCall.inputFile = gd::String(CodeCompiler::Get()->GetOutputDirectory()+"GD"+gd::String::From(&events)+"EventsSource.cpp");
     task.compilerCall.outputFile = gd::String(CodeCompiler::Get()->GetOutputDirectory()+"GD"+gd::String::From(&events)+"ObjectFile.o");
 
-    task.preWork = std::shared_ptr<CodeCompilerExtraWork>(new ExternalEventsCodeCompilerPreWork(&game, &events));
-    task.postWork = std::shared_ptr<CodeCompilerExtraWork>(new ExternalEventsCodeCompilerPostWork(&game, &events));
+    task.preWork = std::make_shared<ExternalEventsCodeCompilerPreWork>(&game, &events);
+    task.postWork = std::make_shared<ExternalEventsCodeCompilerPostWork>(&game, &events);
     task.userFriendlyName = "Compilation of external events "+events.GetName();
 
     CodeCompiler::Get()->AddTask(task);

--- a/GDCpp/GDCpp/IDE/Dialogs/CppLayoutPreviewer.cpp
+++ b/GDCpp/GDCpp/IDE/Dialogs/CppLayoutPreviewer.cpp
@@ -274,7 +274,7 @@ void CppLayoutPreviewer::OnPreviewPlayWindowBtClick( wxCommandEvent & event )
 
     //Create now the window if necessary (not done in the constructor because, on linux, the window was not hidden).
     if (!externalPreviewWindow)
-        externalPreviewWindow = std::shared_ptr<RenderDialog>(new RenderDialog(editor.GetParentControl(), this) );
+        externalPreviewWindow = std::make_shared<RenderDialog>(editor.GetParentControl(), this);
 
     externalPreviewWindow->Show(true);
 
@@ -365,7 +365,7 @@ void CppLayoutPreviewer::SetParentAuiManager(wxAuiManager * manager)
         }
         if ( !profiler )
         {
-            profiler = std::shared_ptr<ProfileDlg>(new ProfileDlg(editor.GetParentControl(), *this));
+            profiler = std::make_shared<ProfileDlg>(editor.GetParentControl(), *this);
             editor.GetLayout().SetProfiler(profiler.get());
             if ( !parentAuiManager->GetPane("PROFILER").IsOk() )
                 parentAuiManager->AddPane( profiler.get(), wxAuiPaneInfo().Name( wxT( "PROFILER" ) ).Float().CloseButton( true ).Caption( _( "Profiling" ) ).MaximizeButton( true ).MinimizeButton( false ).CaptionVisible(true).MinSize(50, 50).BestSize(230,100).Show(false) );

--- a/GDCpp/GDCpp/IDE/Dialogs/CppLayoutPreviewer.cpp
+++ b/GDCpp/GDCpp/IDE/Dialogs/CppLayoutPreviewer.cpp
@@ -132,6 +132,7 @@ void CppLayoutPreviewer::StopPreview()
     RuntimeScene newScene(&editor, &previewGame);
     previewScene = newScene;
     if ( debugger ) previewScene.debugger = debugger.get();
+    if ( debugger ) previewScene.objectsInstances.SetDebugger(debugger);
     if ( profiler ) previewScene.SetProfiler(profiler.get());
     if ( profiler ) editor.GetLayout().SetProfiler(profiler.get());
     if ( debugger ) debugger->Pause();
@@ -196,6 +197,7 @@ void CppLayoutPreviewer::RefreshFromLayout()
     playing = false;
 
     if ( debugger ) previewScene.debugger = debugger.get();
+    if ( debugger ) previewScene.objectsInstances.SetDebugger(debugger);
     if ( profiler ) previewScene.SetProfiler(profiler.get());
     if ( profiler ) editor.GetLayout().SetProfiler(profiler.get());
 

--- a/GDCpp/GDCpp/IDE/Dialogs/DebuggerGUI.h
+++ b/GDCpp/GDCpp/IDE/Dialogs/DebuggerGUI.h
@@ -31,6 +31,11 @@ public:
      */
     void Play();
 
+    virtual void OnRuntimeObjectAdded(RuntimeObject * object);
+    virtual void OnRuntimeObjectAboutToBeRemoved(RuntimeObject * object);
+
+    virtual void OnRuntimeObjectListFullRefresh();
+
 protected:
     static const long ID_EXTLIST;
 
@@ -54,12 +59,12 @@ private:
     void OnExtensionListItemActivated(wxListEvent& event);
     void UpdateListCtrlColumnsWidth();
 
-    void RecreateListForObject(const RuntimeObjSPtr & object);
+    void RecreateListForObject(const RuntimeObject * object);
 
     RuntimeScene & scene;
     std::function<void(bool)> playCallback; //Function called to play/pause the scene.
 
-    std::map < std::weak_ptr<RuntimeObject>, std::pair<gd::String, wxTreeItemId>, std::owner_less<std::weak_ptr<RuntimeObject>>> objectsInTree;
+    std::map < RuntimeObject*, std::pair<gd::String, wxTreeItemId>> objectsInTree;
     //(Use std::owner_less to allow comparison between weak_ptr)
     std::map < gd::String, wxTreeItemId > initialObjects;
     bool mustRecreateTree;

--- a/GDCpp/GDCpp/IDE/FullProjectCompiler.cpp
+++ b/GDCpp/GDCpp/IDE/FullProjectCompiler.cpp
@@ -207,7 +207,7 @@ void FullProjectCompiler::LaunchProjectCompilation()
         task.compilerCall.inputFile = gd::String(CodeCompiler::Get()->GetOutputDirectory()+"GD"+gd::String::From(&game.GetLayout(i))+"RuntimeEventsSource.cpp");
         task.compilerCall.outputFile = gd::String(CodeCompiler::Get()->GetOutputDirectory()+"GD"+gd::String::From(&game.GetLayout(i))+"RuntimeObjectFile.o");
         task.userFriendlyName = "Compilation of events of scene "+game.GetLayout(i).GetName();
-        task.preWork = std::shared_ptr<CodeCompilerExtraWork>(new EventsCodeCompilerRuntimePreWork(&game, &game.GetLayout(i), resourcesMergingHelper));
+        task.preWork = std::make_shared<EventsCodeCompilerRuntimePreWork>(&game, &game.GetLayout(i), resourcesMergingHelper);
         task.scene = &game.GetLayout(i);
 
         CodeCompiler::Get()->AddTask(task);

--- a/GDCpp/GDCpp/Runtime/RuntimeObject.cpp
+++ b/GDCpp/GDCpp/Runtime/RuntimeObject.cpp
@@ -187,12 +187,10 @@ void RuntimeObject::AddForceToMoveAround( float positionX, float positionY, floa
 
 void RuntimeObject::Duplicate(RuntimeScene & scene, std::map <gd::String, std::vector<RuntimeObject*> *> pickedObjectLists)
 {
-    std::shared_ptr<RuntimeObject> newObject = std::shared_ptr<RuntimeObject>(Clone());
+    RuntimeObject * newObject = scene.objectsInstances.AddObject( std::unique_ptr<RuntimeObject>( Clone() ) );
 
-    scene.objectsInstances.AddObject(newObject);
-
-    if ( pickedObjectLists[name] != NULL && find(pickedObjectLists[name]->begin(), pickedObjectLists[name]->end(), newObject.get()) == pickedObjectLists[name]->end() )
-        pickedObjectLists[name]->push_back( newObject.get() );
+    if ( pickedObjectLists[name] != NULL && find(pickedObjectLists[name]->begin(), pickedObjectLists[name]->end(), newObject) == pickedObjectLists[name]->end() )
+        pickedObjectLists[name]->push_back( newObject );
 }
 
 bool RuntimeObject::IsStopped()

--- a/GDCpp/GDCpp/Runtime/RuntimeObject.h
+++ b/GDCpp/GDCpp/Runtime/RuntimeObject.h
@@ -42,6 +42,9 @@ class RuntimeScene;
 class GD_API RuntimeObject
 {
 public:
+    using Ref = RuntimeObject*;
+    using OwningPtr = RuntimeObject*;
+
     /**
      * \brief Construct a RuntimeObject from an object.
      *

--- a/GDCpp/GDCpp/Runtime/RuntimeObject.h
+++ b/GDCpp/GDCpp/Runtime/RuntimeObject.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "GDCore/Tools/MakeUnique.h"
 #include "GDCpp/Runtime/RuntimeVariablesContainer.h"
 #include "GDCpp/Runtime/Force.h"
 #include "GDCpp/Runtime/String.h"
@@ -84,7 +85,7 @@ public:
      * return new MyRuntimeObject(*this);
      * \endcode
      */
-    virtual RuntimeObject * Clone() const { return new RuntimeObject(*this);}
+    virtual std::unique_ptr<RuntimeObject> Clone() const { return gd::make_unique<RuntimeObject>(*this);}
 
     /**
      * \brief Called by RuntimeScene when creating the RuntimeObject from an initial instance.

--- a/GDCpp/GDCpp/Runtime/RuntimeObjectHelpers.h
+++ b/GDCpp/GDCpp/Runtime/RuntimeObjectHelpers.h
@@ -17,21 +17,20 @@
 /**
  * An object list is a vector containing (smart) pointers to objects.
  */
-typedef std::vector < std::shared_ptr<RuntimeObject> > RuntimeObjList;
+using RuntimeObjList = std::vector<std::unique_ptr<RuntimeObject>>;
 
 /**
  * Objects are usually managed thanks to (smart) pointers.
  */
-typedef std::shared_ptr<RuntimeObject> RuntimeObjSPtr;
+using RuntimeObjSPtr = std::unique_ptr<RuntimeObject>;
 
 /**
  * \brief Functor testing object name
  *
  * \see Object
  */
-struct ObjectHasName : public std::binary_function<std::shared_ptr<gd::Object>, gd::String, bool> {
-    bool operator()(const std::shared_ptr<gd::Object> & object, const gd::String & name) const { return object->GetName() == name; }
+struct ObjectHasName : public std::binary_function<std::unique_ptr<gd::Object>, gd::String, bool> {
+    bool operator()(const std::unique_ptr<gd::Object> & object, const gd::String & name) const { return object->GetName() == name; }
 };
 
 #endif // OBJECTHELPERS_H
-

--- a/GDCpp/GDCpp/Runtime/RuntimeObjectsListsTools.h
+++ b/GDCpp/GDCpp/Runtime/RuntimeObjectsListsTools.h
@@ -166,7 +166,7 @@ bool TwoObjectListsTest(RuntimeObjectsLists objectsLists1,
                 for(std::size_t l = 0;l<arr2.size();++l) {
                     if ( pickedList1[i][k] && pickedList2[j][l]) continue; //Avoid unnecessary costly call to functor.
 
-                    if ( arr1[k] != arr2[l] && predicate(arr1[k], arr2[l]) ) {
+                    if ( std::addressof(arr1[k]) != std::addressof(arr2[l]) && predicate(arr1[k], arr2[l]) ) {
                         if ( !negatePredicate ) {
                             isTrue = true;
 

--- a/GDCpp/GDCpp/Runtime/RuntimeScene.h
+++ b/GDCpp/GDCpp/Runtime/RuntimeScene.h
@@ -198,7 +198,7 @@ protected:
     /**
      * \brief Order an object list according to object's Z coordinate.
      */
-    bool OrderObjectsByZOrder( RuntimeObjList & objList );
+    bool OrderObjectsByZOrder( RuntimeObjNonOwningPtrList & objList );
 
     /**
      * \brief Render a frame in the window

--- a/GDCpp/GDCpp/Runtime/RuntimeSpriteObject.h
+++ b/GDCpp/GDCpp/Runtime/RuntimeSpriteObject.h
@@ -53,7 +53,7 @@ public:
 
     RuntimeSpriteObject(RuntimeScene & scene, const gd::SpriteObject & spriteObject);
     virtual ~RuntimeSpriteObject();
-    virtual RuntimeObject * Clone() const { return new RuntimeSpriteObject(*this);}
+    virtual std::unique_ptr<RuntimeObject> Clone() const { return gd::make_unique<RuntimeSpriteObject>(*this);}
 
     virtual bool ExtraInitializationFromInitialInstance(const gd::InitialInstance & position);
 

--- a/GDCpp/GDCpp/Runtime/SceneStack.h
+++ b/GDCpp/GDCpp/Runtime/SceneStack.h
@@ -43,26 +43,26 @@ public:
 	/**
 	 * \brief Stop and remove the current scene from the stack, unless there is
 	 * only one or zero scene in the stack.
-	 * \return A shared pointer to the scene removed, or a null pointer if nothing was removed.
+	 * \return A pointer to the scene removed, or a null pointer if nothing was removed.
 	 */
-	std::shared_ptr<RuntimeScene> Pop();
+	std::unique_ptr<RuntimeScene> Pop();
 
 	/**
 	 * \brief Load a new scene on the top of the stack. This scene becomes the current
 	 * scene and is the one played when you call Step.
 	 * \param newSceneName The name of the scene to launch, as found in the RuntimeGame.
-	 * \return A shared pointer to the scene added (or null pointer if loading failed).
+	 * \return A non owning pointer to the RuntimeScene added or nullptr if loading failed.
 	 */
-	std::shared_ptr<RuntimeScene> Push(gd::String newSceneName);
+	RuntimeScene * Push(gd::String newSceneName);
 
 	/**
 	 * \brief Replace the current scene by a new one. This new scene becomes the current
 	 * scene and is the one played when you call Step.
 	 * \param newSceneName The name of the scene to launch, as found in the RuntimeGame.
 	 * \param clear If set to true, all other scenes will be removed from stack.
-	 * \return A shared pointer to the scene added (or null pointer if loading failed).
+	 * \return A non owning pointer to the RuntimeScene added or nullptr if loading failed.
 	 */
-	std::shared_ptr<RuntimeScene> Replace(gd::String newSceneName, bool clear = false);
+	RuntimeScene * Replace(gd::String newSceneName, bool clear = false);
 
 	/**
 	 * \brief Set the callback called when an error occurs (loading failed...)
@@ -72,12 +72,12 @@ public:
 	/**
 	 * \brief Set a custom function to call when a scene is pushed on the stack.
 	 */
-	void OnLoadScene(std::function<bool(std::shared_ptr<RuntimeScene>)> cb) { loadCallback = cb; }
+	void OnLoadScene(std::function<bool(RuntimeScene &)> cb) { loadCallback = cb; }
 
 private:
 	RuntimeGame & game;
 	sf::RenderWindow * window;
-	std::vector<std::shared_ptr<RuntimeScene>> stack;
+	std::vector<std::unique_ptr<RuntimeScene>> stack;
 	std::function<void(gd::String)> errorCallback;
-	std::function<bool(std::shared_ptr<RuntimeScene>)> loadCallback;
+	std::function<bool(RuntimeScene &)> loadCallback;
 };

--- a/GDCpp/GDCpp/Runtime/SoundManager.cpp
+++ b/GDCpp/GDCpp/Runtime/SoundManager.cpp
@@ -29,7 +29,7 @@ const gd::String & SoundManager::GetFileFromSoundName(const gd::String & name) c
 
 void SoundManager::PlaySoundOnChannel(const gd::String & name, unsigned int channel, bool repeat, float volume, float pitch)
 {
-    std::shared_ptr<Sound> sound = std::shared_ptr<Sound>(new Sound(GetFileFromSoundName(name)));
+    std::shared_ptr<Sound> sound = std::make_shared<Sound>(GetFileFromSoundName(name));
     sound->sound.play();
 
     SetSoundOnChannel(channel, sound);

--- a/GDCpp/GDCpp/Runtime/XmlFilesHelper.h
+++ b/GDCpp/GDCpp/Runtime/XmlFilesHelper.h
@@ -71,7 +71,7 @@ class XmlFilesManager
     static void LoadFile(gd::String filename)
     {
         if ( openedFiles.find(filename) == openedFiles.end() )
-            openedFiles[filename] = std::shared_ptr<XmlFile>(new XmlFile(filename));
+            openedFiles[filename] = std::make_shared<XmlFile>(filename);
     }
 
     /**
@@ -89,7 +89,7 @@ class XmlFilesManager
      */
     static std::shared_ptr<XmlFile> GetFile(gd::String filename, bool isGoingToModifyFile = true)
     {
-        std::shared_ptr<XmlFile> file = openedFiles.find(filename) != openedFiles.end() ? openedFiles[filename] : std::shared_ptr<XmlFile>(new XmlFile(filename));
+        std::shared_ptr<XmlFile> file = openedFiles.find(filename) != openedFiles.end() ? openedFiles[filename] : std::make_shared<XmlFile>(filename);
         if ( isGoingToModifyFile ) file->MarkAsModified();
 
         return file;

--- a/GDCpp/Runtime/main.cpp
+++ b/GDCpp/Runtime/main.cpp
@@ -188,10 +188,10 @@ int main( int argc, char *p_argv[] )
         DisplayMessage(error);
         abort = true;
     });
-    sceneStack.OnLoadScene([&codeLibraryName](std::shared_ptr<RuntimeScene> scene) {
+    sceneStack.OnLoadScene([&codeLibraryName](RuntimeScene & scene) {
         if (!codeLibraryName.empty() &&
-            !scene->GetCodeExecutionEngine()->LoadFromDynamicLibrary(codeLibraryName,
-            "GDSceneEvents"+gd::SceneNameMangler::GetMangledSceneName(scene->GetName())))
+            !scene.GetCodeExecutionEngine()->LoadFromDynamicLibrary(codeLibraryName,
+            "GDSceneEvents"+gd::SceneNameMangler::GetMangledSceneName(scene.GetName())))
         {
             return false;
         }

--- a/GDCpp/tests/ObjInstancesHolder.cpp
+++ b/GDCpp/tests/ObjInstancesHolder.cpp
@@ -24,22 +24,22 @@ TEST_CASE( "ObjInstancesHolder", "[common]" ) {
 		RuntimeGame game;
 		RuntimeScene scene(NULL, &game);
 
-		std::shared_ptr<RuntimeObject> obj1A(new RuntimeObject(scene, obj1));
-		std::shared_ptr<RuntimeObject> obj1B(new RuntimeObject(scene, obj1));
-		std::shared_ptr<RuntimeObject> obj1C(new RuntimeObject(scene, obj1));
+		std::unique_ptr<RuntimeObject> obj1A(new RuntimeObject(scene, obj1));
+		std::unique_ptr<RuntimeObject> obj1B(new RuntimeObject(scene, obj1));
+		std::unique_ptr<RuntimeObject> obj1C(new RuntimeObject(scene, obj1));
 
-		std::shared_ptr<RuntimeObject> obj2A(new RuntimeObject(scene, obj2));
-		std::shared_ptr<RuntimeObject> obj2B(new RuntimeObject(scene, obj2));
-		std::shared_ptr<RuntimeObject> obj2C(new RuntimeObject(scene, obj2));
+		std::unique_ptr<RuntimeObject> obj2A(new RuntimeObject(scene, obj2));
+		std::unique_ptr<RuntimeObject> obj2B(new RuntimeObject(scene, obj2));
+		std::unique_ptr<RuntimeObject> obj2C(new RuntimeObject(scene, obj2));
 
 		//Adding objects
 		ObjInstancesHolder container;
-		container.AddObject(obj1A);
-		container.AddObject(obj1B);
-		container.AddObject(obj1C);
-		container.AddObject(obj2A);
-		container.AddObject(obj2B);
-		container.AddObject(obj2C);
+		container.AddObject(std::move(obj1A));
+		container.AddObject(std::move(obj1B));
+		container.AddObject(std::move(obj1C));
+		RuntimeObject * obj2APtr = container.AddObject(std::move(obj2A));
+		container.AddObject(std::move(obj2B));
+		container.AddObject(std::move(obj2C));
 
 		REQUIRE(container.GetAllObjects().size() == 6);
 		REQUIRE(container.GetObjects("1").size() == 3);
@@ -49,7 +49,7 @@ TEST_CASE( "ObjInstancesHolder", "[common]" ) {
 		ObjInstancesHolder copy = container;
 
 		//Removing objects
-		container.RemoveObject(obj2A);
+		container.RemoveObject(obj2APtr);
 		REQUIRE(container.GetObjects("2").size() == 2);
 
 		container.RemoveObjects("2");

--- a/GDCpp/tests/SceneStack.cpp
+++ b/GDCpp/tests/SceneStack.cpp
@@ -23,11 +23,11 @@ TEST_CASE( "SceneStack", "[game-engine]" ) {
 	SceneStack stack(game,  NULL);
 
 	SECTION("Pop on an empty stack") {
-		REQUIRE(stack.Pop() == std::shared_ptr<RuntimeScene>());
+		REQUIRE(stack.Pop() == nullptr);
 	}
 
 	SECTION("Push a not existing scene") {
-		REQUIRE(stack.Push("test") == std::shared_ptr<RuntimeScene>());
+		REQUIRE(stack.Push("test") == nullptr);
 	}
 
 	SECTION("Push, Pop, Replace") {
@@ -36,11 +36,11 @@ TEST_CASE( "SceneStack", "[game-engine]" ) {
 		auto scene3 = stack.Push("Scene 1");
 		auto scene4 = stack.Replace("Scene 2");
 
-		REQUIRE(stack.Pop() == scene4);
-		REQUIRE(stack.Pop() == scene2);
+		REQUIRE(stack.Pop().get() == scene4);
+		REQUIRE(stack.Pop().get() == scene2);
 
 		auto scene5 = stack.Replace("Scene 1", true);
-		REQUIRE(stack.Pop() == std::shared_ptr<RuntimeScene>());
+		REQUIRE(stack.Pop() == nullptr);
 	}
 
 	SECTION("Step") {
@@ -49,14 +49,14 @@ TEST_CASE( "SceneStack", "[game-engine]" ) {
 	}
 
 	SECTION("OnLoadScene") {
-		stack.OnLoadScene([](std::shared_ptr<RuntimeScene> scene) {
-			REQUIRE(scene->GetName() == "Scene 2");
+		stack.OnLoadScene([](RuntimeScene & scene) {
+			REQUIRE(scene.GetName() == "Scene 2");
 			return true;
 		});
 		stack.Push("Scene 2");
 
-		stack.OnLoadScene([](std::shared_ptr<RuntimeScene> scene) {
-			REQUIRE(scene->GetName() == "Scene 1");
+		stack.OnLoadScene([](RuntimeScene & scene) {
+			REQUIRE(scene.GetName() == "Scene 1");
 			return true;
 		});
 		stack.Replace("Scene 1", true);

--- a/IDE/Dialogs/ExternalLayoutEditor.cpp
+++ b/IDE/Dialogs/ExternalLayoutEditor.cpp
@@ -234,10 +234,10 @@ void ExternalLayoutEditor::SetupForScene(gd::Layout & layout)
         layoutEditorCanvas->SetScrollbars(scrollBar1, scrollBar2);
 
         //Creating external editors and linking them to the layout canvas
-        objectsEditor = std::shared_ptr<gd::ObjectsEditor>(new gd::ObjectsEditor(this, project, layout, mainFrameWrapper));
-        layersEditor = std::shared_ptr<LayersEditorPanel>(new LayersEditorPanel(this, project, layout, mainFrameWrapper) );
-        propertiesPnl = std::shared_ptr<LayoutEditorPropertiesPnl>(new LayoutEditorPropertiesPnl(this, project, layout, layoutEditorCanvas, mainFrameWrapper) );
-        initialInstancesBrowser = std::shared_ptr<InitialPositionBrowserDlg>(new InitialPositionBrowserDlg(this, instanceContainer, *layoutEditorCanvas) );
+        objectsEditor = std::make_shared<gd::ObjectsEditor>(this, project, layout, mainFrameWrapper);
+        layersEditor = std::make_shared<LayersEditorPanel>(this, project, layout, mainFrameWrapper);
+        propertiesPnl = std::make_shared<LayoutEditorPropertiesPnl>(this, project, layout, layoutEditorCanvas, mainFrameWrapper);
+        initialInstancesBrowser = std::make_shared<InitialPositionBrowserDlg>(this, instanceContainer, *layoutEditorCanvas);
 
         layoutEditorCanvas->AddAssociatedEditor(objectsEditor.get());
         layoutEditorCanvas->AddAssociatedEditor(layersEditor.get());

--- a/IDE/Dialogs/ObjectsEditor.cpp
+++ b/IDE/Dialogs/ObjectsEditor.cpp
@@ -1202,7 +1202,7 @@ void ObjectsEditor::OnCopySelected(wxCommandEvent& event)
         if ( !objects.HasObjectNamed(name) )
             return;
 
-        gd::Clipboard::Get()->SetObject(&objects.GetObject(name));
+        gd::Clipboard::Get()->SetObject(objects.GetObject(name));
         gd::Clipboard::Get()->ForgetObjectGroup();
     }
     else if ( data->GetString() == "GlobalGroup" || data->GetString() == "LayoutGroup" )
@@ -1234,7 +1234,7 @@ void ObjectsEditor::OnCutSelected(wxCommandEvent& event)
         if ( !objects.HasObjectNamed(name) )
             return;
 
-        gd::Clipboard::Get()->SetObject(&objects.GetObject(name));
+        gd::Clipboard::Get()->SetObject(objects.GetObject(name));
         gd::Clipboard::Get()->ForgetObjectGroup();
 
         objects.RemoveObject(name);
@@ -1278,7 +1278,7 @@ void ObjectsEditor::OnPasteSelected(wxCommandEvent& event)
         gd::ClassWithObjects & objects = !globalObject ? static_cast<gd::ClassWithObjects&>(layout) : project;
 
         //Add a new object of selected type to objects list
-        gd::Object * object = clipboard->GetObject()->Clone();
+        std::unique_ptr<gd::Object> object = clipboard->GetObject();
         object->SetName(gd::NewNameGenerator::Generate(object->GetName(), _("CopyOf"), [&nameChecker, globalObject](const gd::String & name) {
             return nameChecker.HasObjectOrGroupNamed(
                 name, globalObject /* Only search other layouts if it's a global object */) != gd::ObjectOrGroupFinder::No;

--- a/IDE/EditorScene.cpp
+++ b/IDE/EditorScene.cpp
@@ -112,10 +112,10 @@ mainFrameWrapper(mainFrameWrapper_)
     layoutEditorCanvas->SetScrollbars(hScrollbar, vScrollbar);
 
     //Create all editors linked to scene canvas.
-    objectsEditor = std::shared_ptr<gd::ObjectsEditor>(new gd::ObjectsEditor(this, project, layout, mainFrameWrapper) );
+    objectsEditor = std::make_shared<gd::ObjectsEditor>(this, project, layout, mainFrameWrapper);
     layersEditor =  std::shared_ptr<LayersEditorPanel>(new LayersEditorPanel(this, project, layout, mainFrameWrapper) );
-    initialInstancesBrowser = std::shared_ptr<InitialPositionBrowserDlg>(new InitialPositionBrowserDlg(this, layout.GetInitialInstances(), *layoutEditorCanvas) );
-    propertiesPnl = std::shared_ptr<LayoutEditorPropertiesPnl>(new LayoutEditorPropertiesPnl(this, project, layout, layoutEditorCanvas, mainFrameWrapper));
+    initialInstancesBrowser = std::make_shared<InitialPositionBrowserDlg>(this, layout.GetInitialInstances(), *layoutEditorCanvas);
+    propertiesPnl = std::make_shared<LayoutEditorPropertiesPnl>(this, project, layout, layoutEditorCanvas, mainFrameWrapper);
 
     //Link some editors together
     layoutEditorCanvas->AddAssociatedEditor(objectsEditor.get());


### PR DESCRIPTION
**Needs heavy testing** as the debugger has been reworked not to use weak_ptr anymore (the debugger is now notified through ObjInstanceHolder when an instance is created or removed).
