### PR TITLE
Bugfix/particle system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,9 @@
 /docs/GDJS Documentation
 /docs/GDCpp Documentation
 /docs/GDCore Documentation
-/ExtLibs/boost
-/ExtLibs/SFML
 /ExtLibs/wxwidgets
 /ExtLibs/wxWidgets
+/ExtLibs/SFML
 /ExtLibs/*.7z
 /scripts/Repository keys
 /scripts/logs/*.txt
@@ -71,6 +70,9 @@ Binaries/Packaging/logs
 !/Binaries/Output/Release_Windows/locale/msgfmt.exe
 !/ExtLibs/curl.exe
 !/ExtLibs/7za.exe
+!/ExtLibs/SFML/extlibs/**/*.dll
+!/ExtLibs/SFML/extlibs/**/*.so
+!/ExtLibs/SFML/extlibs/**/*.a
 **/.DS_Store
 **/node_modules/
 .idea

--- a/Binaries/Packaging/PackageForOBS.sh
+++ b/Binaries/Packaging/PackageForOBS.sh
@@ -51,9 +51,9 @@ cd $CUR_DIR/opensuse-build-service/gdevelop
 tar zxf gdevelop_$GD_VERSION.orig.tar.gz
 echo "[OK]"
 
-#We need to include ExtLibs/SFML.7z and ExtLibs/boost.7z because buildbot do not have access to internet
+#We need to include ExtLibs/SFML.7z because the buildbot do not have access to internet
 printf " Copying SFML archive... "
-cp $GD_BASE_DIR/ExtLibs/SFML.7z gdevelop-$GD_VERSION/ExtLibs/
+cp -rf $GD_BASE_DIR/ExtLibs/SFML gdevelop-$GD_VERSION/ExtLibs/
 echo "[OK]"
 
 #Recreate the tar.gz with the added sources

