### PR TITLE
Fix winapi define hiding wxWidgets function.

### DIFF
--- a/Core/GDCore/Project/LayoutEditorPreviewer.h
+++ b/Core/GDCore/Project/LayoutEditorPreviewer.h
@@ -1,6 +1,12 @@
 #ifndef LAYOUTEDITORPREVIEWER_H
 #define LAYOUTEDITORPREVIEWER_H
+
 #if defined(GD_IDE_ONLY) && !defined(GD_NO_WX_GUI)
+
+#ifdef __WINDOWS__
+    #include <wx/msw/winundef.h>
+#endif
+
 #include <wx/event.h>
 namespace gd {
 class LayoutEditorCanvas;


### PR DESCRIPTION
windows.h defines "Yield" to be empty, which invalidates the definition of wxThread::Yield().
winundef.h now undefs winapi defines where they caused a compile error.