### PR TITLE
Fix compilation error due to incomplete type.

### DIFF
--- a/Core/GDCore/IDE/wxTools/FileProperty.h
+++ b/Core/GDCore/IDE/wxTools/FileProperty.h
@@ -7,7 +7,6 @@
 #ifndef GDCORE_FILEPROPERTY_H
 #define GDCORE_FILEPROPERTY_H
 #include <wx/control.h>
-#include <wx/propgrid/property.h>
 #include <wx/propgrid/propgrid.h>
 #include <wx/propgrid/props.h>
 


### PR DESCRIPTION
Remove inclusion of wx/propgrid/property.h preceding
inclusion of wx/propgrid/propgrid.h to avoid incomplete type
error of object m_bitmap in property.h of type wxBitmap during build.
propgrid.h includes property.h anyway.