### PR TITLE
GDJS: store global volume value in HowlerSoundManager

### DIFF
--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.js
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.js
@@ -75,6 +75,8 @@ gdjs.HowlerSoundManager = function(resources)
     this._resources = resources;
     this._availableResources = {}; //Map storing "audio" resources for faster access.
 
+    this._globalVolume = 100;
+
     this._sounds = {};
     this._musics = {};
     this._freeSounds = []; //Sounds without an assigned channel.
@@ -268,11 +270,14 @@ gdjs.HowlerSoundManager.prototype.getMusicOnChannel = function(channel) {
 };
 
 gdjs.HowlerSoundManager.prototype.setGlobalVolume = function(volume) {
-	Howler.volume(volume/100);
+	this._globalVolume = volume;
+	if (this._globalVolume > 100) this._globalVolume = 100;
+	if (this._globalVolume < 0) this._globalVolume = 0;
+	Howler.volume(this._globalVolume/100);
 };
 
 gdjs.HowlerSoundManager.prototype.getGlobalVolume = function() {
-	return Howler.volume()*100;
+	return this._globalVolume;
 };
 
 gdjs.HowlerSoundManager.prototype.clearAll = function() {


### PR DESCRIPTION
Every programmer knows why 0.01 - 0.01 may not equal 0.
However, not eveyone knows why 1 - 1 may not equal 0 :)

As GDevelop uses values 0-100 for its global volume, it's easy
to encounter floating point inaccuracy problems while doing trivial
things like a loop that decrements 1 from the global volume.

I think a chance for a non-programmer to figure out why 1 - 1 is
not 0 is actually 0, so let's work on integers to remove the confussion.