### PR TITLE
Add ability to rename object from object editor

### DIFF
--- a/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
+++ b/newIDE/app/src/ObjectEditor/ObjectEditorDialog.js
@@ -8,10 +8,16 @@ import BehaviorsEditor from '../BehaviorsEditor';
 import { Tabs, Tab } from 'material-ui/Tabs';
 import { withSerializableObject } from '../Utils/SerializableObjectEditorContainer';
 
+import SemiControlledTextField from '../UI/SemiControlledTextField';
+
 const styles = {
   titleContainer: {
     padding: 0,
   },
+  objectTitle: {
+    left: "10px",
+    width:"available",
+  }
 };
 
 type StateType = {|
@@ -21,6 +27,7 @@ type StateType = {|
 export class ObjectEditorDialog extends Component<*, StateType> {
   state = {
     currentTab: 'properties',
+    newObjectName: this.props.objectName
   };
 
   _onChangeTab = (value: string) => {
@@ -47,7 +54,7 @@ export class ObjectEditorDialog extends Component<*, StateType> {
 
     const EditorComponent = this.props.editorComponent;
     const { currentTab } = this.state;
-
+    
     return (
       <Dialog
         key={this.props.object && this.props.object.ptr}
@@ -68,6 +75,18 @@ export class ObjectEditorDialog extends Component<*, StateType> {
         }
         titleStyle={styles.titleContainer}
       >
+      Object Name:
+      <SemiControlledTextField
+          style={styles.objectTitle}
+          commitOnBlur
+          value={this.state.newObjectName}
+          hintText="Object Name"
+          onChange={text => {
+            if (this.props.canRenameObject(text)){
+              this.setState({newObjectName:text})
+            }
+          }}
+        />
         {currentTab === 'properties' &&
           EditorComponent && (
             <EditorComponent
@@ -78,7 +97,6 @@ export class ObjectEditorDialog extends Component<*, StateType> {
               resourceExternalEditors={this.props.resourceExternalEditors}
               onSizeUpdated={() =>
                 this.forceUpdate() /*Force update to ensure dialog is properly positionned*/}
-              objectName={this.props.objectName}
             />
           )}
         {currentTab === 'behaviors' && (

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -60,7 +60,7 @@ class ObjectsList extends Component<*, *> {
 
   render() {
     let { height, width, fullList, project, selectedObjectName } = this.props;
-
+    
     return (
       <List
         ref={list => (this.list = list)}
@@ -312,7 +312,7 @@ export default class ObjectsListContainer extends React.Component<
     });
   };
 
-  _rename = (objectWithContext: ObjectWithContext, newName: string) => {
+  _rename = (objectWithContext: ObjectWithContext, newName: string) => { ///deprecate for the refactored function
     const { object } = objectWithContext;
     const { project, objectsContainer } = this.props;
 


### PR DESCRIPTION
This addresses these usability problems:
- Newly created objects can now be immediately named- creating a better rapid prototyping flow
- Currently edited objects show their name in the object editor

This checks if the object can use the new name when the input box loses focus. It applies the new name when the user actually clicks the apply button

TODO: 
- Possibly refactor the renaming of object  in the object list to use the checking function that I added to the index - should simplify code.
Will do that after getting some feedback
- Better styling for the input box