### PR TITLE
new action/condition popup-put focus on search box

### DIFF
--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorDialog.js
@@ -35,7 +35,7 @@ export default class InstructionEditorDialog extends React.Component {
       <FlatButton
         label="Ok"
         primary={true}
-        //keyboardFocused={true}
+        keyboardFocused={false}
         onTouchTap={this.props.onSubmit}
       />,
     ];

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorDialog.js
@@ -35,7 +35,7 @@ export default class InstructionEditorDialog extends React.Component {
       <FlatButton
         label="Ok"
         primary={true}
-        keyboardFocused={true}
+        //keyboardFocused={true}
         onTouchTap={this.props.onSubmit}
       />,
     ];

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionTypeSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionTypeSelector.js
@@ -218,7 +218,7 @@ export class InstructionTypeSelector extends Component {
   //// autofocus on search
   componentDidMount() {
     this._searchBar.focus();
-    };
+  };
 
   render() {
     return (

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionTypeSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionTypeSelector.js
@@ -215,7 +215,6 @@ export class InstructionTypeSelector extends Component {
     });
   };
 
-  //// autofocus on search
   componentDidMount() {
     this._searchBar.focus();
   };

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionTypeSelector.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionTypeSelector.js
@@ -215,6 +215,11 @@ export class InstructionTypeSelector extends Component {
     });
   };
 
+  //// autofocus on search
+  componentDidMount() {
+    this._searchBar.focus();
+    };
+
   render() {
     return (
       <div style={this.props.style}>


### PR DESCRIPTION
...rather than the ok button. The first thing a user would do when adding a new action or condition would be to search for it.
This should save a few million mouse clicks :)

I tried to add it with minimal changes to the code. Hope the style is ok

I am studying how you wrote this and learning reactjs as I go along. Thought this would be a useful usability change