### PR TITLE
Displayed a warning if the selected instruction is not available in one of the game's platforms

### DIFF
--- a/IDE/InstructionSelectorDialog.h
+++ b/IDE/InstructionSelectorDialog.h
@@ -68,6 +68,7 @@ public:
 	wxNotebook* objectsListsNotebook;
 	wxSearchCtrl* objectsSearchCtrl;
 	wxStaticText* instructionDescriptionTxt;
+	wxStaticText* notAvailableWarningTxt;
 	wxHyperlinkCtrl* instructionHelpLinkCtrl;
 	wxCheckBox* objSortCheck;
 	wxTreeCtrl* instructionsTree;


### PR DESCRIPTION
To warn the user that the instruction will be ignored in at least one platform that the project uses (that is not the current one as the instruction would have been hidden).