### PR TITLE
Add support for fullscreen and close the app on Electron

### DIFF
--- a/GDJS/Runtime/cocos-renderers/runtimegame-cocos-renderer.js
+++ b/GDJS/Runtime/cocos-renderers/runtimegame-cocos-renderer.js
@@ -107,3 +107,7 @@ gdjs.RuntimeGameCocosRenderer.prototype.openURL = function() {
         window.open(url, target);
     }
 }
+
+gdjs.RuntimeGameCocosRenderer.prototype.stopGame = function() {
+    // TODO - Not implemented as not useful for most games on mobile and browsers
+}

--- a/GDJS/Runtime/cocos-renderers/runtimegame-cocos-renderer.js
+++ b/GDJS/Runtime/cocos-renderers/runtimegame-cocos-renderer.js
@@ -93,3 +93,17 @@ gdjs.RuntimeGameCocosRenderer.getScreenWidth = function() {
 gdjs.RuntimeGameCocosRenderer.getScreenHeight = function() {
     return cc.view.getFrameSize().height;
 }
+
+/**
+ * Open the given URL in the system browser
+ */
+gdjs.RuntimeGameCocosRenderer.prototype.openURL = function() {
+    // Try to detect the environment to use the most adapted
+    // way of opening an URL.
+    if (typeof cc !== "undefined" && cc.sys && cc.sys.openURL) {
+        cc.sys.openURL(url);
+    } else if (typeof window !== "undefined") {
+        var target = window.cordova ? "_system" : "_blank";
+        window.open(url, target);
+    }
+}

--- a/GDJS/Runtime/events-tools/windowtools.js
+++ b/GDJS/Runtime/events-tools/windowtools.js
@@ -61,14 +61,5 @@ gdjs.evtTools.window.getCanvasHeight = function(runtimeScene) {
 };
 
 gdjs.evtTools.window.openURL = function(url) {
-    //Try to detect the environment to use the most adapted
-    //way of opening an URL.
-    if (typeof cc !== "undefined" && cc.sys && cc.sys.openURL) {
-        cc.sys.openURL(url);
-    } else if (typeof Cocoon !== "undefined" && Cocoon.App && Cocoon.App.openURL) {
-        Cocoon.App.openURL(url);
-    } else if (typeof window !== "undefined") {
-        var target = window.cordova ? "_system" : "_blank";
-        window.open(url, target);
-    }
+	return runtimeScene.getGame().getRenderer().openURL(url);
 };

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
@@ -347,3 +347,17 @@ gdjs.RuntimeGamePixiRenderer.getScreenWidth = function() {
 gdjs.RuntimeGamePixiRenderer.getScreenHeight = function() {
     return (typeof window !== "undefined") ? window.innerHeight : 800;
 }
+
+/**
+ * Open the given URL in the system browser (or a new tab)
+ */
+gdjs.RuntimeGamePixiRenderer.prototype.openURL = function() {
+    // Try to detect the environment to use the most adapted
+    // way of opening an URL.
+    if (typeof Cocoon !== "undefined" && Cocoon.App && Cocoon.App.openURL) {
+        Cocoon.App.openURL(url);
+    } else if (typeof window !== "undefined") {
+        var target = window.cordova ? "_system" : "_blank";
+        window.open(url, target);
+    }
+}

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
@@ -375,6 +375,25 @@ gdjs.RuntimeGamePixiRenderer.prototype.openURL = function() {
 }
 
 /**
+ * Close the game, if applicable
+ */
+gdjs.RuntimeGamePixiRenderer.prototype.stopGame = function() {
+    // Try to detect the environment to use the most adapted
+    // way of closing the app
+    var electron = gdjs.RuntimeGamePixiRenderer.getElectron();
+    if (electron) {
+        var browserWindow = electron.remote.getCurrentWindow();
+        if (browserWindow) {
+            browserWindow.close();
+        }
+    } else if (typeof navigator !== "undefined" && navigator.app && navigator.app.exitApp) {
+        navigator.app.exitApp();
+    }
+
+    // HTML5 games on mobile/browsers don't have a way to close their window/page.
+}
+
+/**
  * Get the electron module, if running as a electron renderer process.
  */
 gdjs.RuntimeGamePixiRenderer.getElectron = function() {

--- a/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
+++ b/GDJS/Runtime/pixi-renderers/runtimegame-pixi-renderer.js
@@ -3,6 +3,10 @@
  * The renderer for a gdjs.RuntimeGame using Pixi.js.
  * @class RuntimeGamePixiRenderer
  * @memberof gdjs
+ * @param {gdjs.RuntimeGame} game The game that is being rendered
+ * @param {number} width The default width of the renderer
+ * @param {number} height The default height of the renderer
+ * @param {boolean} forceFullscreen If fullscreen should be always activated
  */
 gdjs.RuntimeGamePixiRenderer = function(game, width, height, forceFullscreen)
 {

--- a/GDJS/Runtime/runtimegame.js
+++ b/GDJS/Runtime/runtimegame.js
@@ -280,9 +280,7 @@ gdjs.RuntimeGame.prototype.startGameLoop = function() {
     return;
   }
 
-  if (this._data.properties.sizeOnStartupMode) {
-    this.adaptRendererSizeToFillScreen(this._data.properties.sizeOnStartupMode);
-  }
+  this.adaptRendererSizeToFillScreen();
 
   //Load the first scene
   var firstSceneName = this._data.firstLayout;
@@ -326,11 +324,13 @@ gdjs.RuntimeGame.prototype.startGameLoop = function() {
 
 /**
  * Enlarge/reduce the width (or the height) of the game to fill the screen.
- * @param {string} mode `adaptWidth` to change the width, `adaptHeight` to change the height
+ * @param {?string} mode `adaptWidth` to change the width, `adaptHeight` to change the height. If not defined, will use the game "sizeOnStartupMode" .
  */
 gdjs.RuntimeGame.prototype.adaptRendererSizeToFillScreen = function(mode) {
   if (!gdjs.RuntimeGameRenderer || !gdjs.RuntimeGameRenderer.getScreenWidth || !gdjs.RuntimeGameRenderer.getScreenHeight)
     return;
+
+  newMode = mode !== undefined ? mode : (this._data.properties.sizeOnStartupMode || '');
 
   var screenWidth = gdjs.RuntimeGameRenderer.getScreenWidth();
   var screenHeight = gdjs.RuntimeGameRenderer.getScreenHeight();
@@ -339,9 +339,9 @@ gdjs.RuntimeGame.prototype.adaptRendererSizeToFillScreen = function(mode) {
   var renderer = this.getRenderer();
   var width = renderer.getCurrentWidth();
   var height = renderer.getCurrentHeight();
-  if (mode === "adaptWidth") {
+  if (newMode === "adaptWidth") {
     width = height * screenWidth / screenHeight;
-  } else if (mode === "adaptHeight") {
+  } else if (newMode === "adaptHeight") {
     height = width * screenHeight / screenWidth;
   }
 

--- a/GDJS/Runtime/runtimescene.js
+++ b/GDJS/Runtime/runtimescene.js
@@ -29,10 +29,15 @@ gdjs.RuntimeScene = function(runtimeGame)
     this._timeManager = new gdjs.TimeManager(Date.now());
     this._gameStopRequested = false;
     this._requestedScene = "";
-    this._isLoaded = false; // True if loadFromScene was called and the scene is being played.
+	this._isLoaded = false; // True if loadFromScene was called and the scene is being played.
+	
+	/** @type gdjs.RuntimeObject[] */
     this._allInstancesList = []; //An array used to create a list of all instance when necessary ( see _constructListOfAllInstances )
-    this._instancesRemoved = []; //The instances removed from the scene and waiting to be sent to the cache.
-
+	
+	/** @type gdjs.RuntimeObject[] */
+	this._instancesRemoved = []; //The instances removed from the scene and waiting to be sent to the cache.
+	
+	/** @type gdjs.Profiler */
 	this._profiler = null; // Set to `new gdjs.Profiler()` to have profiling done on the scene.
 	this._onProfilerStopped = null; // The callback function to call when the profiler is stopped.
 

--- a/GDJS/Runtime/scenestack.js
+++ b/GDJS/Runtime/scenestack.js
@@ -28,7 +28,8 @@ gdjs.SceneStack.prototype.step = function(elapsedTime) {
     	var request = currentScene.getRequestedChange();
         //Something special was requested by the current scene.
         if (request === gdjs.RuntimeScene.STOP_GAME) {
-            return false;
+            this._runtimeGame.getRenderer().stopGame();
+            return true;
         } else if (request === gdjs.RuntimeScene.POP_SCENE) {
         	this.pop();
         } else if (request === gdjs.RuntimeScene.PUSH_SCENE) {

--- a/GDJS/Runtime/scenestack.js
+++ b/GDJS/Runtime/scenestack.js
@@ -3,6 +3,7 @@
  * Hold the stack of scenes (gdjs.RuntimeScene) being played.
  * 
  * @memberof gdjs
+ * @param {gdjs.RuntimeGame} runtimeGame The runtime game that is using the scene stack
  * @class SceneStack
  */
 gdjs.SceneStack = function(runtimeGame) {
@@ -11,6 +12,8 @@ gdjs.SceneStack = function(runtimeGame) {
     }
 
     this._runtimeGame = runtimeGame;
+
+    /** @type gdjs.RuntimeScene[] */
 	this._stack = [];
 };
 


### PR DESCRIPTION
This add support to make the app fullscreen on Electron, and also to close the app on Electron and Cordova (even if not recommended/useful on mobiles).

TODO:
- [ ] Going to fullscreen should adapt again the size of the game canvas
- [ ] For HTML5 games in most browsers, fullscreen API need a user input to work