### PR TITLE
Fix include order

### DIFF
--- a/Core/GDCore/Tools/SystemStats.cpp
+++ b/Core/GDCore/Tools/SystemStats.cpp
@@ -8,8 +8,8 @@
 #include "stdlib.h"
 #include "string.h"
 #if defined(WINDOWS)
-#include "psapi.h"
 #include "windows.h"
+#include "psapi.h"
 #endif
 
 namespace gd {


### PR DESCRIPTION
I have a compilation error otherwise, what do you think?
By the way, I was forced to add a -fpermissive flag to avoid (more warnings than real) compilation errors from wxWidget code.