### PR TITLE
Fix FileStream constructor on OS X

### DIFF
--- a/Core/GDCore/Tools/FileStream.cpp
+++ b/Core/GDCore/Tools/FileStream.cpp
@@ -59,7 +59,8 @@ FileStream::InternalBufferType* OpenBuffer(const gd::String & path, std::ios_bas
 
 }
 
-FileStream::FileStream()
+FileStream::FileStream() :
+	std::iostream(nullptr)
 {
 
 }


### PR DESCRIPTION
@victorlevasseur I had error while compiling on OS X with the new FileStream and I think you forgot to fix a constructor.
With this PR it seems to work properly (I can compile, open a game, export it, not tested much more). Can you tell me if this looks good to you? I'll merge it then. :)