### PR TITLE
Resolve incomplete type wxBitmap issue

### DIFF
--- a/Core/GDCore/IDE/wxTools/FileProperty.h
+++ b/Core/GDCore/IDE/wxTools/FileProperty.h
@@ -6,7 +6,7 @@
 #if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
 #ifndef GDCORE_FILEPROPERTY_H
 #define GDCORE_FILEPROPERTY_H
-#include <wx/control.h>
+#include <wx/bitmap.h>
 #include <wx/propgrid/propgrid.h>
 #include <wx/propgrid/props.h>
 


### PR DESCRIPTION
Include wx/bitmap.h in FileProperty.h .
Remove redundant inclusion of wx/control.h .