### PR TITLE
XCOPY hotfix

### DIFF
--- a/GDJS/scripts/CopyRuntimeToGD.bat
+++ b/GDJS/scripts/CopyRuntimeToGD.bat
@@ -8,7 +8,7 @@ set destDir=%1
 if "%destDir%"=="" set destDir="..\..\Binaries\Output\Release_Windows\JsPlatform\Runtime"
 
 echo Copying GDJS and extensions runtime files (*.js) to %destDir%...
-xcopy ..\Runtime\* %destDir%\* /S /E  /D /Y /Q
-xcopy ..\..\Extensions\*.js %destDir%\Extensions\*.js /S /E  /D /Y /Q /EXCLUDE:FilesExcludedFromCopy
+xcopy "..\Runtime"\* "%destDir%"\* /S /E  /D /Y /Q
+xcopy "..\..\Extensions"\*.js "%destDir%\Extensions"\*.js /S /E  /D /Y /Q /EXCLUDE:FilesExcludedFromCopy
 
 echo ✅ Copied GDJS and extensions runtime files (*.js) to '%destDir%'.


### PR DESCRIPTION
In my PC xcopy crashes with an "Invalid number of parameters" error, these changes shouldn't break already working environments