### PR TITLE
Time scale for layers

### DIFF
--- a/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
@@ -288,69 +288,97 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(gd::Pla
         .AddParameter("expression", _("New value"))
         .MarkAsAdvanced();
 
-    extension.AddExpression("CameraWidth", _("Width of a camera of a layer"), _("Width of a camera of a layer"), _("Camera"), "res/actions/camera.png")
+    extension.AddCondition("LayerTimeScale",
+                   _("Layer time scale"),
+                   _("Compare the time scale applied on the objects of the layer."),
+                   _("The time scale of layer _PARAM1_ is _PARAM2__PARAM3_"),
+                   _("Layers and cameras/Time"),
+                   "res/conditions/time24.png",
+                   "res/conditions/time.png")
+        .AddCodeOnlyParameter("currentScene", "")
+        .AddParameter("layer", _("Layer (base layer if empty)"), "",true).SetDefaultValue("\"\"")
+        .AddParameter("relationalOperator", _("Sign of the test"))
+        .AddParameter("expression", _("Value to test"))
+        .MarkAsAdvanced()
+        .SetManipulatedType("number");
+
+    extension.AddAction("ChangeLayerTimeScale",
+                   _("Change layer time scale"),
+                   _("Change the time scale applied on the objects of the layer."),
+                   _("Set time scale of layer _PARAM1_ to _PARAM2_"),
+                   _("Layers and cameras/Time"),
+                   "res/actions/time24.png",
+                   "res/actions/time.png")
+        .AddCodeOnlyParameter("currentScene", "")
+        .AddParameter("layer", _("Layer (base layer if empty)"), "",true).SetDefaultValue("\"\"")
+        .AddParameter("expression", _("Scale (1: Default, 2: 2x faster, 0.5: 2x slower...)"));
+
+    extension.AddExpression("CameraWidth", _("Width of a camera of a layer"), _("Width of a camera of a layer"), _("Layers and cameras"), "res/actions/camera.png")
         .AddCodeOnlyParameter("currentScene", "")
         .AddParameter("layer", _("Layer"))
         .AddParameter("expression", _("Camera number (default : 0)")).SetDefaultValue("0");
 
-    extension.AddExpression("CameraHeight", _("Height of a camera of a layer"), _("Height of a camera of a layer"), _("Camera"), "res/actions/camera.png")
+    extension.AddExpression("CameraHeight", _("Height of a camera of a layer"), _("Height of a camera of a layer"), _("Layers and cameras"), "res/actions/camera.png")
         .AddCodeOnlyParameter("currentScene", "")
         .AddParameter("layer", _("Layer"))
         .AddParameter("expression", _("Camera number (default : 0)")).SetDefaultValue("0");
 
-    extension.AddExpression("CameraViewportLeft", _("X position of the top left side point of a render zone"), _("X position of the top left side point of a render zone"), _("Camera"), "res/actions/camera.png")
+    extension.AddExpression("CameraViewportLeft", _("X position of the top left side point of a render zone"), _("X position of the top left side point of a render zone"), _("Layers and cameras"), "res/actions/camera.png")
         .AddCodeOnlyParameter("currentScene", "")
         .AddParameter("layer", _("Layer"))
         .AddParameter("expression", _("Camera number (default : 0)")).SetDefaultValue("0");
 
-    extension.AddExpression("CameraViewportTop", _("Y position of the top left side point of a render zone"), _("Y position of the top left side point of a render zone"), _("Camera"), "res/actions/camera.png")
+    extension.AddExpression("CameraViewportTop", _("Y position of the top left side point of a render zone"), _("Y position of the top left side point of a render zone"), _("Layers and cameras"), "res/actions/camera.png")
         .AddCodeOnlyParameter("currentScene", "")
         .AddParameter("layer", _("Layer"))
         .AddParameter("expression", _("Camera number (default : 0)")).SetDefaultValue("0");
 
-    extension.AddExpression("CameraViewportRight", _("X position of the bottom right side point of a render zone"), _("X position of the bottom right side point of a render zone"), _("Camera"), "res/actions/camera.png")
+    extension.AddExpression("CameraViewportRight", _("X position of the bottom right side point of a render zone"), _("X position of the bottom right side point of a render zone"), _("Layers and cameras"), "res/actions/camera.png")
         .AddCodeOnlyParameter("currentScene", "")
         .AddParameter("layer", _("Layer"))
         .AddParameter("expression", _("Camera number (default : 0)")).SetDefaultValue("0");
 
-    extension.AddExpression("CameraViewportBottom", _("Y position of the bottom right side point of a render zone"), _("Y position of the bottom right side point of a render zone"), _("Camera"), "res/actions/camera.png")
+    extension.AddExpression("CameraViewportBottom", _("Y position of the bottom right side point of a render zone"), _("Y position of the bottom right side point of a render zone"), _("Layers and cameras"), "res/actions/camera.png")
         .AddCodeOnlyParameter("currentScene", "")
         .AddParameter("layer", _("Layer"))
         .AddParameter("expression", _("Camera number (default : 0)")).SetDefaultValue("0");
 
-    extension.AddExpression("CameraX", _("Camera X position"), _("Camera X position"), _("Camera"), "res/actions/camera.png")
+    extension.AddExpression("CameraX", _("Camera X position"), _("Camera X position"), _("Layers and cameras"), "res/actions/camera.png")
         .AddCodeOnlyParameter("currentScene", "")
         .AddParameter("layer", _("Layer"), "",true).SetDefaultValue("\"\"")
         .AddParameter("expression", _("Camera number (default : 0)"), "",true).SetDefaultValue("0");
 
-    extension.AddExpression("VueX", _("Camera X position"), _("Camera X position"), _("Camera"), "res/actions/camera.png")
+    extension.AddExpression("VueX", _("Camera X position"), _("Camera X position"), _("Layers and cameras"), "res/actions/camera.png")
         .SetHidden()
         .AddCodeOnlyParameter("currentScene", "")
         .AddParameter("layer", _("Layer"), "",true).SetDefaultValue("\"\"")
         .AddParameter("expression", _("Camera number (default : 0)"), "",true).SetDefaultValue("0");
 
-    extension.AddExpression("CameraY", _("Camera Y position"), _("Camera Y position"), _("Camera"), "res/actions/camera.png")
+    extension.AddExpression("CameraY", _("Camera Y position"), _("Camera Y position"), _("Layers and cameras"), "res/actions/camera.png")
         .AddCodeOnlyParameter("currentScene", "")
         .AddParameter("layer", _("Layer"), "",true).SetDefaultValue("\"\"")
         .AddParameter("expression", _("Camera number (default : 0)"), "",true).SetDefaultValue("0");
 
-    extension.AddExpression("VueY", _("Camera Y position"), _("Camera Y position"), _("Camera"), "res/actions/camera.png")
+    extension.AddExpression("VueY", _("Camera Y position"), _("Camera Y position"), _("Layers and cameras"), "res/actions/camera.png")
         .SetHidden()
         .AddCodeOnlyParameter("currentScene", "")
         .AddParameter("layer", _("Layer"), "",true).SetDefaultValue("\"\"")
         .AddParameter("expression", _("Camera number (default : 0)"), "",true).SetDefaultValue("0");
 
-    extension.AddExpression("CameraRotation", _("Angle of a camera of a layer"), _("Angle of a camera of a layer"), _("Camera"), "res/actions/camera.png")
+    extension.AddExpression("CameraRotation", _("Angle of a camera of a layer"), _("Angle of a camera of a layer"), _("Layers and cameras"), "res/actions/camera.png")
         .AddCodeOnlyParameter("currentScene", "")
         .AddParameter("layer", _("Layer"), "",true).SetDefaultValue("\"\"")
         .AddParameter("expression", _("Camera number (default : 0)"), "",true).SetDefaultValue("0");
 
-    extension.AddExpression("VueRotation", _("Angle of a camera of a layer"), _("Angle of a camera of a layer"), _("Camera"), "res/actions/camera.png")
+    extension.AddExpression("VueRotation", _("Angle of a camera of a layer"), _("Angle of a camera of a layer"), _("Layers and cameras"), "res/actions/camera.png")
         .SetHidden()
         .AddCodeOnlyParameter("currentScene", "")
         .AddParameter("layer", _("Layer"), "",true).SetDefaultValue("\"\"")
         .AddParameter("expression", _("Camera number (default : 0)"), "",true).SetDefaultValue("0");
 
+    extension.AddExpression("LayerTimeScale", _("Time scale"), _("Time scale"), _("Layers and cameras"), "res/actions/time.png")
+        .AddCodeOnlyParameter("currentScene", "")
+        .AddParameter("layer", _("Layer"));
     #endif
 }
 