--- a/ExtLibs/CMakeLists.txt
+++ b/ExtLibs/CMakeLists.txt
@@ -1,13 +1,44 @@
+#Clone SFML from its official directory using Git
+find_package(Git)
+if(GIT_FOUND)
+	message( "Cloning SFML in ExtLibs/SFML with Git..." )
+	execute_process(
+		COMMAND ${GIT_EXECUTABLE} clone "https://www.github.com/SFML/SFML.git" SFML
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+		ERROR_QUIET
+		OUTPUT_QUIET)
+
+	message( "Resetting SFML source code to version 2.4.1..." )
+	execute_process(
+		COMMAND ${GIT_EXECUTABLE} reset --hard 2.4.1
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/SFML
+		ERROR_QUIET
+		OUTPUT_QUIET)
+
+	message( "Applying the patches..." )
+	file(GLOB SFML_PATCHES
+     	LIST_DIRECTORIES FALSE
+		${CMAKE_CURRENT_SOURCE_DIR}/SFML-patches/*.patch)
+
+	if(SFML_PATCHES)
+		list(SORT SFML_PATCHES)
+
+		foreach(SFML_PATCH ${SFML_PATCHES})
+			message( "Applying patch: ${SFML_PATCH}..." )
+			execute_process(
+				COMMAND ${GIT_EXECUTABLE} apply ${SFML_PATCH}
+				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/SFML
+				ERROR_QUIET
+				OUTPUT_QUIET)
+		endforeach()
+	endif()
+else()
+	message( "Git not found, make sure you have SFML >= 2.4 in ExtLibs/SFML and you applied the needed patches (from ExtLibs/SFML-patches)!" )
+endif()
 
 #SFML:
-IF(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/SFML")
-	message( "Downloading SFML... (can take a bit of time, be patient)" )
-	execute_process(COMMAND curl -o SFML.7z http://www.compilgames.net/code/GameDevelopSDK/SFML.7z -\# WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ )
-	message( "Extracting SFML in ExtLibs/SFML... (can take a bit of time, be patient)" )
-	execute_process(COMMAND 7za x -y SFML.7z WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ OUTPUT_QUIET)
-ENDIF()
 IF(NOT EMSCRIPTEN) #Don't build SFML binaries when compiling with emscripten (but keep include files!)
-	ADD_SUBDIRECTORY(SFML)
+	add_subdirectory(SFML)
 	set(sfml_lib_dir ${CMAKE_BINARY_DIR}/ExtLibs/SFML/lib PARENT_SCOPE)
 	set(sfml_LIBRARIES sfml-audio sfml-graphics sfml-window sfml-network sfml-system)
 	IF(WIN32)

--- a/ExtLibs/SFML-patches/01_GCC_5_and_6_sse2.patch
+++ b/ExtLibs/SFML-patches/01_GCC_5_and_6_sse2.patch
@@ -1,0 +1,19 @@
+diff --git a/extlibs/headers/stb_image/stb_image.h b/extlibs/headers/stb_image/stb_image.h
+index c3945c2..5fe1050 100644
+--- a/extlibs/headers/stb_image/stb_image.h
++++ b/extlibs/headers/stb_image/stb_image.h
+@@ -671,14 +671,9 @@ static int stbi__sse2_available()
+ 
+ static int stbi__sse2_available()
+ {
+-#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 // GCC 4.8 or later
+-   // GCC 4.8+ has a nice way to do this
+-   return __builtin_cpu_supports("sse2");
+-#else
+    // portable way to do this, preferably without using GCC inline ASM?
+    // just bail for now.
+    return 0;
+-#endif
+ }
+ #endif
+ #endif

--- a/ExtLibs/SFML-patches/02_workaround_OSX_crash_SFViewController.patch
+++ b/ExtLibs/SFML-patches/02_workaround_OSX_crash_SFViewController.patch
@@ -1,0 +1,16 @@
+diff --git a/ExtLibs/SFML/src/SFML/Window/OSX/SFViewController.mm b/ExtLibs/SFML/src/SFML/Window/OSX/SFViewController.mm
+index 7d736e3..113cacd 100644
+--- a/ExtLibs/SFML/src/SFML/Window/OSX/SFViewController.mm
++++ b/ExtLibs/SFML/src/SFML/Window/OSX/SFViewController.mm
+@@ -82,8 +82,11 @@ -(id)initWithView:(NSView *)view
+ ////////////////////////////////////////////////////////
+ -(void)dealloc
+ {
++    NSLog(@"SFViewController::dealloc called on %@", self);
+     [self closeWindow];
+ 
++    // See https://github.com/SFML/SFML/issues/824
++    [[NSNotificationCenter defaultCenter] removeObserver:m_oglView];
+     [m_view release];
+     [m_oglView release];
+ 

--- a/Extensions/ParticleSystem/ParticleEmitterObject.cpp
+++ b/Extensions/ParticleSystem/ParticleEmitterObject.cpp
@@ -368,10 +368,10 @@ void ParticleEmitterBase::CreateParticleSystem()
 	{
 	    SPK::GL::GLQuadRenderer * quadRenderer = new SPK::GL::GLQuadRenderer(rendererParam1,rendererParam2);
 
-        if ( particleSystem->openGLTextureParticle && particleSystem->openGLTextureParticle->GetOpenGLTexture() != 0 )
+        if ( particleSystem->textureParticle )
         {
             quadRenderer->setTexturingMode(SPK::TEXTURE_2D);
-            quadRenderer->setTexture(particleSystem->openGLTextureParticle->GetOpenGLTexture());
+            quadRenderer->setTexture(particleSystem->textureParticle->texture.getNativeHandle());
         }
 
         particleSystem->renderer = quadRenderer;
@@ -759,15 +759,15 @@ void ParticleEmitterBase::SetTexture( RuntimeScene & scene, const gd::String & t
     if ( particleSystem && rendererType == Quad )
     {
         //Load new texture
-        particleSystem->openGLTextureParticle = scene.GetImageManager()->GetOpenGLTexture(textureParticleName);
+        particleSystem->textureParticle = scene.GetImageManager()->GetSFMLTexture(textureParticleName);
 
 	    //Notify the renderer of the change
 	    SPK::GL::GLQuadRenderer * quadRenderer = dynamic_cast<SPK::GL::GLQuadRenderer*>(particleSystem->renderer);
 
-        if ( quadRenderer && particleSystem->openGLTextureParticle->GetOpenGLTexture() != 0 )
+        if ( quadRenderer )
         {
             quadRenderer->setTexturingMode(SPK::TEXTURE_2D);
-            quadRenderer->setTexture(particleSystem->openGLTextureParticle->GetOpenGLTexture());
+            quadRenderer->setTexture(particleSystem->textureParticle->texture.getNativeHandle());
         }
     }
 }

--- a/Extensions/ParticleSystem/ParticleSystemWrapper.cpp
+++ b/Extensions/ParticleSystem/ParticleSystemWrapper.cpp
@@ -42,7 +42,7 @@ ParticleSystemWrapper::~ParticleSystemWrapper()
 
 void ParticleSystemWrapper::Init(const ParticleSystemWrapper & other)
 {
-    openGLTextureParticle = other.openGLTextureParticle;
+    textureParticle = other.textureParticle;
     if ( particleSystem ) delete particleSystem;
     if ( particleModel ) delete particleModel;
     if ( emitter ) delete emitter;
@@ -68,4 +68,3 @@ void ParticleSystemWrapper::Init(const ParticleSystemWrapper & other)
     particleSystem->removeGroup(other.group);
     particleSystem->addGroup(group);
 }
-

--- a/Extensions/ParticleSystem/ParticleSystemWrapper.h
+++ b/Extensions/ParticleSystem/ParticleSystemWrapper.h
@@ -9,7 +9,7 @@ This project is released under the MIT License.
 #define PARTICLESYSTEMWRAPPER_H
 
 #include <memory>
-class OpenGLTextureWrapper;
+class SFMLTextureWrapper;
 
 namespace SPK
 {
@@ -57,7 +57,7 @@ class GD_EXTENSION_API ParticleSystemWrapper
         SPK::Sphere * zone;
         SPK::Group * group;
         SPK::GL::GLRenderer * renderer;
-        std::shared_ptr<OpenGLTextureWrapper> openGLTextureParticle;
+        std::shared_ptr<SFMLTextureWrapper> textureParticle;
 
     private:
         void Init(const ParticleSystemWrapper & other);
@@ -66,4 +66,3 @@ class GD_EXTENSION_API ParticleSystemWrapper
 };
 
 #endif // PARTICLESYSTEMWRAPPER_H
-

--- a/GDCpp/GDCpp/IDE/CodeCompiler.cpp
+++ b/GDCpp/GDCpp/IDE/CodeCompiler.cpp
@@ -188,11 +188,11 @@ gd::String CodeCompilerCall::GetFullCall() const
         args.push_back("\""+baseDir+"libsfml-window.dylib\"");
         args.push_back("\""+baseDir+"libsfml-system.dylib\"");
         #else
-        args.push_back("\""+baseDir+"libsfml-audio.so.2\"");
-        args.push_back("\""+baseDir+"libsfml-network.so.2\"");
-        args.push_back("\""+baseDir+"libsfml-graphics.so.2\"");
-        args.push_back("\""+baseDir+"libsfml-window.so.2\"");
-        args.push_back("\""+baseDir+"libsfml-system.so.2\"");
+        args.push_back("\""+baseDir+"libsfml-audio.so.2.4\"");
+        args.push_back("\""+baseDir+"libsfml-network.so.2.4\"");
+        args.push_back("\""+baseDir+"libsfml-graphics.so.2.4\"");
+        args.push_back("\""+baseDir+"libsfml-window.so.2.4\"");
+        args.push_back("\""+baseDir+"libsfml-system.so.2.4\"");
         #endif
         #elif defined(DEBUG)
         #if defined(WINDOWS)
@@ -208,11 +208,11 @@ gd::String CodeCompilerCall::GetFullCall() const
         args.push_back("\""+baseDir+"libsfml-window.dylib\"");
         args.push_back("\""+baseDir+"libsfml-system.dylib\"");
         #else
-        args.push_back("\""+baseDir+"libsfml-audio-d.so.2\"");
-        args.push_back("\""+baseDir+"libsfml-network-d.so.2\"");
-        args.push_back("\""+baseDir+"libsfml-graphics-d.so.2\"");
-        args.push_back("\""+baseDir+"libsfml-window-d.so.2\"");
-        args.push_back("\""+baseDir+"libsfml-system-d.so.2\"");
+        args.push_back("\""+baseDir+"libsfml-audio-d.so.2.4\"");
+        args.push_back("\""+baseDir+"libsfml-network-d.so.2.4\"");
+        args.push_back("\""+baseDir+"libsfml-graphics-d.so.2.4\"");
+        args.push_back("\""+baseDir+"libsfml-window-d.so.2.4\"");
+        args.push_back("\""+baseDir+"libsfml-system-d.so.2.4\"");
         #endif
         #endif
         for (std::size_t i = 0;i<extraLibFiles.size();++i)

--- a/IDE/scripts/copyLinuxLibraries.sh
+++ b/IDE/scripts/copyLinuxLibraries.sh
@@ -14,12 +14,12 @@ SYS_LIB_DIR2=/lib/x86_64-linux-gnu/
 if [ -d $SFML_LIB_DIR ]; then
 	echo "Copying SFML files to '$DESTINATION'..."
 
-	cp "$SFML_LIB_DIR"/libsfml-audio.so.2.1 "$SFML_LIB_DIR"/libsfml-network.so.2.1 "$SFML_LIB_DIR"/libsfml-graphics.so.2.1 "$SFML_LIB_DIR"/libsfml-window.so.2.1 "$SFML_LIB_DIR"/libsfml-system.so.2.1 "$DESTINATION"/
-	mv "$DESTINATION"/libsfml-audio.so.2.1 "$DESTINATION"/libsfml-audio.so.2
-	mv "$DESTINATION"/libsfml-network.so.2.1 "$DESTINATION"/libsfml-network.so.2
-	mv "$DESTINATION"/libsfml-graphics.so.2.1 "$DESTINATION"/libsfml-graphics.so.2
-	mv "$DESTINATION"/libsfml-window.so.2.1 "$DESTINATION"/libsfml-window.so.2
-	mv "$DESTINATION"/libsfml-system.so.2.1 "$DESTINATION"/libsfml-system.so.2
+	cp "$SFML_LIB_DIR"/libsfml-audio.so.2.4 "$SFML_LIB_DIR"/libsfml-network.so.2.4 "$SFML_LIB_DIR"/libsfml-graphics.so.2.4 "$SFML_LIB_DIR"/libsfml-window.so.2.4 "$SFML_LIB_DIR"/libsfml-system.so.2.4 "$DESTINATION"/
+	#mv "$DESTINATION"/libsfml-audio.so.2.4 "$DESTINATION"/libsfml-audio.so.2
+	#mv "$DESTINATION"/libsfml-network.so.2.4 "$DESTINATION"/libsfml-network.so.2
+	#mv "$DESTINATION"/libsfml-graphics.so.2.4 "$DESTINATION"/libsfml-graphics.so.2
+	#mv "$DESTINATION"/libsfml-window.so.2.4 "$DESTINATION"/libsfml-window.so.2
+	#mv "$DESTINATION"/libsfml-system.so.2.4 "$DESTINATION"/libsfml-system.so.2
 else
 	echo "SFML lib files not found in '$SFML_LIB_DIR', skipping it..."
 fi


### PR DESCRIPTION
By using ```sf::Texture::getNativeHandle()```.

However, it needs SFML 2.3 at least, so I've updated SFML to 2.4.1. SFML is now embedded into the repository so it's more easier to track its updates (we are sure that everybody has the good SFML version and it's also easier for build workers as they wouldn't have been able to update SFML by themselves).

*In fact, I've been building GDevelop with SFML 2.3.1 for months on my computer, that's why I first fixed the bug by use a SFML >= 2.3 feature).*