### PR TITLE
Add a build and run Windows batch script in /scripts folder

### DIFF
--- a/newIDE/README.md
+++ b/newIDE/README.md
@@ -47,6 +47,14 @@ node node_modules\electron\cli.js app
 ./node_modules/electron/dist/electron app
 ```
 
+### Quick Install and Run
+
+There is a script file that automates cloning this repository, building the newIde and running it
+
+#Fow Windows:
+If you are on windows, you can download the batch script [here](https://raw.githubusercontent.com/4ian/GD/master/scripts/gitCloneAndBuildGD.bat) and run it
+
+
 ### Development of UI components
 
 You can run a [storybook](https://github.com/storybooks/storybook) that is used as a playground for rapid UI component development and testing:

--- a/newIDE/README.md
+++ b/newIDE/README.md
@@ -51,7 +51,7 @@ node node_modules\electron\cli.js app
 
 There is a script file that automates cloning this repository, building the newIde and running it
 
-#Fow Windows:
+* For Windows:
 If you are on windows, you can download the batch script [here](https://raw.githubusercontent.com/4ian/GD/master/scripts/gitCloneAndBuildGD.bat) and run it
 
 

--- a/newIDE/README.md
+++ b/newIDE/README.md
@@ -51,8 +51,7 @@ node node_modules\electron\cli.js app
 
 There is a script file that automates cloning this repository, building the newIde and running it
 
-* For Windows:
-If you are on windows, you can download the batch script [here](https://raw.githubusercontent.com/4ian/GD/master/scripts/gitCloneAndBuildGD.bat) and run it
+* For Windows: You can download the batch script [here](https://raw.githubusercontent.com/4ian/GD/master/scripts/gitCloneAndBuildGD.bat) and save it to where you want GD to be cloned to, then simply run it.
 
 
 ### Development of UI components

--- a/scripts/gitCloneAndBuildGD.bat
+++ b/scripts/gitCloneAndBuildGD.bat
@@ -4,6 +4,7 @@ REM
 REM It still requires git, nodejs and electron to be installed.
 REM If Gdevelop is already built, the script will simply launch it.
 REM ===============================================================
+echo This will install the dependencies and launch GDevelop development version. Please make sure you have git and Node.js installed.
 
 @echo off
 SET fork=4ian

--- a/scripts/gitCloneAndBuildGD.bat
+++ b/scripts/gitCloneAndBuildGD.bat
@@ -4,7 +4,7 @@ REM
 REM It still requires git, nodejs and electron to be installed.
 REM If Gdevelop is already built, the script will simply launch it.
 REM ===============================================================
-echo This will install the dependencies and launch GDevelop development version. Please make sure you have git and Node.js installed.
+echo This will clone, install, and launch GDevelop development version. Please make sure you have git and Node.js installed.
 
 @echo off
 SET fork=4ian

--- a/scripts/gitCloneAndBuildGD.bat
+++ b/scripts/gitCloneAndBuildGD.bat
@@ -18,5 +18,5 @@ call npm install
 cd ../app
 start cmd /k npm start
 cd ../electron-app
-TIMEOUT /T 20
+TIMEOUT /T 40
 call node node_modules\electron\cli.js app

--- a/scripts/gitCloneAndBuildGD.bat
+++ b/scripts/gitCloneAndBuildGD.bat
@@ -1,3 +1,5 @@
+@echo off
+
 REM ===============================================================
 REM This Windows batch script downloads Gdevelop from the master branch, builds the newIde and launches it.
 REM
@@ -6,7 +8,6 @@ REM If Gdevelop is already built, the script will simply launch it.
 REM ===============================================================
 echo This will clone, install, and launch GDevelop development version. Please make sure you have git and Node.js installed.
 
-@echo off
 SET fork=4ian
 
 call git clone https://github.com/%fork%/GD.git

--- a/scripts/gitCloneAndBuildGD.bat
+++ b/scripts/gitCloneAndBuildGD.bat
@@ -1,0 +1,21 @@
+REM ===============================================================
+REM This Windows batch script downloads Gdevelop from the master branch, builds the newIde and launches it.
+REM
+REM It still requires git, nodejs and electron to be installed.
+REM If Gdevelop is already built, the script will simply launch it.
+REM ===============================================================
+
+@echo off
+SET fork=4ian
+
+call git clone https://github.com/%fork%/GD.git
+cd GD/newIDE/app
+call npm install
+cd ../electron-app
+call npm install
+
+cd ../app
+start cmd /k npm start
+cd ../electron-app
+TIMEOUT /T 20
+call node node_modules\electron\cli.js app


### PR DESCRIPTION
I've been using this simple batch script to automate all the install and run steps to get the electron editor up and running. Perhaps it can save others some time- especially those who like running the bleeding edge version