### PR TITLE
Add mouse button input support to Scene editor

### DIFF
--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -52,9 +52,9 @@ export default class InstancesEditorContainer extends Component {
       if (this.keyboardShortcuts.shouldZoom()) {
         this.zoomBy(event.wheelDelta / 5000);
       } else if (this.keyboardShortcuts.shouldScrollHorizontally()) {
-        this.viewPosition.scrollBy(-event.wheelDelta / 20, 0);
+        this.viewPosition.scrollBy(-event.wheelDelta / 10, 0);
       } else {
-        this.viewPosition.scrollBy(0, -event.wheelDelta / 20);
+        this.viewPosition.scrollBy(event.deltaX / 10, event.deltaY / 10);
       }
 
       if (this.props.onViewPositionChanged) {

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -129,8 +129,8 @@ export default class KeyboardShortcuts {
       this.onRedo();
     }
 
-    if (isMacLike() == true) //Mac specific shortcuts -- zooming done differently on windows and linux
-    {
+    if (isMacLike()) {
+      //Mac specific shortcuts -- zooming done differently on windows and linux
       if (this._isControlPressed() && evt.which === MINUS_KEY) {
         this.onZoomOut();
       }
@@ -159,34 +159,29 @@ export default class KeyboardShortcuts {
   _onMouseDown = evt => {
     if (!this.isFocused) return;
 
-    if (isMacLike() == false) {
-      if (evt.button == MID_MOUSE_BUTTON) {
-        this.mouseMidButtonPressed = true;
-      };
-    };
+    if (!isMacLike() && evt.button === MID_MOUSE_BUTTON) {
+      this.mouseMidButtonPressed = true;
+    }
   };
 
   _onMouseUp = evt => {
     if (!this.isFocused) return;
 
-    if (isMacLike() == false) {
-      if (evt.button == MID_MOUSE_BUTTON){
-        this.mouseMidButtonPressed = false;
-      };
-    };
+    if (!isMacLike() && evt.button === MID_MOUSE_BUTTON) {
+      this.mouseMidButtonPressed = false;
+    }
   };
 
   _onMouseScroll = evt => {
     if (!this.isFocused) return;
 
-    if (isMacLike() == false) {
+    if (!isMacLike()) {
       if (evt.deltaY > 0) {
         this.onZoomOut();
-      }
-      else {
+      } else {
         this.onZoomIn();
-      };
-    };
+      }
+    }
   };
 
   _onKeyPress = evt => {};

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -1,3 +1,5 @@
+import { isMacLike } from '../../Utils/Platform';
+
 const CTRL_KEY = 17;
 const SHIFT_KEY = 16;
 const LEFT_KEY = 37;
@@ -42,8 +44,7 @@ export default class KeyboardShortcuts {
     this.isFocused = false;
     this.shiftPressed = false;
     this.rawCtrlPressed = false;
-    this.metaPressed = false;
-
+    this.metaPressed = false;    
     this.mount();
   }
 
@@ -125,19 +126,22 @@ export default class KeyboardShortcuts {
     if (this._isControlPressed() && evt.which === Y_KEY) {
       this.onRedo();
     }
-    if (this._isControlPressed() && evt.which === MINUS_KEY) {
-      this.onZoomOut();
-    }
-    if (this._isControlPressed() && evt.which === EQUAL_KEY) {
-      this.onZoomIn();
-    }
-    if (evt.which === NUMPAD_SUBSTRACT) {
-      this.onZoomOut();
-    }
-    if (evt.which === NUMPAD_ADD) {
-      this.onZoomIn();
-    }
 
+    if (isMacLike() == true) //Mac specific shortcuts -- zooming done differently on windows and linux
+    {
+      if (this._isControlPressed() && evt.which === MINUS_KEY) {
+        this.onZoomOut();
+      }
+      if (this._isControlPressed() && evt.which === EQUAL_KEY) {
+        this.onZoomIn();
+      }
+      if (evt.which === NUMPAD_SUBSTRACT) {
+        this.onZoomOut();
+      }
+      if (evt.which === NUMPAD_ADD) {
+        this.onZoomIn();
+      }
+    }
   };
 
   _onKeyUp = evt => {
@@ -152,28 +156,34 @@ export default class KeyboardShortcuts {
 
   _onMouseDown = evt => { 
     if (!this.isFocused) return;
-    
-    if (evt.button == MID_MOUSE_BUTTON){
-      this.spacePressed = true;
+
+    if (isMacLike() == false) {
+      if (evt.button == MID_MOUSE_BUTTON) {
+        this.spacePressed = true;
+      };
     };
   };
 
   _onMouseUp = evt => {
     if (!this.isFocused) return;
-    
-    if (evt.button == MID_MOUSE_BUTTON){
-      this.spacePressed = false;
+
+    if (isMacLike() == false) {
+      if (evt.button == MID_MOUSE_BUTTON){
+        this.spacePressed = false;
+      };
     };
   };
 
   _onMouseScroll = evt => {
     if (!this.isFocused) return;
     
-    if (evt.deltaY > 0) {
-      this.onZoomOut();
-    }
-    else {
-      this.onZoomIn();
+    if (isMacLike() == false) {
+      if (evt.deltaY > 0) {
+        this.onZoomOut();
+      }
+      else {
+        this.onZoomIn();
+      };
     };
   };
   

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -44,7 +44,9 @@ export default class KeyboardShortcuts {
     this.isFocused = false;
     this.shiftPressed = false;
     this.rawCtrlPressed = false;
-    this.metaPressed = false;    
+    this.metaPressed = false;
+    this.spacePressed = false;
+    this.mouseMidButtonPressed = false;
     this.mount();
   }
 
@@ -73,7 +75,7 @@ export default class KeyboardShortcuts {
   }
 
   shouldMoveView() {
-    return this.spacePressed;
+    return this.spacePressed || this.mouseMidButtonPressed;
   }
 
   _isControlPressed = () => {
@@ -91,7 +93,7 @@ export default class KeyboardShortcuts {
 
     const textEditorSelectors = 'textarea, input, [contenteditable="true"]';
     if (evt.target && evt.target.closest(textEditorSelectors)) {
-      return; // Something else is currently being edited. 
+      return; // Something else is currently being edited.
     }
 
     if (this.onMove) {
@@ -154,12 +156,12 @@ export default class KeyboardShortcuts {
     if (evt.which === SPACE_KEY) this.spacePressed = false;
   };
 
-  _onMouseDown = evt => { 
+  _onMouseDown = evt => {
     if (!this.isFocused) return;
 
     if (isMacLike() == false) {
       if (evt.button == MID_MOUSE_BUTTON) {
-        this.spacePressed = true;
+        this.mouseMidButtonPressed = true;
       };
     };
   };
@@ -169,14 +171,14 @@ export default class KeyboardShortcuts {
 
     if (isMacLike() == false) {
       if (evt.button == MID_MOUSE_BUTTON){
-        this.spacePressed = false;
+        this.mouseMidButtonPressed = false;
       };
     };
   };
 
   _onMouseScroll = evt => {
     if (!this.isFocused) return;
-    
+
     if (isMacLike() == false) {
       if (evt.deltaY > 0) {
         this.onZoomOut();
@@ -186,7 +188,7 @@ export default class KeyboardShortcuts {
       };
     };
   };
-  
+
   _onKeyPress = evt => {};
 
   _noop = () => {};

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -16,6 +16,7 @@ const V_KEY = 86;
 const X_KEY = 88;
 const Y_KEY = 89;
 const Z_KEY = 90;
+const MID_MOUSE_BUTTON = 1;
 
 export default class KeyboardShortcuts {
   constructor({
@@ -81,7 +82,6 @@ export default class KeyboardShortcuts {
 
   _onKeyDown = evt => {
     if (!this.isFocused) return;
-
     if (evt.metaKey) this.metaPressed = true;
     if (evt.altKey) this.altPressed = true;
     if (evt.which === CTRL_KEY) this.rawCtrlPressed = true;
@@ -90,7 +90,7 @@ export default class KeyboardShortcuts {
 
     const textEditorSelectors = 'textarea, input, [contenteditable="true"]';
     if (evt.target && evt.target.closest(textEditorSelectors)) {
-      return; // Something else is currently being edited.
+      return; // Something else is currently being edited. 
     }
 
     if (this.onMove) {
@@ -137,6 +137,7 @@ export default class KeyboardShortcuts {
     if (evt.which === NUMPAD_ADD) {
       this.onZoomIn();
     }
+
   };
 
   _onKeyUp = evt => {
@@ -149,6 +150,27 @@ export default class KeyboardShortcuts {
     if (evt.which === SPACE_KEY) this.spacePressed = false;
   };
 
+  _onMouseDown = evt => { 
+    if (evt.button == MID_MOUSE_BUTTON){
+      this.spacePressed = true;
+    };
+  };
+
+  _onMouseUp = evt => {
+    if (evt.button == MID_MOUSE_BUTTON){
+      this.spacePressed = false;
+    };
+  };
+
+  _onMouseScroll = evt => {
+    if (evt.deltaY > 0) {
+      this.onZoomOut();
+    }
+    else {
+      this.onZoomIn();
+    };
+  };
+  
   _onKeyPress = evt => {};
 
   _noop = () => {};
@@ -167,6 +189,9 @@ export default class KeyboardShortcuts {
     document.addEventListener('keydown', this._onKeyDown, true);
     document.addEventListener('keyup', this._onKeyUp, true);
     document.addEventListener('keypress', this._onKeyPress, true);
+    document.addEventListener('mousedown', this._onMouseDown, true);
+    document.addEventListener('mouseup', this._onMouseUp, true);
+    document.addEventListener('wheel', this._onMouseScroll, true);
   }
 
   unmount() {
@@ -175,5 +200,8 @@ export default class KeyboardShortcuts {
     document.removeEventListener('keydown', this._onKeyDown, true);
     document.removeEventListener('keyup', this._onKeyUp, true);
     document.removeEventListener('keypress', this._onKeyPress, true);
+    document.removeEventListener('mousedown', this._onMouseDown, true);
+    document.removeEventListener('mouseup', this._onMouseUp, true);
+    document.removeEventListener('wheel', this._onMouseScroll, true);
   }
 }

--- a/newIDE/app/src/UI/KeyboardShortcuts/index.js
+++ b/newIDE/app/src/UI/KeyboardShortcuts/index.js
@@ -151,18 +151,24 @@ export default class KeyboardShortcuts {
   };
 
   _onMouseDown = evt => { 
+    if (!this.isFocused) return;
+    
     if (evt.button == MID_MOUSE_BUTTON){
       this.spacePressed = true;
     };
   };
 
   _onMouseUp = evt => {
+    if (!this.isFocused) return;
+    
     if (evt.button == MID_MOUSE_BUTTON){
       this.spacePressed = false;
     };
   };
 
   _onMouseScroll = evt => {
+    if (!this.isFocused) return;
+    
     if (evt.deltaY > 0) {
       this.onZoomOut();
     }


### PR DESCRIPTION
Using Standard navigation design present in other software: gimp, Krita, Inkscape, blender, etc
- Scrolling mouse to zoom in and out the view
- Mid click mouse to pan the view

Should make gdevelop easier to use and get into, since most people know these controls from other software.

Another advantage to that is that the user can pan and zoom in and out with only one hand

I have a few more ideas how to make the newIde more intuitive and fun to use ;)