### PR TITLE
Fix Text Entry crash on HTML5

### DIFF
--- a/Extensions/TextEntryObject/textentryruntimeobject.js
+++ b/Extensions/TextEntryObject/textentryruntimeobject.js
@@ -56,3 +56,11 @@ gdjs.TextEntryRuntimeObject.prototype.activate = function(enable) {
     this._activated = enable;
     this._renderer.activate(this._activated);
 };
+
+gdjs.TextEntryRuntimeObject.prototype.setLayer = function(layer) {
+     // No renderable object
+};
+
+gdjs.TextEntryRuntimeObject.prototype.setZOrder = function(z) {
+     // No renderable object
+};


### PR DESCRIPTION
As the text entry object has no real renderable object, PIXI (only tested this renderer) crash trying to set the renderable object on Z-Order and Layer updates, a better solution is welcomed :)