--- a/Core/GDCore/Extensions/Builtin/TimeExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/TimeExtension.cpp
@@ -106,7 +106,7 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsTimeExtension(gd::Platf
                    "res/actions/time24.png",
                    "res/actions/time.png")
         .AddCodeOnlyParameter("currentScene", "")
-        .AddParameter("expression", _("Scale (1 : Default, 2 : Faster, 0.5 : Slower...)"));
+        .AddParameter("expression", _("Scale (1: Default, 2: 2x faster, 0.5: 2x slower...)"));
 
     extension.AddExpression("TimeDelta", _("Time elapsed since the last image"), _("Time elapsed since the last image"), _("Time"), "res/actions/time.png")
         .AddCodeOnlyParameter("currentScene", "");

--- a/Extensions/PanelSpriteObject/panelspriteruntimeobject.js
+++ b/Extensions/PanelSpriteObject/panelspriteruntimeobject.js
@@ -45,7 +45,7 @@ gdjs.PanelSpriteRuntimeObject.prototype.onDeletedFromScene = function(runtimeSce
     }
 };
 
-gdjs.PanelSpriteRuntimeObject.prototype.updateTime = function() {
+gdjs.PanelSpriteRuntimeObject.prototype.update = function() {
     this._renderer.ensureUpToDate();
 }
 

--- a/Extensions/ParticleSystem/ParticleEmitterObject.cpp
+++ b/Extensions/ParticleSystem/ParticleEmitterObject.cpp
@@ -483,17 +483,14 @@ void ParticleEmitterBase::UpdateLifeTime()
     particleSystem->particleModel->setLifeTime(particleLifeTimeMin,particleLifeTimeMax);
 }
 
-RuntimeParticleEmitterObject::RuntimeParticleEmitterObject(RuntimeScene & scene_, const ParticleEmitterObject & particleEmitterObject):
-    RuntimeObject(scene_, particleEmitterObject),
+RuntimeParticleEmitterObject::RuntimeParticleEmitterObject(RuntimeScene & scene, const ParticleEmitterObject & particleEmitterObject):
+    RuntimeObject(scene, particleEmitterObject),
     hasSomeParticles(true)
 {
     ParticleEmitterBase::operator=(particleEmitterObject);
 
-    //Store a pointer to the scene
-    scene = &scene_;
-
 	CreateParticleSystem();
-    SetTexture(scene_, GetParticleTexture());
+    SetTexture(scene, GetParticleTexture());
 
     OnPositionChanged();
 }
@@ -683,13 +680,14 @@ void ParticleEmitterBase::SetZoneRadius(float newValue)
     if ( particleSystem && particleSystem->zone ) particleSystem->zone->setRadius(zoneRadius);
 }
 
-void RuntimeParticleEmitterObject::UpdateTime(float deltaTime)
+void RuntimeParticleEmitterObject::Update(const RuntimeScene & scene)
 {
+    double elapsedTimeInSeconds = static_cast<double>(GetElapsedTime(scene))/1000000.0;
     if ( GetParticleSystem() )
-        hasSomeParticles = GetParticleSystem()->particleSystem->update(deltaTime);
+        hasSomeParticles = GetParticleSystem()->particleSystem->update(elapsedTimeInSeconds);
 
 	if (GetDestroyWhenNoParticles() && !hasSomeParticles)
-        DeleteFromScene(const_cast<RuntimeScene&>(*scene)); //Ugly const cast
+        DeleteFromScene(const_cast<RuntimeScene&>(scene)); //Ugly const cast
 }
 
 void ParticleEmitterBase::SetParticleGravityAngle( float newAngleInDegree )

--- a/Extensions/ParticleSystem/ParticleEmitterObject.h
+++ b/Extensions/ParticleSystem/ParticleEmitterObject.h
@@ -259,7 +259,7 @@ public :
     virtual float GetWidth() const {return 32;};
     virtual float GetHeight() const {return 32;};
 
-    virtual void UpdateTime(float timeElapsed);
+    virtual void Update(const RuntimeScene & scene);
 
     bool NoMoreParticles() const {return !hasSomeParticles;};
 
@@ -281,7 +281,6 @@ public :
 private:
 
     bool hasSomeParticles;
-    const RuntimeScene * scene; ///< Pointer to the scene. Initialized during LoadRuntimeResources call.
 };
 
 #endif // PARTICLEEMITTEROBJECT_H

--- a/Extensions/PathBehavior/PathBehavior.cpp
+++ b/Extensions/PathBehavior/PathBehavior.cpp
@@ -120,7 +120,7 @@ void PathBehavior::DoStepPreEvents(RuntimeScene & scene)
     }
 
     //  add to the current time along the path
-    timeOnSegment += static_cast<double>(scene.GetTimeManager().GetElapsedTime())
+    timeOnSegment += static_cast<double>(object->GetElapsedTime(scene))
         / 1000000.0 * speed;
 
     //  if I reached the end of this segment, move to a new segment

--- a/Extensions/PathfindingBehavior/PathfindingBehavior.cpp
+++ b/Extensions/PathfindingBehavior/PathfindingBehavior.cpp
@@ -458,7 +458,7 @@ void PathfindingBehavior::DoStepPreEvents(RuntimeScene & scene)
     if (path.empty() || reachedEnd) return;
 
     //Update the speed of the object
-    float timeDelta = static_cast<double>(scene.GetTimeManager().GetElapsedTime()) / 1000000.0;
+    float timeDelta = static_cast<double>(object->GetElapsedTime(scene)) / 1000000.0;
     speed += acceleration*timeDelta;
     if ( speed > maxSpeed ) speed = maxSpeed;
     angularSpeed = angularMaxSpeed; //No acceleration for angular speed for now

