### PR TITLE
Fixed link to GDevelop.js

### DIFF
--- a/newIDE/README.md
+++ b/newIDE/README.md
@@ -1,7 +1,7 @@
 # GDevelop IDE
 
 This is a new, revamped editor for GDevelop. It is based on [React](https://facebook.github.io/react/), [Material-UI](http://www.material-ui.com), [Pixi.js](https://github.com/pixijs/pixi.js) and [Electron](https://electron.atom.io/).
-It uses GDevelop [core C++ classes compiled to Javascript](github.com/4ian/GDevelop.js) to work with GDevelop games.
+It uses GDevelop [core C++ classes compiled to Javascript](https://github.com/4ian/GDevelop.js) to work with GDevelop games.
 
 ![GDevelop editor](https://raw.githubusercontent.com/4ian/GD/master/newIDE/gd-ide-screenshot.png "GDevelop editor")
 


### PR DESCRIPTION
The link to [core C++ classes compiled to Javascript](https://github.com/4ian/GDevelop.js) has been fixed as it lead to a 404.