### PR TITLE
Run CopyRuntimeToGD.sh with bash explicitly

### DIFF
--- a/GDJS/CMakeLists.txt
+++ b/GDJS/CMakeLists.txt
@@ -103,7 +103,7 @@ ELSE()
 	ELSE()
 		add_custom_target(GDJS_Runtime
 			ALL
-			COMMAND sh "CopyRuntimeToGD.sh" ${GD_base_dir}/Binaries/Output/${CMAKE_BUILD_TYPE}_${CMAKE_SYSTEM_NAME}/JsPlatform/Runtime
+			COMMAND bash "CopyRuntimeToGD.sh" ${GD_base_dir}/Binaries/Output/${CMAKE_BUILD_TYPE}_${CMAKE_SYSTEM_NAME}/JsPlatform/Runtime
 			WORKING_DIRECTORY ${GD_base_dir}/GDJS/scripts)
 	ENDIF()
 ENDIF()

--- a/GDJS/scripts/CopyRuntimeToGD.sh
+++ b/GDJS/scripts/CopyRuntimeToGD.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #Get the destination, or copy by default to release directory
 DESTINATION=../../Binaries/Output/Release_Linux/JsPlatform/Runtime/
 if [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
The script contains bashisms which failed on systems, where sh is
symlinked to dash instead of bash.