### PR TITLE
Fix 3D Box blending with textures with fully transparent pixels

### DIFF
--- a/Extensions/Box3DObject/Box3DObject.cpp
+++ b/Extensions/Box3DObject/Box3DObject.cpp
@@ -139,9 +139,11 @@ bool RuntimeBox3DObject::Draw( sf::RenderTarget& window )
     glTranslatef(-sizeWidth/2, -sizeHeight/2, -sizeDepth/2);
 
     //Render the box
+    glAlphaFunc(GL_GREATER, 0.0);
+    glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glEnable(GL_ALPHA_TEST);
     glEnable(GL_BLEND);
     glEnable(GL_TEXTURE_2D);
-    glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     sf::Texture::bind(&backTexture->texture);
     glBegin(GL_QUADS);
@@ -190,6 +192,8 @@ bool RuntimeBox3DObject::Draw( sf::RenderTarget& window )
         glTexCoord2f(1, 0); glVertex3f(sizeWidth,   sizeHeight, 0);
         glTexCoord2f(1, 1); glVertex3f(sizeWidth,   sizeHeight, sizeDepth);
     glEnd();
+
+    glDisable(GL_ALPHA_TEST);
 
     window.pushGLStates();
 
@@ -269,9 +273,11 @@ void Box3DObject::DrawInitialInstance(gd::InitialInstance & instance, sf::Render
     glTranslatef(-sizeWidth/2, -sizeHeight/2, -sizeDepth/2);
 
     //Render the box
+    glAlphaFunc(GL_GREATER, 0.0);
+    glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glEnable(GL_ALPHA_TEST);
     glEnable(GL_BLEND);
     glEnable(GL_TEXTURE_2D);
-    glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     sf::Texture::bind(&backTexture->texture);
     glBegin(GL_QUADS);
@@ -320,6 +326,8 @@ void Box3DObject::DrawInitialInstance(gd::InitialInstance & instance, sf::Render
         glTexCoord2f(1, 0); glVertex3f(sizeWidth,   sizeHeight, 0);
         glTexCoord2f(1, 1); glVertex3f(sizeWidth,   sizeHeight, sizeDepth);
     glEnd();
+
+    glDisable(GL_ALPHA_TEST);
 
     renderTarget.pushGLStates();
 }


### PR DESCRIPTION
Use the OpenGL alpha testing to discard the drawing of fully transparent pixels of 3D box textures. However, this method doesn't work for semi-transparent pixels that would require a manual ordering of box sides combined with some advanced rendering method.