### PR TITLE
Add missing functions and bugfix for particles

### DIFF
--- a/Extensions/ParticleSystem/particleemitterobject-pixi-renderer.js
+++ b/Extensions/ParticleSystem/particleemitterobject-pixi-renderer.js
@@ -199,6 +199,10 @@ gdjs.ParticleEmitterObjectPixiRenderer.prototype.setColor = function(r1, g1, b1,
     this.emitter.startColor.value.r = r1;
     this.emitter.startColor.value.g = g1;
     this.emitter.startColor.value.b = b1;
+    this.emitter.startColor.next = this.emitter.startColor.next || {
+        time : 1,
+        value : {}
+    };
     this.emitter.startColor.next.value.r = r2;
     this.emitter.startColor.next.value.g = g2;
     this.emitter.startColor.next.value.b = b2;

--- a/Extensions/ParticleSystem/particleemitterobject.js
+++ b/Extensions/ParticleSystem/particleemitterobject.js
@@ -381,6 +381,24 @@ gdjs.ParticleEmitterObject.prototype.setParticleBlue2 = function(blue){
     }
 };
 
+gdjs.ParticleEmitterObject.prototype.setParticleColor1 = function(rgbColor){
+    var colors = rgbColor.split(";");
+    if ( colors.length < 3 ) return;
+
+    this.setParticleRed1(parseInt(colors[0]));
+    this.setParticleGreen1(parseInt(colors[1]));
+    this.setParticleBlue1(parseInt(colors[2]));
+};
+
+gdjs.ParticleEmitterObject.prototype.setParticleColor2 = function(rgbColor){
+    var colors = rgbColor.split(";");
+    if ( colors.length < 3 ) return;
+
+    this.setParticleRed2(parseInt(colors[0]));
+    this.setParticleGreen2(parseInt(colors[1]));
+    this.setParticleBlue2(parseInt(colors[2]));
+};
+
 gdjs.ParticleEmitterObject.prototype.getParticleSize1 = function(){
     return this.size1;
 };

--- a/Extensions/ParticleSystem/particleemitterobject.js
+++ b/Extensions/ParticleSystem/particleemitterobject.js
@@ -385,18 +385,18 @@ gdjs.ParticleEmitterObject.prototype.setParticleColor1 = function(rgbColor){
     var colors = rgbColor.split(";");
     if ( colors.length < 3 ) return;
 
-    this.setParticleRed1(parseInt(colors[0]));
-    this.setParticleGreen1(parseInt(colors[1]));
-    this.setParticleBlue1(parseInt(colors[2]));
+    this.setParticleRed1(parseInt(colors[0], 10));
+    this.setParticleGreen1(parseInt(colors[1], 10));
+    this.setParticleBlue1(parseInt(colors[2], 10));
 };
 
 gdjs.ParticleEmitterObject.prototype.setParticleColor2 = function(rgbColor){
     var colors = rgbColor.split(";");
     if ( colors.length < 3 ) return;
 
-    this.setParticleRed2(parseInt(colors[0]));
-    this.setParticleGreen2(parseInt(colors[1]));
-    this.setParticleBlue2(parseInt(colors[2]));
+    this.setParticleRed2(parseInt(colors[0], 10));
+    this.setParticleGreen2(parseInt(colors[1], 10));
+    this.setParticleBlue2(parseInt(colors[2], 10));
 };
 
 gdjs.ParticleEmitterObject.prototype.getParticleSize1 = function(){


### PR DESCRIPTION
Didn't noticed the functions to change the general color (not r, g, b independetly) were missing. Also added a bugfix, when you set the same start and end color, the library used ignored the last; trying to set a new final color caused crashes.