### PR TITLE
Bind Ctrl+Z/Ctrl+Y to undo/redo actions in scene editor

### DIFF
--- a/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
+++ b/Core/GDCore/IDE/Dialogs/LayoutEditorCanvas/LayoutEditorCanvas.cpp
@@ -1253,6 +1253,24 @@ void LayoutEditorCanvas::OnKey( wxKeyEvent& evt )
 
         eventIsOnlyForMe = true;
     }
+    else if ( evt.GetModifiers() == wxMOD_CMD ) //Ctrl-xxx
+    {
+        switch ( evt.GetKeyCode() )
+        {
+            case 89: //Ctrl-Y
+            {
+                Redo();
+                break;
+            }
+            case 90: //Ctrl-Z
+            {
+                Undo();
+                break;
+            }
+            default:
+                break;
+        }
+    }
 
     if (eventIsOnlyForMe)
         evt.StopPropagation();


### PR DESCRIPTION
Undo/redo actions can be carried out through the Ctrl+Z/Ctrl+Y keyboard shortcuts in the layout editor canvas.
Code from the events editor has been reused, which provides the same functionality.

Question: is it fine to make pull requests for features this small, or would you rather like the community to provide suggestions on the forums, since reviewing the requests is comparable in effort to writing the code yourself, 4ian?