### PR TITLE
Add search/replace panel (SearchPanel) to EventsSheet

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -75,7 +75,8 @@
         "cstring": "cpp",
         "iomanip": "cpp",
         "cstdint": "cpp",
-        "forward_list": "cpp"
+        "forward_list": "cpp",
+        "mutex": "cpp"
     },
     "files.exclude": {
         "Binaries/*build*": true,

--- a/Core/GDCore/IDE/Events/EventsRefactorer.h
+++ b/Core/GDCore/IDE/Events/EventsRefactorer.h
@@ -11,26 +11,12 @@
 #include "GDCore/String.h"
 namespace gd {
 class EventsList;
-}
-namespace gd {
 class Layout;
-}
-namespace gd {
 class Platform;
-}
-namespace gd {
 class Project;
-}
-namespace gd {
 class ExternalEvents;
-}
-namespace gd {
 class BaseEvent;
-}
-namespace gd {
 class Instruction;
-}
-namespace gd {
 typedef std::shared_ptr<gd::BaseEvent> BaseEventSPtr;
 }
 
@@ -53,6 +39,24 @@ class GD_CORE_API EventsSearchResult {
   std::weak_ptr<gd::BaseEvent> event;
   gd::EventsList* eventsList;
   std::size_t positionInList;
+
+  bool IsEventsListValid() const { return eventsList != nullptr; }
+  
+  /**
+   * \brief Get the events list containing the event pointed by the EventsSearchResult.
+   * \warning Only call this when IsEventsListValid returns true.
+   */
+  const gd::EventsList & GetEventsList() const { return *eventsList; }
+
+  std::size_t GetPositionInList() const { return positionInList; }
+  
+  bool IsEventValid() const { return !event.expired(); }
+
+  /**
+   * \brief Get the event pointed by the EventsSearchResult.
+   * \warning Only call this when IsEventValid returns true.
+   */
+  const gd::BaseEvent & GetEvent() const { return *event.lock(); }
 };
 
 /**

--- a/newIDE/app/flow-typed/libGD.js
+++ b/newIDE/app/flow-typed/libGD.js
@@ -19,6 +19,7 @@ declare type gdBaseEvent = EmscriptenObject;
 declare type gdResource = EmscriptenObject;
 declare type gdObject = EmscriptenObject;
 declare type gdResourcesManager = EmscriptenObject;
+declare type gdEventsList = EmscriptenObject;
 
 declare type gdInstruction = EmscriptenObject;
 declare type gdInstructionMetadata = EmscriptenObject;
@@ -34,6 +35,8 @@ declare type gdSpriteObject = EmscriptenObject;
 declare type gdSprite = EmscriptenObject;
 declare type gdDirection = EmscriptenObject;
 declare type gdAnimation = EmscriptenObject;
+
+declare type gdVectorEventsSearchResult = EmscriptenObject;
 
 //Represents all objects that have serializeTo and unserializeFrom methods.
 declare type gdSerializable = EmscriptenObject;

--- a/newIDE/app/src/EventsSheet/EventsContextAnalyzerDialog.js
+++ b/newIDE/app/src/EventsSheet/EventsContextAnalyzerDialog.js
@@ -21,9 +21,14 @@ export default class EventsContextAnalyzerDialog extends React.Component<
       <FlatButton label="Close" primary={true} onClick={this.props.onClose} />,
     ];
 
-    return <Dialog actions={actions} open={open} onRequestClose={onClose}>
-        <p>Objects or groups being directly referenced in the events: {objectOrGroupNames.join(', ')}</p>
+    return (
+      <Dialog actions={actions} open={open} onRequestClose={onClose}>
+        <p>
+          Objects or groups being directly referenced in the events:{' '}
+          {objectOrGroupNames.join(', ')}
+        </p>
         <p>All objects potentially used in events: {objectsNames.join(', ')}</p>
-    </Dialog>;
+      </Dialog>
+    );
   }
 }

--- a/newIDE/app/src/EventsSheet/EventsSearcher.js
+++ b/newIDE/app/src/EventsSheet/EventsSearcher.js
@@ -1,0 +1,211 @@
+// @flow
+import * as React from 'react';
+import { type SelectionState } from './SelectionHandler';
+import { mapFor } from '../Utils/MapFor';
+import uniqBy from 'lodash/uniqBy';
+const gd = global.gd;
+
+export type SearchInEventsInputs = {|
+  searchInSelection: boolean,
+  searchText: string,
+  matchCase: boolean,
+  searchInConditions: boolean,
+  searchInActions: boolean,
+|};
+
+export type ReplaceInEventsInputs = {|
+  searchInSelection: boolean,
+  searchText: string,
+  replaceText: ?string,
+  matchCase: boolean,
+  searchInConditions: boolean,
+  searchInActions: boolean,
+|};
+
+type State = {|
+  eventsSearchResults: ?gdVectorEventsSearchResult,
+  searchFocusOffset: ?number,
+|};
+
+type Props = {|
+  project: gdProject,
+  layout: gdLayout,
+  events: gdEventsList,
+  selection: SelectionState,
+  children: (props: {|
+    eventsSearchResultEvents: ?Array<gdBaseEvent>,
+    searchFocusOffset: ?number,
+    searchInEvents: (SearchInEventsInputs, cb: () => void) => void,
+    replaceInEvents: ReplaceInEventsInputs => void,
+    goToNextSearchResult: () => ?gdBaseEvent,
+    goToPreviousSearchResult: () => ?gdBaseEvent,
+  |}) => React.Node,
+|};
+
+/**
+ * Component allowing to do search in events and pass the results
+ * to its children components, as well as methods to browse the results.
+ */
+export default class EventsSearcher extends React.Component<Props, State> {
+  state = {
+    eventsSearchResults: null, // The list of results
+    searchFocusOffset: null,
+  };
+
+  // The list containing the raw events results. Should be derived from this.state.eventsSearchResults using
+  // this._updateListOfResultEvents before being used.
+  _resultEvents: ?Array<gdBaseEvent> = null;
+
+  componentWillUnmount() {
+    if (this.state.eventsSearchResults) this.state.eventsSearchResults.delete();
+  }
+
+  reset() {
+    if (this.state.eventsSearchResults) this.state.eventsSearchResults.delete();
+    
+    this._resultEvents = null;
+    this.setState({
+      eventsSearchResults: null,
+      searchFocusOffset: null,
+    });
+  }
+
+  _doReplaceInEvents = ({
+    searchInSelection,
+    searchText,
+    replaceText,
+    matchCase,
+    searchInConditions,
+    searchInActions,
+  }: ReplaceInEventsInputs) => {
+    const { project, layout, events } = this.props;
+
+    if (searchInSelection) {
+      // Replace in selection is a bit tricky to implement as it requires to have a list
+      // of events (gd.EventsList) pointing to the same events. Need some workaround/helper
+      // function to be done in C++.
+      console.error('Replace in selection is not implemented yet');
+    }
+
+    gd.EventsRefactorer.replaceStringInEvents(
+      project,
+      layout,
+      events,
+      searchText,
+      replaceText,
+      matchCase,
+      searchInConditions,
+      searchInActions
+    );
+  };
+
+  _doSearchInEvents = (
+    {
+      searchInSelection,
+      searchText,
+      matchCase,
+      searchInConditions,
+      searchInActions,
+    }: SearchInEventsInputs,
+    cb: () => void
+  ) => {
+    const { project, layout, events } = this.props;
+
+    if (searchInSelection) {
+      // Search in selection is a bit tricky to implement as it requires to have a list
+      // of events (gd.EventsList) pointing to the same events. Need some workaround/helper
+      // function to be done in C++.
+      console.error('Search in selection is not implemented yet');
+    }
+
+    const newEventsSearchResults = gd.EventsRefactorer.searchInEvents(
+      project,
+      layout,
+      events,
+      searchText,
+      matchCase,
+      searchInConditions,
+      searchInActions
+    );
+
+    if (this.state.eventsSearchResults) {
+      this.state.eventsSearchResults.delete();
+    }
+    this.setState(
+      {
+        eventsSearchResults: newEventsSearchResults.clone(),
+        searchFocusOffset: null,
+      },
+      () => {
+        this._updateListOfResultEvents();
+        cb();
+      }
+    );
+  };
+
+  _updateListOfResultEvents = () => {
+    const { eventsSearchResults } = this.state;
+    if (!eventsSearchResults) {
+      this._resultEvents = null;
+      return;
+    }
+
+    const resultEventsWithDuplicates = mapFor(
+      0,
+      eventsSearchResults.size(),
+      i => {
+        const eventsSearchResult = eventsSearchResults.at(i);
+        return eventsSearchResult.isEventValid()
+          ? eventsSearchResult.getEvent()
+          : null;
+      }
+    ).filter(result => !!result);
+
+    // Store a list of unique events, because browsing for results in the events
+    // tree is made event by event.
+    this._resultEvents = uniqBy(resultEventsWithDuplicates, event => event.ptr);
+  };
+
+  _goToSearchResults = (step: number): ?gdBaseEvent => {
+    this._updateListOfResultEvents();
+    if (!this._resultEvents || this._resultEvents.length === 0) {
+      this.setState({ searchFocusOffset: null });
+      return null;
+    }
+
+    let newSearchFocusOffset =
+      this.state.searchFocusOffset === null
+        ? 0
+        : ((this.state.searchFocusOffset || 0) + step) %
+          this._resultEvents.length;
+    if (newSearchFocusOffset < 0)
+      newSearchFocusOffset += this._resultEvents.length;
+
+    const event = this._resultEvents[newSearchFocusOffset];
+    setTimeout(
+      // Change the offset on next tick to give a chance to children to unfold events before focusing it.
+      () => this.setState({ searchFocusOffset: newSearchFocusOffset }),
+      0
+    );
+    return event;
+  };
+
+  _goToPreviousSearchResult = (): ?gdBaseEvent => {
+    return this._goToSearchResults(-1);
+  };
+
+  _goToNextSearchResult = (): ?gdBaseEvent => {
+    return this._goToSearchResults(+1);
+  };
+
+  render() {
+    return this.props.children({
+      eventsSearchResultEvents: this._resultEvents,
+      searchFocusOffset: this.state.searchFocusOffset,
+      searchInEvents: this._doSearchInEvents,
+      replaceInEvents: this._doReplaceInEvents,
+      goToNextSearchResult: this._goToNextSearchResult,
+      goToPreviousSearchResult: this._goToPreviousSearchResult,
+    });
+  }
+}

--- a/newIDE/app/src/EventsSheet/EventsTree/ClassNames.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/ClassNames.js
@@ -15,3 +15,4 @@ export const disabledText = 'disabled-text';
 export const background = 'background';
 
 export const eventsTree = 'events-tree';
+export const eventsTreeWithSearchResults = 'with-search-results';

--- a/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Instruction.js
@@ -10,10 +10,11 @@ import {
   instructionParameter,
   disabledText,
 } from './ClassNames';
-import InstructionsList, {
+import {
   type InstructionsListContext,
   type InstructionContext,
-} from './InstructionsList';
+} from '../SelectionHandler';
+import InstructionsList from './InstructionsList';
 const gd = global.gd;
 const instrFormatter = gd.InstructionSentenceFormatter.get();
 instrFormatter.loadTypesFormattingFromConfig();

--- a/newIDE/app/src/EventsSheet/EventsTree/InstructionsList.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/InstructionsList.js
@@ -85,7 +85,10 @@ export default class InstructionsList extends React.Component<Props, *> {
             onInstructionContextMenu(x, y, instructionContext)}
           onParameterClick={(domEvent, parameterIndex) =>
             onParameterClick({
-              ...instructionContext,
+              isCondition: instructionContext.isCondition,
+              instrsList: instructionContext.instrsList,
+              instruction: instructionContext.instruction,
+              indexInList: instructionContext.indexInList,
               parameterIndex,
               domEvent,
             })}

--- a/newIDE/app/src/EventsSheet/EventsTree/InstructionsList.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/InstructionsList.js
@@ -2,28 +2,18 @@
 import * as React from 'react';
 import Instruction from './Instruction';
 import { mapFor } from '../../Utils/MapFor';
-import { isInstructionSelected } from '../SelectionHandler';
+import {
+  isInstructionSelected,
+  type InstructionsListContext,
+  type InstructionContext,
+  type ParameterContext,
+} from '../SelectionHandler';
 import { actionsContainer, conditionsContainer } from './ClassNames';
 
 const styles = {
   addButton: {
     cursor: 'pointer',
   },
-};
-
-export type InstructionsListContext = {
-  instrsList: gdInstructionsList,
-  isCondition: boolean,
-};
-
-export type InstructionContext = InstructionsListContext & {
-  instruction: gdInstruction,
-  indexInList: number,
-};
-
-export type ParameterContext = InstructionContext & {
-  parameterIndex: number,
-  domEvent: any,
 };
 
 type Props = {

--- a/newIDE/app/src/EventsSheet/EventsTree/Renderers/EventRenderer.flow.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/Renderers/EventRenderer.flow.js
@@ -3,7 +3,7 @@ import {
   type InstructionsListContext,
   type InstructionContext,
   type ParameterContext,
-} from '../InstructionsList';
+} from '../../SelectionHandler';
 
 export type EventRendererProps = {
   project: gdProject,

--- a/newIDE/app/src/EventsSheet/InlineParameterEditor.js
+++ b/newIDE/app/src/EventsSheet/InlineParameterEditor.js
@@ -17,7 +17,7 @@ type Props = {|
   onRequestClose: () => void,
   onChange: string => void,
 
-  instruction: gdInstruction,
+  instruction: ?gdInstruction,
   isCondition: boolean,
   parameterIndex: number,
 
@@ -31,7 +31,6 @@ type Props = {|
 type State = {|
   isValid: boolean,
   parameterMetadata: ?gdParameterMetadata,
-  instruction: ?gdInstruction,
   ParameterComponent: ?any,
 |};
 
@@ -43,7 +42,6 @@ export default class InlineParameterEditor extends React.Component<
     isValid: false,
     parameterMetadata: null,
     ParameterComponent: null,
-    instruction: null,
   };
 
   _field: ?any;
@@ -61,7 +59,6 @@ export default class InlineParameterEditor extends React.Component<
     this.setState({
       ParameterComponent: null,
       parameterMetadata: null,
-      instruction: null,
     });
   }
 
@@ -100,6 +97,8 @@ export default class InlineParameterEditor extends React.Component<
 
   render() {
     if (!this.state.ParameterComponent || !this.props.open) return null;
+    const instruction = this.props.instruction;
+    if (!instruction) return null;
 
     const { ParameterComponent } = this.state;
 
@@ -113,9 +112,9 @@ export default class InlineParameterEditor extends React.Component<
           parameterMetadata={this.state.parameterMetadata}
           project={this.props.project}
           layout={this.props.layout}
-          value={this.props.instruction.getParameter(this.props.parameterIndex)}
-          instructionOrExpression={this.props.instruction}
-          key={this.props.instruction.ptr}
+          value={instruction.getParameter(this.props.parameterIndex)}
+          instructionOrExpression={instruction}
+          key={instruction.ptr}
           onChange={this.props.onChange}
           ref={field => (this._field = field)}
           parameterRenderingService={ParameterRenderingService}

--- a/newIDE/app/src/EventsSheet/SearchPanel.js
+++ b/newIDE/app/src/EventsSheet/SearchPanel.js
@@ -1,0 +1,165 @@
+// @flow
+import React, { PureComponent } from 'react';
+import Paper from 'material-ui/Paper';
+import TextField from 'material-ui/TextField';
+import { Line, Column } from '../UI/Grid';
+import FlatButton from 'material-ui/FlatButton';
+import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
+import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
+import IconButton from 'material-ui/IconButton';
+import InlineCheckbox from '../UI/InlineCheckbox';
+import { showMessageBox } from '../UI/Messages/MessageBox';
+import {
+  type SearchInEventsInputs,
+  type ReplaceInEventsInputs,
+} from './EventsSearcher';
+
+type Props = {|
+  onSearchInEvents: SearchInEventsInputs => void,
+  onReplaceInEvents: ReplaceInEventsInputs => void,
+  resultsCount: ?number,
+  hasEventSelected: boolean,
+  onGoToPreviousSearchResult: () => ?gdBaseEvent,
+  onGoToNextSearchResult: () => ?gdBaseEvent,
+|};
+type State = {|
+  searchDirty: boolean,
+  searchText: string,
+  replaceText: string,
+  matchCase: boolean,
+  searchInSelection: boolean,
+|};
+
+export default class SearchPanel extends PureComponent<Props, State> {
+  state = {
+    searchDirty: false,
+    searchText: '',
+    replaceText: '',
+    matchCase: false,
+    searchInSelection: false,
+  };
+
+  launchSearch = () => {
+    const { searchText, searchInSelection, matchCase } = this.state;
+    this.props.onSearchInEvents({
+      searchInSelection,
+      searchText,
+      matchCase,
+      searchInActions: true,
+      searchInConditions: true,
+    });
+    this.setState({
+      searchDirty: false,
+    });
+  };
+
+  launchReplace = () => {
+    const {
+      searchDirty,
+      searchText,
+      replaceText,
+      searchInSelection,
+      matchCase,
+    } = this.state;
+    if (searchDirty) {
+      showMessageBox(
+        'Click on Search first, inspect the results and then click on Replace to do the replacement(s).'
+      );
+      return;
+    }
+
+    this.props.onReplaceInEvents({
+      searchInSelection,
+      searchText,
+      replaceText,
+      matchCase,
+      searchInActions: true,
+      searchInConditions: true,
+    });
+  };
+
+  render() {
+    const {
+      resultsCount,
+      hasEventSelected,
+      onGoToPreviousSearchResult,
+      onGoToNextSearchResult,
+    } = this.props;
+    const { searchText, replaceText, searchInSelection } = this.state;
+
+    return (
+      <Paper>
+        <Column>
+          <Line alignItems="baseline">
+            <TextField
+              hintText="Text to search"
+              onChange={(e, searchText) =>
+                this.setState({ searchText, searchDirty: true })}
+              value={searchText}
+              fullWidth
+            />
+            <FlatButton
+              disabled={!searchText}
+              primary
+              label="Search"
+              onClick={this.launchSearch}
+            />
+          </Line>
+          <Line alignItems="baseline">
+            <TextField
+              hintText="Text to replace"
+              onChange={(e, replaceText) => this.setState({ replaceText })}
+              value={replaceText}
+              fullWidth
+            />
+            <FlatButton
+              disabled={
+                !replaceText ||
+                !searchText ||
+                (!hasEventSelected && searchInSelection)
+              }
+              label="Replace"
+              onClick={this.launchReplace}
+            />
+          </Line>
+          <Line noMargin alignItems="center" justifyContent="space-between">
+            <Line noMargin alignItems="center">
+              <InlineCheckbox
+                label="Case insensitive"
+                checked={!this.state.matchCase}
+                onCheck={(e, checked) => this.setState({ matchCase: !checked })}
+              />
+              {/* <InlineCheckbox //TODO: Implement search/replace in selection
+                label="Replace in selection"
+                checked={this.state.searchInSelection}
+                onCheck={(e, checked) =>
+                  this.setState({ searchInSelection: checked })}
+              /> */}
+            </Line>
+            <Line noMargin alignItems="center">
+              <p>
+                {resultsCount === null || resultsCount === undefined
+                  ? ''
+                  : resultsCount !== 0
+                    ? `${resultsCount} results`
+                    : `No results`}
+              </p>
+              <IconButton
+                disabled={!resultsCount}
+                onClick={() => onGoToPreviousSearchResult()}
+              >
+                <ChevronLeft />
+              </IconButton>
+              <IconButton
+                disabled={!resultsCount}
+                onClick={() => onGoToNextSearchResult()}
+              >
+                <ChevronRight />
+              </IconButton>
+            </Line>
+          </Line>
+        </Column>
+      </Paper>
+    );
+  }
+}

--- a/newIDE/app/src/EventsSheet/SelectionHandler.js
+++ b/newIDE/app/src/EventsSheet/SelectionHandler.js
@@ -2,39 +2,35 @@
 
 import values from 'lodash/values';
 
-type Event = {
-  ptr: number,
-};
-type EventsList = {
-  ptr: number,
-};
-type Instruction = {
-  ptr: number,
-};
-type InstructionsList = {
-  ptr: number,
-};
-
-type InstructionContext = {|
+export type InstructionsListContext = {|
   isCondition: boolean,
-  instrsList: InstructionsList,
-  instruction: Instruction,
+  instrsList: gdInstructionsList,
+|};
+
+export type InstructionContext = {|
+  isCondition: boolean,
+  instrsList: gdInstructionsList,
+  instruction: gdInstruction,
   indexInList: number,
 |};
 
-type InstructionsListContext = {|
+export type ParameterContext = {|
   isCondition: boolean,
-  instrsList: InstructionsList,
+  instrsList: gdInstructionsList,
+  instruction: gdInstruction,
+  indexInList: number,
+  parameterIndex: number,
+  domEvent?: any,
 |};
 
-type EventContext = {|
+export type EventContext = {|
   isCondition: boolean,
-  eventsList: EventsList,
-  event: Event,
+  eventsList: gdEventsList,
+  event: gdBaseEvent,
   indexInList: number,
 |};
 
-type SelectionState = {
+export type SelectionState = {
   selectedInstructions: { [number]: InstructionContext },
   selectedInstructionsLists: { [number]: InstructionsListContext },
   selectedEvents: { [number]: EventContext },
@@ -62,7 +58,7 @@ export const getSelectedEventContexts = (
 
 export const getSelectedInstructions = (
   selection: SelectionState
-): Array<Instruction> => {
+): Array<gdInstruction> => {
   return values(selection.selectedInstructions).map(
     (instructionContext: InstructionContext) => instructionContext.instruction
   );
@@ -89,14 +85,14 @@ export const isEventSelected = (
 
 export const isInstructionSelected = (
   selection: SelectionState,
-  instruction: Instruction
+  instruction: gdInstruction
 ): boolean => {
   return !!selection.selectedInstructions[instruction.ptr];
 };
 
 export const isInstructionsListSelected = (
   selection: SelectionState,
-  instructionsList: InstructionsList
+  instructionsList: gdInstructionsList
 ): boolean => {
   return !!selection.selectedInstructionsLists[instructionsList.ptr];
 };
@@ -150,7 +146,7 @@ export const selectInstruction = (
   instructionContext: InstructionContext,
   multiSelection: boolean = false
 ): SelectionState => {
-  const instruction: Instruction = instructionContext.instruction;
+  const instruction: gdInstruction = instructionContext.instruction;
   if (isInstructionSelected(selection, instruction)) return selection;
 
   const existingSelection = multiSelection ? selection : clearSelection();
@@ -168,7 +164,7 @@ export const selectInstructionsList = (
   instructionsListContext: InstructionsListContext,
   multiSelection: boolean = false
 ): SelectionState => {
-  const instructionsList: InstructionsList = instructionsListContext.instrsList;
+  const instructionsList: gdInstructionsList = instructionsListContext.instrsList;
   if (isInstructionsListSelected(selection, instructionsList)) return selection;
 
   const existingSelection = multiSelection ? selection : clearSelection();

--- a/newIDE/app/src/EventsSheet/Toolbar.js
+++ b/newIDE/app/src/EventsSheet/Toolbar.js
@@ -120,10 +120,7 @@ export class Toolbar extends PureComponent {
         />
         <ToolbarSeparator />
         <ToolbarIcon
-          disabled
-          onClick={() => {
-            /*TODO*/
-          }}
+          onClick={() => this.props.onToggleSearchPanel()}
           src="res/ribbon_default/search32.png"
           tooltip={t('Search in events')}
         />

--- a/newIDE/app/src/UI/InlineCheckbox.js
+++ b/newIDE/app/src/UI/InlineCheckbox.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Checkbox from 'material-ui/Checkbox';
+
+const styles = {
+  root: {
+    width: 'auto',
+    marginRight: 16,
+  },
+  label: {
+    width: 'auto',
+  },
+};
+
+/**
+ * A checkbox based on Material-UI Checkbox, but that can be displayed
+ * without having it taking the full width of its container.
+ */
+export default props => (
+  <Checkbox style={styles.root} labelStyle={styles.label} {...props} />
+);

--- a/newIDE/app/src/UI/Theme/DarkTheme/EventsSheet.css
+++ b/newIDE/app/src/UI/Theme/DarkTheme/EventsSheet.css
@@ -117,3 +117,16 @@
 .gd-events-sheet-dark-theme .instruction-parameter.globalvar {
     color: #18DCF2;
 }
+
+/**
+ * Search results highlight
+ */
+ .gd-events-sheet-dark-theme .rst__rowSearchMatch {
+    outline: none;
+    border-left: solid 3px #18DCF2;
+}
+
+.gd-events-sheet-dark-theme .rst__rowSearchFocus {
+    outline: none;
+    border-left: solid 5px #18DCF2;
+}

--- a/newIDE/app/src/UI/Theme/DefaultTheme/EventsSheet.css
+++ b/newIDE/app/src/UI/Theme/DefaultTheme/EventsSheet.css
@@ -110,3 +110,21 @@
 .gd-events-sheet-default-theme .instruction-parameter.globalvar {
     color: rgb(131, 55, 162);
 }
+
+/**
+ * Search results highlight
+ */
+.gd-events-sheet-default-theme.with-search-results .rst__moveHandle {
+    background: #d3d3d3  !important;
+    border: 1px solid #d3d3d3  !important;
+}
+
+.gd-events-sheet-default-theme .rst__rowSearchMatch {
+    outline: none;
+    border-left: solid 3px #18DCF2
+}
+
+.gd-events-sheet-default-theme .rst__rowSearchFocus {
+    outline: none;
+    border-left: solid 5px #18DCF2
+}

--- a/newIDE/app/src/stories/index.js
+++ b/newIDE/app/src/stories/index.js
@@ -89,6 +89,7 @@ import BuildProgress from '../Export/Builds/BuildProgress';
 import BuildStepsProgress from '../Export/Builds/BuildStepsProgress';
 import MeasuresTable from '../Debugger/Profiler/MeasuresTable';
 import Profiler from '../Debugger/Profiler';
+import SearchPanel from '../EventsSheet/SearchPanel';
 
 const gd = global.gd;
 const {
@@ -621,7 +622,7 @@ storiesOf('EventsTree', module)
   .addDecorator(muiDecorator)
   .add('default', () => (
     <DragDropContextProvider>
-      <div className="gd-events-sheet">
+      <div className="gd-events-sheet" style={{ height: 500, display: 'flex' }}>
         <EventsTree
           events={testLayout.getEvents()}
           selectedEvents={[]}
@@ -635,31 +636,84 @@ storiesOf('EventsSheet', module)
   .addDecorator(muiDecorator)
   .add('default', () => (
     <DragDropContextProvider>
-      <EventsSheet
-        project={project}
-        layout={testLayout}
-        events={testLayout.getEvents()}
-        onOpenExternalEvents={action('Open external events')}
-        resourceSources={[]}
-        onChooseResource={source =>
-          action('Choose resource from source', source)}
-        resourceExternalEditors={[]}
-      />
+      <div className="gd-events-sheet" style={{ height: 500, display: 'flex' }}>
+        <EventsSheet
+          project={project}
+          layout={testLayout}
+          events={testLayout.getEvents()}
+          onOpenExternalEvents={action('Open external events')}
+          resourceSources={[]}
+          onChooseResource={source =>
+            action('Choose resource from source', source)}
+          resourceExternalEditors={[]}
+          onOpenDebugger={action('open debugger')}
+          updateToolbar={() => {}}
+          onOpenLayout={action('open layout')}
+          onOpenSettings={action('open settings')}
+          onPreview={action('preview')}
+          setToolbar={() => {}}
+          showNetworkPreviewButton={false}
+          showPreviewButton={false}
+        />
+      </div>
     </DragDropContextProvider>
   ))
   .add('empty (no events)', () => (
     <DragDropContextProvider>
-      <EventsSheet
-        project={project}
-        layout={emptyLayout}
-        events={emptyLayout.getEvents()}
-        onOpenExternalEvents={action('Open external events')}
-        resourceSources={[]}
-        onChooseResource={source =>
-          action('Choose resource from source', source)}
-        resourceExternalEditors={[]}
-      />
+      <div className="gd-events-sheet" style={{ height: 500, display: 'flex' }}>
+        <EventsSheet
+          project={project}
+          layout={emptyLayout}
+          events={emptyLayout.getEvents()}
+          onOpenExternalEvents={action('Open external events')}
+          resourceSources={[]}
+          onChooseResource={source =>
+            action('Choose resource from source', source)}
+          resourceExternalEditors={[]}
+          onOpenDebugger={action('open debugger')}
+          updateToolbar={() => {}}
+          onOpenLayout={action('open layout')}
+          onOpenSettings={action('open settings')}
+          onPreview={action('preview')}
+          setToolbar={() => {}}
+          showNetworkPreviewButton={false}
+          showPreviewButton={false}
+        />
+      </div>
     </DragDropContextProvider>
+  ));
+
+storiesOf('SearchPanel', module)
+  .addDecorator(muiDecorator)
+  .add('default (no search done)', () => (
+    <SearchPanel
+      onSearchInEvents={() => {}}
+      onReplaceInEvents={() => {}}
+      resultsCount={null}
+      hasEventSelected={false}
+      onGoToNextSearchResult={action('next')}
+      onGoToPreviousSearchResult={action('previous')}
+    />
+  ))
+  .add('default (no results)', () => (
+    <SearchPanel
+      onSearchInEvents={() => {}}
+      onReplaceInEvents={() => {}}
+      resultsCount={0}
+      hasEventSelected={false}
+      onGoToNextSearchResult={action('next')}
+      onGoToPreviousSearchResult={action('previous')}
+    />
+  ))
+  .add('3 results', () => (
+    <SearchPanel
+      onSearchInEvents={() => {}}
+      onReplaceInEvents={() => {}}
+      resultsCount={3}
+      hasEventSelected={false}
+      onGoToNextSearchResult={action('next')}
+      onGoToPreviousSearchResult={action('previous')}
+    />
   ));
 
 storiesOf('ExpressionSelector', module)


### PR DESCRIPTION
This add a search/replace panel in GD5. Search/replace in selection is not implemented but could be added later!
Results can be browsed and are highlighted in the events editor

<img width="796" alt="screenshot 2018-08-13 18 35 18" src="https://user-images.githubusercontent.com/1280130/44045100-d0ac9514-9f27-11e8-9fcb-4aaedc95ec0c.png">
<img width="792" alt="screenshot 2018-08-13 18 35 30" src="https://user-images.githubusercontent.com/1280130/44045101-d0e3e2ee-9f27-11e8-98c8-495f600687d9.png">