--- a/Extensions/PathfindingBehavior/pathfindingruntimebehavior.js
+++ b/Extensions/PathfindingBehavior/pathfindingruntimebehavior.js
@@ -271,7 +271,7 @@ gdjs.PathfindingRuntimeBehavior.prototype.doStepPreEvents = function(runtimeScen
     if (this._path.length === 0 || this._reachedEnd) return;
 
     //Update the speed of the object
-    var timeDelta = runtimeScene.getTimeManager().getElapsedTime()/1000;
+    var timeDelta = this.owner.getElapsedTime(runtimeScene)/1000;
     this._speed += this._acceleration*timeDelta;
     if ( this._speed > this._maxSpeed ) this._speed = this._maxSpeed;
     this._angularSpeed = this._angularMaxSpeed;

--- a/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
+++ b/Extensions/PlatformBehavior/PlatformerObjectBehavior.cpp
@@ -96,7 +96,7 @@ void PlatformerObjectBehavior::DoStepPreEvents(RuntimeScene & scene)
 
     if ( !sceneManager ) return;
 
-    double timeDelta = static_cast<double>(scene.GetTimeManager().GetElapsedTime()) / 1000000.0;
+    double timeDelta = static_cast<double>(object->GetElapsedTime(scene)) / 1000000.0;
 
     //0.1) Get the player input:
 

--- a/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
+++ b/Extensions/PlatformBehavior/platformerobjectruntimebehavior.js
@@ -62,7 +62,7 @@ gdjs.PlatformerObjectRuntimeBehavior.prototype.doStepPreEvents = function(runtim
     var SHIFTKEY = 16;
     var SPACEKEY = 32;
     var object = this.owner;
-    var timeDelta = runtimeScene.getTimeManager().getElapsedTime()/1000;
+    var timeDelta = this.owner.getElapsedTime(runtimeScene)/1000;
 
     //0.1) Get the player input:
     var requestedDeltaX = 0;

--- a/Extensions/TextEntryObject/TextEntryObject.cpp
+++ b/Extensions/TextEntryObject/TextEntryObject.cpp
@@ -40,7 +40,6 @@ TextEntryObject::TextEntryObject(gd::String name_) :
 RuntimeTextEntryObject::RuntimeTextEntryObject(RuntimeScene & scene_, const TextEntryObject & textEntryObject) :
     RuntimeObject(scene_, textEntryObject),
     text(),
-    scene(&scene_),
     activated(true)
 {
 }
@@ -48,12 +47,12 @@ RuntimeTextEntryObject::RuntimeTextEntryObject(RuntimeScene & scene_, const Text
 /**
  * \brief Used to update input
  */
-void RuntimeTextEntryObject::UpdateTime(float)
+void RuntimeTextEntryObject::Update(const RuntimeScene & scene)
 {
-    if (!activated || scene == NULL) return;
+    if (!activated) return;
 
     //Retrieve text entered
-    const auto & characters = scene->GetInputManager().GetCharactersEntered();
+    const auto & characters = scene.GetInputManager().GetCharactersEntered();
     for (std::size_t i = 0;i<characters.size();++i)
     {
         //Skip some non displayable characters
@@ -64,7 +63,6 @@ void RuntimeTextEntryObject::UpdateTime(float)
         }
         else if (characters[i] == 8)
         {
-            std::cout << "Backspace" << std::endl;
             //Backspace : find the previous codepoint and remove it
             if(text.empty())
                 continue;

--- a/Extensions/TextEntryObject/TextEntryObject.h
+++ b/Extensions/TextEntryObject/TextEntryObject.h
@@ -62,7 +62,7 @@ public :
     virtual std::size_t GetNumberOfProperties() const;
     #endif
 
-    virtual void UpdateTime(float);
+    virtual void Update(const RuntimeScene & scene);
 
     inline void SetString(gd::String str) { text = str; };
     const gd::String & GetString() const { return text; };
@@ -73,7 +73,6 @@ public :
 private:
 
     gd::String text;
-    const RuntimeScene * scene; ///< Pointer to the scene. Initialized during LoadRuntimeResources call.
     bool activated;
 };
 

--- a/Extensions/TextEntryObject/textentryruntimeobject.js
+++ b/Extensions/TextEntryObject/textentryruntimeobject.js
@@ -33,7 +33,7 @@ gdjs.TextEntryRuntimeObject.prototype.onDeletedFromScene = function(runtimeScene
     }
 };
 
-gdjs.TextEntryRuntimeObject.prototype.updateTime = function(elapsedTime) {
+gdjs.TextEntryRuntimeObject.prototype.update = function() {
     if (this._renderer.getString) {
         this._str = this._renderer.getString();
     }

--- a/Extensions/TextObject/textruntimeobject.js
+++ b/Extensions/TextObject/textruntimeobject.js
@@ -37,7 +37,7 @@ gdjs.TextRuntimeObject.prototype.getRendererObject = function() {
     return this._renderer.getRendererObject();
 };
 
-gdjs.TextRuntimeObject.prototype.updateTime = function() {
+gdjs.TextRuntimeObject.prototype.update = function() {
     this._renderer.ensureUpToDate();
 };
 

--- a/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
+++ b/Extensions/TopDownMovementBehavior/TopDownMovementBehavior.cpp
@@ -94,7 +94,7 @@ void TopDownMovementBehavior::DoStepPreEvents(RuntimeScene & scene)
     }
 
     //Update the speed of the object
-    float timeDelta = static_cast<double>(scene.GetTimeManager().GetElapsedTime())/1000000.0;
+    float timeDelta = static_cast<double>(object->GetElapsedTime(scene))/1000000.0;
     if (direction != -1)
     {
         directionInRad = static_cast<float>(direction)*gd::Pi()/4.0;

--- a/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.js
+++ b/Extensions/TopDownMovementBehavior/topdownmovementruntimebehavior.js
@@ -94,7 +94,7 @@ gdjs.TopDownMovementRuntimeBehavior.prototype.doStepPreEvents = function(runtime
     var DOWNKEY = 40;
     var SHIFTKEY = 16;
     var object = this.owner;
-    var timeDelta = runtimeScene.getTimeManager().getElapsedTime()/1000;
+    var timeDelta = this.owner.getElapsedTime(runtimeScene)/1000;
 
     //Get the player input:
     this._leftKey |= !this._ignoreDefaultControls && runtimeScene.getGame().getInputManager().isKeyPressed(LEFTKEY);

--- a/GDCpp/GDCpp/Extensions/Builtin/CameraExtension.cpp
+++ b/GDCpp/GDCpp/Extensions/Builtin/CameraExtension.cpp
@@ -49,6 +49,10 @@ CameraExtension::CameraExtension()
 
     GetAllConditions()["LayerVisible"].SetFunctionName("LayerVisible").SetIncludeFile("GDCpp/Extensions/Builtin/RuntimeSceneTools.h");
 
+    GetAllConditions()["LayerTimeScale"].SetFunctionName("GetLayerTimeScale").SetIncludeFile("GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.h");
+    GetAllActions()["ChangeLayerTimeScale"].SetFunctionName("SetLayerTimeScale").SetIncludeFile("GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.h");
+    GetAllExpressions()["LayerTimeScale"].SetFunctionName("GetLayerTimeScale").SetIncludeFile("GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.h");
+
     GetAllExpressions()["CameraWidth"].SetFunctionName("GetCameraWidth").SetIncludeFile("GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.h");
     GetAllExpressions()["CameraHeight"].SetFunctionName("GetCameraHeight").SetIncludeFile("GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.h");
     GetAllExpressions()["CameraViewportLeft"].SetFunctionName("GetCameraViewportLeft").SetIncludeFile("GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.h");
@@ -64,4 +68,3 @@ CameraExtension::CameraExtension()
 
     #endif
 }
-

--- a/GDCpp/GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.cpp
+++ b/GDCpp/GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.cpp
@@ -221,3 +221,13 @@ void GD_API SetCameraViewport( RuntimeScene & scene,  const gd::String & layer, 
     RuntimeCamera & camera = scene.GetRuntimeLayer(layer).GetCamera(cameraNb);
     camera.SetViewport(viewportLeft, viewportTop, viewportRight, viewportBottom);
 }
+
+double GD_API GetLayerTimeScale(RuntimeScene & scene, const gd::String & layer)
+{
+    return scene.GetRuntimeLayer(layer).GetTimeScale();
+}
+
+void GD_API SetLayerTimeScale(RuntimeScene & scene, const gd::String & layer, double timeScale)
+{
+    scene.GetRuntimeLayer(layer).SetTimeScale(timeScale);
+}

--- a/GDCpp/GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.cpp
+++ b/GDCpp/GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.cpp
@@ -140,7 +140,7 @@ void GD_API CenterCameraOnObjectWithLimits(RuntimeScene & scene, RuntimeObject *
 
     float xOffset = 0;
     float yOffset = 0;
-    double elapsedTime = static_cast<double>(scene.GetTimeManager().GetElapsedTime()) / 1000000.0;
+    double elapsedTime = static_cast<double>(object->GetElapsedTime(scene)) / 1000000.0;
     if (anticipateObjectMove)
     {
         xOffset = object->TotalForceX() * elapsedTime;
@@ -166,7 +166,7 @@ void GD_API CenterCameraOnObject(RuntimeScene & scene, RuntimeObject * object,  
 
     float xOffset = 0;
     float yOffset = 0;
-    double elapsedTime = static_cast<double>(scene.GetTimeManager().GetElapsedTime()) / 1000000.0;
+    double elapsedTime = static_cast<double>(object->GetElapsedTime(scene)) / 1000000.0;
     if (anticipateObjectMove)
     {
         xOffset = object->TotalForceX() * elapsedTime;

--- a/GDCpp/GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.h
+++ b/GDCpp/GDCpp/Extensions/Builtin/RuntimeSceneCameraTools.h
@@ -27,5 +27,8 @@ void GD_API CenterCameraOnObject(RuntimeScene & scene, RuntimeObject * object, b
 void GD_API ActDeleteCamera(RuntimeScene & scene, const gd::String & layer, std::size_t camera);
 void GD_API AddCamera( RuntimeScene & scene, const gd::String & layer, float width, float height, float viewportLeft, float viewportTop, float viewportRight, float viewportBottom );
 void GD_API SetCameraViewport( RuntimeScene & scene,  const gd::String & layer, std::size_t cameraNb, float viewportLeft, float viewportTop, float viewportRight, float viewportBottom );
+double GD_API GetLayerTimeScale(RuntimeScene & scene, const gd::String & layer);
+void GD_API SetLayerTimeScale(RuntimeScene & scene, const gd::String & layer, double timeScale);
+
 
 #endif // RUNTIMESCENECAMERATOOLS_H

--- a/GDCpp/GDCpp/Extensions/Builtin/RuntimeSceneTools.cpp
+++ b/GDCpp/GDCpp/Extensions/Builtin/RuntimeSceneTools.cpp
@@ -84,9 +84,9 @@ void GD_API MoveObjects( RuntimeScene & scene )
 {
     RuntimeObjNonOwningPtrList allObjects = scene.objectsInstances.GetAllObjects();
 
-    double elapsedTime = static_cast<double>(scene.GetTimeManager().GetElapsedTime()) / 1000000.0;
     for (std::size_t id = 0;id < allObjects.size();++id)
     {
+        double elapsedTime = static_cast<double>(allObjects[id]->GetElapsedTime(scene)) / 1000000.0;
         allObjects[id]->SetX(allObjects[id]->GetX() + allObjects[id]->TotalForceX() * elapsedTime);
         allObjects[id]->SetY(allObjects[id]->GetY() + allObjects[id]->TotalForceY() * elapsedTime);
 

--- a/GDCpp/GDCpp/Runtime/RuntimeLayer.cpp
+++ b/GDCpp/GDCpp/Runtime/RuntimeLayer.cpp
@@ -5,14 +5,21 @@
  */
 #include "RuntimeLayer.h"
 #include "GDCpp/Runtime/Project/Layer.h"
+#include "GDCpp/Runtime/RuntimeScene.h"
 #include <SFML/Graphics.hpp>
 
 RuntimeLayer::RuntimeLayer(gd::Layer & layer, const sf::View & defaultView) :
     name(layer.GetName()),
-    isVisible(layer.GetVisibility())
+    isVisible(layer.GetVisibility()),
+    timeScale(1)
 {
     for (std::size_t i = 0;i<layer.GetCameraCount();++i)
         cameras.push_back(RuntimeCamera(layer.GetCamera(i), defaultView));
+}
+
+signed long long RuntimeLayer::GetElapsedTime(const RuntimeScene & scene) const
+{
+    return scene.GetTimeManager().GetElapsedTime() * timeScale;
 }
 
 RuntimeCamera::RuntimeCamera(sf::View & view) :

--- a/GDCpp/GDCpp/Runtime/RuntimeLayer.h
+++ b/GDCpp/GDCpp/Runtime/RuntimeLayer.h
@@ -9,6 +9,7 @@
 #include "GDCpp/Runtime/String.h"
 namespace gd { class Camera; }
 namespace gd { class Layer; }
+class RuntimeScene;
 
 /**
  * \brief A camera which is displayed on a part of a window ( see Viewport related methods )
@@ -111,7 +112,7 @@ private:
 class GD_API RuntimeLayer
 {
 public:
-    RuntimeLayer() : isVisible(true) {};
+    RuntimeLayer() : isVisible(true), timeScale(1) {};
     RuntimeLayer(gd::Layer & layer, const sf::View & defaultView);
     virtual ~RuntimeLayer() {};
 
@@ -160,11 +161,28 @@ public:
      */
     inline void AddCamera(const RuntimeCamera & camera) { cameras.push_back(camera); };
 
+    /**
+     * \brief Get the time scale of the layer
+     */
+    double GetTimeScale() { return timeScale; }
+
+    /**
+     * \brief Change the time scale applied on the (objects of the) layer.
+     */
+    void SetTimeScale(double timeScale_) { if (timeScale_ > 0) timeScale = timeScale_; }
+
+    /**
+     * \brief Return the time elapsed since the last frame, in microseconds, for the layer.
+     * This can be different than the time elapsed on the scene
+     */
+    signed long long GetElapsedTime(const RuntimeScene & scene) const;
+
 private:
 
     gd::String name; ///< The name of the layer
     bool isVisible; ///< True if the layer is visible
     std::vector < RuntimeCamera > cameras; ///< The camera displayed by the layer
+    double timeScale; ///< Time scale that is applied on the (objects of the) layer.
 };
 
 #endif // RUNTIMELAYER_H

--- a/GDCpp/GDCpp/Runtime/RuntimeLayer.h
+++ b/GDCpp/GDCpp/Runtime/RuntimeLayer.h
@@ -169,7 +169,7 @@ public:
     /**
      * \brief Change the time scale applied on the (objects of the) layer.
      */
-    void SetTimeScale(double timeScale_) { if (timeScale_ > 0) timeScale = timeScale_; }
+    void SetTimeScale(double timeScale_) { if (timeScale_ >= 0) timeScale = timeScale_; }
 
     /**
      * \brief Return the time elapsed since the last frame, in microseconds, for the layer.

--- a/GDCpp/GDCpp/Runtime/RuntimeObject.cpp
+++ b/GDCpp/GDCpp/Runtime/RuntimeObject.cpp
@@ -124,6 +124,12 @@ std::size_t RuntimeObject::GetNumberOfProperties() const
 }
 #endif
 
+signed long long RuntimeObject::GetElapsedTime(const RuntimeScene & scene) const
+{
+    const RuntimeLayer & theLayer = scene.GetRuntimeLayer(layer);
+    return theLayer.GetElapsedTime(scene);
+}
+
 void RuntimeObject::DeleteFromScene(RuntimeScene & scene)
 {
     name = "";
@@ -316,7 +322,7 @@ void RuntimeObject::RotateTowardAngle(float angleInDegrees, float speed, Runtime
         return;
     }
 
-    float timeDelta = static_cast<double>(scene.GetTimeManager().GetElapsedTime()) / 1000000.0;
+    float timeDelta = static_cast<double>(GetElapsedTime(scene)) / 1000000.0;
     float angularDiff = GDpriv::MathematicalTools::angleDifference(GetAngle(), angleInDegrees);
     bool diffWasPositive = angularDiff >= 0;
 
@@ -331,7 +337,7 @@ void RuntimeObject::RotateTowardAngle(float angleInDegrees, float speed, Runtime
 
 void RuntimeObject::Rotate(float speed, RuntimeScene & scene)
 {
-    float timeDelta = static_cast<double>(scene.GetTimeManager().GetElapsedTime()) / 1000000.0;
+    float timeDelta = static_cast<double>(GetElapsedTime(scene)) / 1000000.0;
     SetAngle(GetAngle()+speed*timeDelta);
 }
 

--- a/GDCpp/GDCpp/Runtime/RuntimeObject.h
+++ b/GDCpp/GDCpp/Runtime/RuntimeObject.h
@@ -243,10 +243,17 @@ public:
     virtual bool CursorOnObject(RuntimeScene & scene, bool accurate);
 
     /**
-     * \brief Called at each frame so as to update internal object's things using time (such as animation for a sprite).
+     * \brief Called at each frame, before events and rendering.
      * \note The default implementation does nothing.
      */
-    virtual void UpdateTime(float timeElapsed) {};
+    virtual void Update(const RuntimeScene & scene) {};
+
+    /**
+     * \brief Return the time elapsed since the last frame, in microseconds, for the object.
+     *
+     * Objects can have different elapsed time if they are on layers with different time scales.
+     */
+    signed long long GetElapsedTime(const RuntimeScene & scene) const;
 
     /**
      * \brief Get the width of the object, in pixels.

--- a/GDCpp/GDCpp/Runtime/RuntimeScene.cpp
+++ b/GDCpp/GDCpp/Runtime/RuntimeScene.cpp
@@ -290,10 +290,19 @@ bool RuntimeScene::OrderObjectsByZOrder(RuntimeObjNonOwningPtrList & objList)
 
 RuntimeLayer & RuntimeScene::GetRuntimeLayer(const gd::String & name)
 {
-    for (std::size_t i = 0;i<layers.size();++i)
+    for(RuntimeLayer & layer : layers)
     {
-        if ( layers[i].GetName() == name )
-            return layers[i];
+        if (layer.GetName() == name) return layer;
+    }
+
+    return badRuntimeLayer;
+}
+
+const RuntimeLayer & RuntimeScene::GetRuntimeLayer(const gd::String & name) const
+{
+    for(const RuntimeLayer & layer : layers)
+    {
+        if (layer.GetName() == name) return layer;
     }
 
     return badRuntimeLayer;
@@ -316,14 +325,14 @@ void RuntimeScene::ManageObjectsAfterEvents()
 
     //Update objects positions, forces and behaviors
     allObjects = objectsInstances.GetAllObjects();
-    double elapsedTime = static_cast<double>(timeManager.GetElapsedTime())/1000000.0;
-    for (std::size_t id = 0;id<allObjects.size();++id)
+    for (RuntimeObjSPtr & object : allObjects)
     {
-        allObjects[id]->SetX( allObjects[id]->GetX() + (allObjects[id]->TotalForceX() * elapsedTime));
-        allObjects[id]->SetY( allObjects[id]->GetY() + (allObjects[id]->TotalForceY() * elapsedTime));
-        allObjects[id]->UpdateTime(elapsedTime);
-        allObjects[id]->UpdateForce(elapsedTime);
-        allObjects[id]->DoBehaviorsPostEvents(*this);
+        double elapsedTimeInSeconds = static_cast<double>(object->GetElapsedTime(*this))/1000000.0;
+        object->SetX( object->GetX() + (object->TotalForceX() * elapsedTimeInSeconds));
+        object->SetY( object->GetY() + (object->TotalForceY() * elapsedTimeInSeconds));
+        object->Update(*this);
+        object->UpdateForce(elapsedTimeInSeconds);
+        object->DoBehaviorsPostEvents(*this);
     }
 }
 

--- a/GDCpp/GDCpp/Runtime/RuntimeScene.cpp
+++ b/GDCpp/GDCpp/Runtime/RuntimeScene.cpp
@@ -325,7 +325,7 @@ void RuntimeScene::ManageObjectsAfterEvents()
 
     //Update objects positions, forces and behaviors
     allObjects = objectsInstances.GetAllObjects();
-    for (RuntimeObjSPtr & object : allObjects)
+    for (RuntimeObject * object : allObjects)
     {
         double elapsedTimeInSeconds = static_cast<double>(object->GetElapsedTime(*this))/1000000.0;
         object->SetX( object->GetX() + (object->TotalForceX() * elapsedTimeInSeconds));

--- a/GDCpp/GDCpp/Runtime/RuntimeScene.h
+++ b/GDCpp/GDCpp/Runtime/RuntimeScene.h
@@ -97,6 +97,11 @@ public:
     RuntimeLayer & GetRuntimeLayer(const gd::String & name);
 
     /**
+     * Get the layer with specified name.
+     */
+    const RuntimeLayer & GetRuntimeLayer(const gd::String & name) const;
+
+    /**
      * \brief Return the shared data for a behavior.
      * \warning Be careful, no check is made to ensure that the shared data exist.
      * \param name The name of the behavior for which shared data must be fetched.

--- a/GDCpp/GDCpp/Runtime/RuntimeSpriteObject.cpp
+++ b/GDCpp/GDCpp/Runtime/RuntimeSpriteObject.cpp
@@ -317,11 +317,12 @@ void RuntimeSpriteObject::UpdateCurrentSprite() const
     needUpdateCurrentSprite = false;
 }
 
-void RuntimeSpriteObject::UpdateTime(float elapsedTime)
+void RuntimeSpriteObject::Update(const RuntimeScene & scene)
 {
     if ( animationStopped || currentAnimation >= GetAnimationsCount() ) return;
 
-    timeElapsedOnCurrentSprite += elapsedTime * animationSpeedScale;
+    double elapsedTimeInSeconds = static_cast<double>(GetElapsedTime(scene))/1000000.0;
+    timeElapsedOnCurrentSprite += elapsedTimeInSeconds * animationSpeedScale;
 
     const gd::Direction & direction = animations[currentAnimation].Get().GetDirection( currentDirection );
 

--- a/GDCpp/GDCpp/Runtime/RuntimeSpriteObject.h
+++ b/GDCpp/GDCpp/Runtime/RuntimeSpriteObject.h
@@ -65,7 +65,7 @@ public:
     virtual std::size_t GetNumberOfProperties() const;
     #endif
 
-    virtual void UpdateTime(float timeElapsed);
+    virtual void Update(const RuntimeScene & scene);
 
     virtual void OnPositionChanged() {needUpdateCurrentSprite = true;};
 

--- a/GDJS/GDJS/Extensions/Builtin/CameraExtension.cpp
+++ b/GDJS/GDJS/Extensions/Builtin/CameraExtension.cpp
@@ -48,6 +48,10 @@ CameraExtension::CameraExtension()
 
     GetAllActions()["SetLayerEffectParameter"].SetFunctionName("gdjs.evtTools.camera.setLayerEffectParameter");
 
+    GetAllConditions()["LayerTimeScale"].SetFunctionName("gdjs.evtTools.camera.getLayerTimeScale");
+    GetAllActions()["ChangeLayerTimeScale"].SetFunctionName("gdjs.evtTools.camera.setLayerTimeScale");
+    GetAllExpressions()["LayerTimeScale"].SetFunctionName("gdjs.evtTools.camera.getLayerTimeScale");
+
     StripUnimplementedInstructionsAndExpressions(); //Unimplemented things are listed here:
 /*
     AddAction("AddCamera",

--- a/GDJS/Runtime/cocos-renderers/runtimescene-cocos-renderer.js
+++ b/GDJS/Runtime/cocos-renderers/runtimescene-cocos-renderer.js
@@ -20,9 +20,16 @@ gdjs.RuntimeSceneCocosRenderer = function(runtimeScene, runtimeGameRenderer)
         onEnter: function() {
             this._super();
             this.scheduleUpdate();
+
+            // Hide the first frame of the scene (until update is called)
+            // to let the scene render method run (including scene events).
+            // This can avoid a glitchy first frame where objects are shown before
+            // events are run.
+            this.visible = false;
         },
         update: function(dt) {
             runtimeGameRenderer.onSceneUpdated(dt*1000);
+            this.visible = true;
         }
     });
     this._cocosScene = new ContainerScene();

--- a/GDJS/Runtime/events-tools/cameratools.js
+++ b/GDJS/Runtime/events-tools/cameratools.js
@@ -84,11 +84,12 @@ gdjs.evtTools.camera.setCameraZoom = function(runtimeScene, newZoom, layer, came
 gdjs.evtTools.camera.centerCamera = function(runtimeScene, object, anticipateMove, layer, cameraId) {
     if ( !runtimeScene.hasLayer(layer) || object == null ) { return; }
 
-    var elapsedTimeInSeconds = runtimeScene.getTimeManager().getElapsedTime() / 1000;
     var layer = runtimeScene.getLayer(layer);
     var xOffset = 0; var yOffset = 0;
     if ( anticipateMove && !object.hasNoForces() ) {
         var objectAverageForce  = object.getAverageForce();
+        var elapsedTimeInSeconds = obj.getElapsedTime(runtimeScene) / 1000;
+
         xOffset = objectAverageForce.getX() * elapsedTimeInSeconds;
         yOffset = objectAverageForce.getY() * elapsedTimeInSeconds;
     }
@@ -100,11 +101,12 @@ gdjs.evtTools.camera.centerCamera = function(runtimeScene, object, anticipateMov
 gdjs.evtTools.camera.centerCameraWithinLimits = function(runtimeScene, object, left, top, right, bottom, anticipateMove, layer, cameraId) {
     if ( !runtimeScene.hasLayer(layer) || object == null ) { return; }
 
-    var elapsedTimeInSeconds = runtimeScene.getTimeManager().getElapsedTime() / 1000;
     var layer = runtimeScene.getLayer(layer);
     var xOffset = 0; var yOffset = 0;
     if ( anticipateMove && !object.hasNoForces() ) {
         var objectAverageForce  = object.getAverageForce();
+        var elapsedTimeInSeconds = obj.getElapsedTime(runtimeScene) / 1000;
+
         xOffset = objectAverageForce.getX() * elapsedTimeInSeconds;
         yOffset = objectAverageForce.getY() * elapsedTimeInSeconds;
     }

--- a/GDJS/Runtime/events-tools/cameratools.js
+++ b/GDJS/Runtime/events-tools/cameratools.js
@@ -128,3 +128,13 @@ gdjs.evtTools.camera.setLayerEffectParameter = function(runtimeScene, layer, eff
 
     return runtimeScene.getLayer(layer).setEffectParameter(effect, parameter, value);
 }
+
+gdjs.evtTools.camera.setLayerTimeScale = function(runtimeScene, layer, timeScale) {
+    if ( !runtimeScene.hasLayer(layer) ) { return; }
+    return runtimeScene.getLayer(layer).setTimeScale(timeScale);
+}
+
+gdjs.evtTools.camera.getLayerTimeScale = function(runtimeScene, layer) {
+    if ( !runtimeScene.hasLayer(layer) ) { return 1; }
+    return runtimeScene.getLayer(layer).getTimeScale();
+}

--- a/GDJS/Runtime/gd.js
+++ b/GDJS/Runtime/gd.js
@@ -171,14 +171,28 @@ gdjs.getBehaviorConstructor = function(name) {
     return gdjs.behaviorsTypes.get(""); //Create a base empty runtime behavior.
 };
 
+/**
+ * Create a static array that won't need a new allocation each time it's used.
+ */
 gdjs.staticArray = function(owner) {
     owner._staticArray = owner._staticArray || [];
     return owner._staticArray;
 }
 
+/**
+ * Create a second static array that won't need a new allocation each time it's used.
+ */
 gdjs.staticArray2 = function(owner) {
     owner._staticArray2 = owner._staticArray2 || [];
     return owner._staticArray2;
+}
+
+/**
+ * Create a static object that won't need a new allocation each time it's used.
+ */
+gdjs.staticObject = function(owner) {
+    owner._staticObject = owner._staticObject || {};
+    return owner._staticObject;
 }
 
 Array.prototype.remove = function(from) {

--- a/GDJS/Runtime/layer.js
+++ b/GDJS/Runtime/layer.js
@@ -18,6 +18,7 @@ gdjs.Layer = function(layerData, runtimeScene)
     this._name = layerData.name;
     this._cameraRotation = 0;
     this._zoomFactor = 1;
+    this._timeScale = 1;
     this._hidden = !layerData.visibility;
     this._effects = layerData.effects || [];
     this._cameraX = runtimeScene.getGame().getDefaultWidth()/2;
@@ -221,3 +222,30 @@ gdjs.Layer.prototype.setEffectsDefaultParameters = function() {
         }
     }
 };
+
+/**
+ * Set the time scale for the objects on the layer:
+ * time will be slower if time scale is < 1, faster if > 1.
+ * @method setTimeScale
+ * @param timeScale {Number} The new time scale (must be positive).
+ */
+gdjs.Layer.prototype.setTimeScale = function(timeScale) {
+	if ( timeScale >= 0 ) this._timeScale = timeScale;
+};
+
+/**
+ * Get the time scale for the objects on the layer.
+ * @method getTimeScale
+ */
+gdjs.Layer.prototype.getTimeScale = function() {
+	return this._timeScale;
+};
+
+/**
+ * Return the time elapsed since the last frame,
+ * in milliseconds, for objects on the layer.
+ * @method getElapsedTime
+ */
+gdjs.Layer.prototype.getElapsedTime = function(runtimeScene) {
+   return runtimeScene.getTimeManager().getElapsedTime() * this._timeScale;
+}

--- a/GDJS/Runtime/runtimegame.js
+++ b/GDJS/Runtime/runtimegame.js
@@ -266,16 +266,16 @@ gdjs.RuntimeGame.prototype.startGameLoop = function() {
         this._injectExternalLayout);
 
     //Uncomment to profile the first x frames of the game.
-    /*var x = 250;
-    var startTime = Date.now();
-    console.profile("Stepping for " + x + " frames")
-    for(var i = 0; i < x; ++i) {
-        this._sceneStack.step(16);
-    }
-    console.profileEnd();
-    var time = Date.now() - startTime;
-    console.log("Took", time, "ms");
-    return;*/
+    // var x = 500;
+    // var startTime = Date.now();
+    // console.profile("Stepping for " + x + " frames")
+    // for(var i = 0; i < x; ++i) {
+    //     this._sceneStack.step(16);
+    // }
+    // console.profileEnd();
+    // var time = Date.now() - startTime;
+    // console.log("Took", time, "ms");
+    // return;
 
     //The standard game loop
     var that = this;

--- a/GDJS/Runtime/runtimeobject.js
+++ b/GDJS/Runtime/runtimeobject.js
@@ -96,18 +96,32 @@ gdjs.RuntimeObject.forcesGarbage = []; //Global container for unused forces, avo
 //Common members functions related to the object and its runtimeScene :
 
 /**
- * Called each time the scene is rendered.
+ * Return the time elapsed since the last frame,
+ * in milliseconds, for the object.
  *
- * @method updateTime
- * @param elapsedTime {Number} The time elapsedTime since the last frame, in **seconds**.
+ * Objects can have different elapsed time if they are on layers with different time scales.
+ *
+ * @method getElapsedTime
+ * @param runtimeScene The RuntimeScene the object belongs to.
  */
-gdjs.RuntimeObject.prototype.updateTime = function(elapsedTime) {
+gdjs.RuntimeObject.prototype.getElapsedTime = function(runtimeScene) {
+    //TODO: Memoize?
+    var theLayer = runtimeScene.getLayer(this.layer);
+    return theLayer.getElapsedTime(runtimeScene);
+}
+
+/**
+ * Called once during the game loop, before events and rendering.
+ * @method update
+ * @param runtimeScene The gdjs.RuntimeScene the object belongs to.
+ */
+gdjs.RuntimeObject.prototype.update = function(runtimeScene) {
     //Nothing to do.
 };
 
 /**
  * Called when the object is created from an initial instance at the startup of the scene.<br>
- * Note this.common properties ( position, angle, z order... ) have already been setup.
+ * Note that common properties (position, angle, z order...) have already been setup.
  *
  * @method extraInitializationFromInitialInstance
  * @param initialInstanceData The data of the initial instance.
@@ -285,7 +299,7 @@ gdjs.RuntimeObject.prototype.rotateTowardAngle = function(angle, speed, runtimeS
     var diffWasPositive = angularDiff >= 0;
 
     var newAngle = this.getAngle() + (diffWasPositive ? -1.0 : 1.0)
-        * speed * runtimeScene.getTimeManager().getElapsedTime() / 1000;
+        * speed * this.getElapsedTime(runtimeScene) / 1000;
     if (gdjs.evtTools.common.angleDifference(newAngle, angle) > 0 ^ diffWasPositive)
         newAngle = angle;
     this.setAngle(newAngle);
@@ -295,8 +309,7 @@ gdjs.RuntimeObject.prototype.rotateTowardAngle = function(angle, speed, runtimeS
 };
 
 gdjs.RuntimeObject.prototype.rotate = function(speed, runtimeScene) {
-    this.setAngle(this.getAngle() +
-        speed * runtimeScene.getTimeManager().getElapsedTime() / 1000);
+    this.setAngle(this.getAngle() + speed * this.getElapsedTime(runtimeScene) / 1000);
 };
 
 /**
@@ -417,6 +430,7 @@ gdjs.RuntimeObject.prototype.getVariableNumber = gdjs.RuntimeObject.getVariableN
 gdjs.RuntimeObject.getVariableString = function(variable) {
     return variable.getAsString();
 };
+gdjs.RuntimeObject.prototype.getVariableString = gdjs.RuntimeObject.getVariableString;
 
 /**
  * Get the number of children from a variable
@@ -429,8 +443,6 @@ gdjs.RuntimeObject.getVariableChildCount = function(variable) {
     if (variable.isStructure() == false) return 0;
     return Object.keys(variable.getAllChildren()).length;
 };
-
-gdjs.RuntimeObject.prototype.getVariableString = gdjs.RuntimeObject.getVariableString;
 
 /**
  * Shortcut to set the value of a variable considered as a number

--- a/GDJS/Runtime/runtimescene.js
+++ b/GDJS/Runtime/runtimescene.js
@@ -365,9 +365,8 @@ gdjs.RuntimeScene.prototype._updateObjects = function() {
 	//It is *mandatory* to create and iterate on a external list of all objects, as the behaviors
 	//may delete the objects.
 	this._constructListOfAllInstances();
-	var elapsedTimeInSeconds = this._timeManager.getElapsedTime() / 1000;
 	for( var i = 0, len = this._allInstancesList.length;i<len;++i) {
-		this._allInstancesList[i].updateTime(elapsedTimeInSeconds);
+		this._allInstancesList[i].update(this);
 		this._allInstancesList[i].stepBehaviorsPostEvents(this);
 	}
 
@@ -399,7 +398,6 @@ gdjs.RuntimeScene.prototype.getName = function() {
  * @method updateObjectsForces
  */
 gdjs.RuntimeScene.prototype.updateObjectsForces = function() {
-    var elapsedTimeInSeconds = this._timeManager.getElapsedTime() / 1000;
     for (var name in this._instances.items) {
         if (this._instances.items.hasOwnProperty(name)) {
             var list = this._instances.items[name];
@@ -408,6 +406,7 @@ gdjs.RuntimeScene.prototype.updateObjectsForces = function() {
         		var obj = list[j];
         		if (!obj.hasNoForces()) {
         			var averageForce = obj.getAverageForce();
+                    var elapsedTimeInSeconds = obj.getElapsedTime(this) / 1000;
 
         			obj.setX(obj.getX() + averageForce.getX() * elapsedTimeInSeconds);
         			obj.setY(obj.getY() + averageForce.getY() * elapsedTimeInSeconds);
@@ -416,7 +415,6 @@ gdjs.RuntimeScene.prototype.updateObjectsForces = function() {
         	}
         }
     }
-
 };
 
 /**

--- a/GDJS/Runtime/spriteruntimeobject.js
+++ b/GDJS/Runtime/spriteruntimeobject.js
@@ -211,10 +211,11 @@ gdjs.SpriteRuntimeObject.prototype.extraInitializationFromInitialInstance = func
 };
 
 /**
- * Update the current frame according to the elapsed time.
- * @method updateTime
+ * Update the current frame of the object according to the elapsed time on the scene.
+ * @method update
  */
-gdjs.SpriteRuntimeObject.prototype.updateTime = function(elapsedTime) {
+gdjs.SpriteRuntimeObject.prototype.update = function(runtimeScene) {
+    var elapsedTime = this.getElapsedTime(runtimeScene) / 1000;
     var oldFrame = this._currentFrame;
     this._frameElapsedTime += this._animationPaused ? 0 : elapsedTime * this._animationSpeedScale;
 

--- a/GDJS/Runtime/timer.js
+++ b/GDJS/Runtime/timer.js
@@ -37,7 +37,7 @@ gdjs.Timer.prototype.getTime = function() {
 }
 
 /**
- * Notify the timer this.some time elapsed.
+ * Notify the timer that some time elapsed.
  * @method updateTime
  */
 gdjs.Timer.prototype.updateTime = function(time) {

--- a/GDJS/scripts/LinkRuntimeFiles.sh
+++ b/GDJS/scripts/LinkRuntimeFiles.sh
@@ -1,0 +1,39 @@
+# Make links to the GDJS runtime files and extensions in the specified directory.
+# Useful for working on the game engine:
+# - First export your game/preview in a directory
+# - Then launch ./LinkRuntimeFiles /path/to/the/export/dir
+# - You can then modify the game engine files and test your changes directly in the game
+
+if [ $# -eq 0 ]; then
+	echo "You must specify the directory where the symbolic links should be created"
+  exit
+fi
+
+DESTINATION=$1
+RUNTIME_SOURCE=$(pwd)/../Runtime
+
+#Instead of removing directories, keep a backup of them in case
+rm_destination_with_BACKUP() {
+  if [ -d $DESTINATION/$1 ]; then
+    if [ ! -d $DESTINATION/BACKUP-$1 ]; then
+      mv -f $DESTINATION/$1 $DESTINATION/BACKUP-$1
+    fi
+    rm -rf $DESTINATION/$1
+  fi
+}
+
+#Remove all sub-directories that are going to be replaced by links
+for D in `find $RUNTIME_SOURCE -type d -depth 1`
+do
+  if [ $D != $RUNTIME_SOURCE ]; then
+    NAME=`basename $D`
+    rm_destination_with_BACKUP $NAME
+  fi
+done
+rm_destination_with_BACKUP "Extensions"
+
+#Link all runtime files and directories
+ln -s -f -F $RUNTIME_SOURCE/* $DESTINATION
+
+#Link Extensions directory
+ln -s -f -F $(pwd)/../../Extensions $DESTINATION

--- a/GDJS/tests/games/Layer time scale.gdg
+++ b/GDJS/tests/games/Layer time scale.gdg
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<project firstLayout="">
+    <gdVersion build="94" major="4" minor="0" revision="15" />
+    <properties folderProject="false" linuxExecutableFilename="" macExecutableFilename="" packageName="com.example.gamename" useExternalSourceFiles="false" winExecutableFilename="" winExecutableIconFile="">
+        <name>Project</name>
+        <author></author>
+        <windowWidth>800</windowWidth>
+        <windowHeight>600</windowHeight>
+        <latestCompilationDirectory></latestCompilationDirectory>
+        <maxFPS>60</maxFPS>
+        <minFPS>10</minFPS>
+        <verticalSync>false</verticalSync>
+        <extensions>
+            <extension name="BuiltinObject" />
+            <extension name="BuiltinAudio" />
+            <extension name="BuiltinVariables" />
+            <extension name="BuiltinTime" />
+            <extension name="BuiltinMouse" />
+            <extension name="BuiltinKeyboard" />
+            <extension name="BuiltinJoystick" />
+            <extension name="BuiltinCamera" />
+            <extension name="BuiltinWindow" />
+            <extension name="BuiltinFile" />
+            <extension name="BuiltinNetwork" />
+            <extension name="BuiltinScene" />
+            <extension name="BuiltinAdvanced" />
+            <extension name="Sprite" />
+            <extension name="BuiltinCommonInstructions" />
+            <extension name="BuiltinCommonConversions" />
+            <extension name="BuiltinStringInstructions" />
+            <extension name="BuiltinMathematicalTools" />
+            <extension name="BuiltinExternalLayouts" />
+        </extensions>
+        <platforms>
+            <platform name="GDevelop JS platform" />
+        </platforms>
+        <currentPlatform>GDevelop JS platform</currentPlatform>
+    </properties>
+    <resources>
+        <resources>
+            <resource alwaysLoaded="false" file="brickWall.png" kind="image" name="brickWall.png" smoothed="true" userAdded="false" />
+        </resources>
+        <resourceFolders />
+    </resources>
+    <objects />
+    <objectsGroups />
+    <variables />
+    <layouts>
+        <layout b="209" disableInputWhenNotFocused="true" mangledName="New_32scene" name="New scene" oglFOV="90.000000" oglZFar="500.000000" oglZNear="1.000000" r="209" standardSortMethod="true" stopSoundsOnStartup="true" title="" v="209">
+            <uiSettings grid="false" gridB="255" gridG="180" gridHeight="32" gridOffsetX="0" gridOffsetY="0" gridR="158" gridWidth="32" snap="true" windowMask="false" zoomFactor="1.000000" />
+            <objectsGroups />
+            <variables />
+            <instances>
+                <instance angle="0.000000" customSize="false" height="0.000000" layer="New layer 1" locked="false" name="NewObject" width="0.000000" x="86.999985" y="67.999969" zOrder="1">
+                    <numberProperties />
+                    <stringProperties />
+                    <initialVariables />
+                </instance>
+                <instance angle="0.000000" customSize="false" height="0.000000" layer="New layer" locked="false" name="NewObject" width="0.000000" x="84.999969" y="357.999939" zOrder="1">
+                    <numberProperties />
+                    <stringProperties />
+                    <initialVariables />
+                </instance>
+                <instance angle="0.000000" customSize="false" height="0.000000" layer="" locked="false" name="NewObject" width="0.000000" x="82.999939" y="219.999969" zOrder="1">
+                    <numberProperties />
+                    <stringProperties />
+                    <initialVariables />
+                </instance>
+            </instances>
+            <objects>
+                <object name="NewObject" type="Sprite">
+                    <variables />
+                    <behaviors />
+                    <animations>
+                        <animation name="" useMultipleDirections="false">
+                            <directions>
+                                <direction looping="false" timeBetweenFrames="1.000000">
+                                    <sprites>
+                                        <sprite hasCustomCollisionMask="false" image="brickWall.png">
+                                            <points />
+                                            <originPoint name="origine" x="0.000000" y="0.000000" />
+                                            <centerPoint automatic="true" name="centre" x="35.000000" y="35.000000" />
+                                            <customCollisionMask>
+                                                <polygon>
+                                                    <vertice x="0.000000" y="0.000000" />
+                                                    <vertice x="70.000000" y="0.000000" />
+                                                    <vertice x="70.000000" y="70.000000" />
+                                                    <vertice x="0.000000" y="70.000000" />
+                                                </polygon>
+                                            </customCollisionMask>
+                                        </sprite>
+                                    </sprites>
+                                </direction>
+                            </directions>
+                        </animation>
+                    </animations>
+                </object>
+            </objects>
+            <events>
+                <event disabled="false" folded="false">
+                    <type>BuiltinCommonInstructions::Standard</type>
+                    <conditions>
+                        <condition>
+                            <type inverted="false" value="DepartScene" />
+                            <parameters>
+                                <parameter></parameter>
+                            </parameters>
+                            <subConditions />
+                        </condition>
+                    </conditions>
+                    <actions>
+                        <action>
+                            <type inverted="false" value="ChangeTimeScale" />
+                            <parameters>
+                                <parameter></parameter>
+                                <parameter>0.3</parameter>
+                            </parameters>
+                            <subActions />
+                        </action>
+                        <action>
+                            <type inverted="false" value="AddForceXY" />
+                            <parameters>
+                                <parameter>NewObject</parameter>
+                                <parameter>300</parameter>
+                                <parameter>0</parameter>
+                                <parameter>1</parameter>
+                            </parameters>
+                            <subActions />
+                        </action>
+                        <action>
+                            <type inverted="false" value="ChangeLayerTimeScale" />
+                            <parameters>
+                                <parameter></parameter>
+                                <parameter>&quot;New layer 1&quot;</parameter>
+                                <parameter>2</parameter>
+                            </parameters>
+                            <subActions />
+                        </action>
+                        <action>
+                            <type inverted="false" value="ChangeLayerTimeScale" />
+                            <parameters>
+                                <parameter></parameter>
+                                <parameter>&quot;New layer&quot;</parameter>
+                                <parameter>0.5</parameter>
+                            </parameters>
+                            <subActions />
+                        </action>
+                    </actions>
+                    <events />
+                </event>
+                <event disabled="false" folded="false">
+                    <type>BuiltinCommonInstructions::Standard</type>
+                    <conditions />
+                    <actions>
+                        <action>
+                            <type inverted="false" value="Rotate" />
+                            <parameters>
+                                <parameter>NewObject</parameter>
+                                <parameter>180</parameter>
+                                <parameter></parameter>
+                            </parameters>
+                            <subActions />
+                        </action>
+                    </actions>
+                    <events />
+                </event>
+            </events>
+            <layers>
+                <layer name="New layer" visibility="true">
+                    <cameras>
+                        <camera defaultSize="true" defaultViewport="true" height="0.000000" viewportBottom="1.000000" viewportLeft="0.000000" viewportRight="1.000000" viewportTop="0.000000" width="0.000000" />
+                    </cameras>
+                    <effects />
+                </layer>
+                <layer name="" visibility="true">
+                    <cameras>
+                        <camera defaultSize="true" defaultViewport="true" height="0.000000" viewportBottom="1.000000" viewportLeft="0.000000" viewportRight="1.000000" viewportTop="0.000000" width="0.000000" />
+                    </cameras>
+                    <effects />
+                </layer>
+                <layer name="New layer 1" visibility="true">
+                    <cameras>
+                        <camera defaultSize="true" defaultViewport="true" height="0.000000" viewportBottom="1.000000" viewportLeft="0.000000" viewportRight="1.000000" viewportTop="0.000000" width="0.000000" />
+                    </cameras>
+                    <effects />
+                </layer>
+            </layers>
+            <behaviorsSharedData />
+        </layout>
+    </layouts>
+    <externalEvents />
+    <externalLayouts />
+    <externalSourceFiles />
+</project>


### PR DESCRIPTION
This refactor objects and layers to add custom time scale support for layers.
In particular `UpdateTime`/`updateTime` has been renamed `Update`/`update`. The whole scene is passed as an argument, avoiding some objects to retain a pointer to the scene which was hacky.
Runtime objects have a `GetElapsedTime` that is used to get the elapsed time for the object (that depends on the scene time scale and layer time scale).
A test game is included.

Actions/conditions/expressions are available to change the time scale for a layer (native and JS game engine support). 

This enables to "pause" the gameplay of a layer while still having other layers animations running (for example, an interface or a tutorial with animations displayed while the game is paused).